### PR TITLE
DONE 	>> make sure the registration UUID is carried into all logging …

### DIFF
--- a/csvpath/csvpath.py
+++ b/csvpath/csvpath.py
@@ -313,9 +313,10 @@ class CsvPath(ErrorCollector, Printer):  # pylint: disable=R0902, R0904
                 self.error_manager.error_metrics.provider.shutdown()
                 self.error_manager.error_metrics = None
                 self.error_manager = None
-            lout.release_logger(self)
         except Exception:
             print(traceback.format_exc())
+        finally:
+            lout.release_logger(self)
 
     #
     # this method saves and reloads the config. if you don't want that use

--- a/csvpath/csvpaths.py
+++ b/csvpath/csvpaths.py
@@ -588,9 +588,10 @@ Cache: {cache}
     def __del__(self) -> None:
         try:
             self.wrap_up()
-            lout.release_logger(self)
         except Exception:
             print(traceback.format_exc())
+        finally:
+            lout.release_logger(self)
 
     def _trim_archive_if(self, home: str) -> str:
         archive = self.config.get(section="results", name="archive")
@@ -877,6 +878,7 @@ Cache: {cache}
                 run_dir=crt,
                 run_uuid=run_uuid,
                 method="collect_paths",
+                template=template,
             )
             # casting a broad net because if "raise" not in the error policy we
             # want to never fail during a run
@@ -1047,6 +1049,7 @@ Cache: {cache}
                 run_dir=crt,
                 run_uuid=run_uuid,
                 method="fast_forward_paths",
+                template=template,
             )
             try:
                 self._load_csvpath(
@@ -1181,6 +1184,7 @@ Cache: {cache}
                 run_dir=crt,
                 run_uuid=run_uuid,
                 method="next_paths",
+                template=template,
             )
             if self._fail_all:
                 self.logger.warning(
@@ -1447,6 +1451,7 @@ Cache: {cache}
             crt=crt,
             method=method,
             extra_data=extra_data,
+            template=template,
         )
         #
         # setting file into the csvpath is less obviously useful at CsvPaths
@@ -1624,6 +1629,7 @@ Cache: {cache}
         crt: str,
         method: str,
         extra_data: Optional[dict[str, str]],
+        template: str = "",
     ):
         """@private"""
         #
@@ -1660,6 +1666,7 @@ Cache: {cache}
                     by_line=True,
                     run_uuid=run_uuid,
                     method=method,
+                    template=template,
                 )
                 csvpath[1] = result
                 #

--- a/csvpath/managers/files/file_manager.py
+++ b/csvpath/managers/files/file_manager.py
@@ -1,7 +1,7 @@
 import re
 import json
 import traceback
-from uuid import UUID
+from uuid import UUID, uuid4
 from typing import NewType
 from json import JSONDecodeError
 from csvpath.util.file_readers import DataFileReader
@@ -19,6 +19,7 @@ from csvpath.util.path_util import PathUtility as pathu
 from csvpath.util.template_util import TemplateUtility as temu
 from .file_registrar import FileRegistrar
 from .lines_and_headers_cacher import LinesAndHeadersCacher
+from .files_listener import FilesListener
 from .file_metadata import FileMetadata
 from .file_describer import NamedFileDescriber
 from .file_activator import NamedFileActivator
@@ -219,8 +220,6 @@ class FileManager:
                 #
                 path = lst[0]
                 path = Nos(path).join("manifest.json")
-                # path = os.path.join(path, "manifest.json")
-                # nos = self.nos
                 nos = Nos(path)
                 if nos.exists():
                     mani = self.registrar.get_manifest(path)
@@ -634,11 +633,18 @@ class FileManager:
             # issue driven by the 3rd party or business rules.
             #
             UUID(registration_uuid)
-            self.csvpaths.logger.info(
-                "Registration of %s will be associated with UUID %s",
-                path,
-                registration_uuid,
-            )
+        else:
+            #
+            # if we don't create the uuid here the metadata object will create one;
+            # however, if we want to tie log statements back we should have a uuid
+            # here, regardless of if the user creates it or we do.
+            #
+            registration_uuid = str(uuid4())
+        self.csvpaths.logger.info(
+            "Registration of %s will be associated with UUID %s",
+            path,
+            registration_uuid,
+        )
         if not self.can_load(path):
             #
             # if False, can_load() will have already raised an error and/or, minimally,
@@ -648,9 +654,26 @@ class FileManager:
             # will load any allowed files, even if some are not allowed -- but with the
             # caveat that if an exception is raised we may stop in the middle of the load.
             #
+            #
+            #
+            _ = {
+                "name": name,
+                "path": path,
+                "template": template,
+                "registration_uuid": registration_uuid,
+            }
+            self._registration_failed(_)
+            #
             return
         self.legal_name(name)
         if path is None or path.strip() == "":
+            _ = {
+                "name": name,
+                "path": path,
+                "template": template,
+                "registration_uuid": registration_uuid,
+            }
+            self._registration_failed(_)
             raise ValueError("Path cannot be None or empty")
         if template is None:
             template = self.describer.get_template(name)
@@ -666,7 +689,7 @@ class FileManager:
             #
             self.configure_named_file(name, config)
         path = pathu.resep(path)
-        self.csvpaths.logger.debug("Path after resep %s", path)
+        self.csvpaths.logger.debug("[%s] Path after resep %s", registration_uuid, path)
         config = self.csvpaths.config
         http = config.get(section="inputs", name="allow_http_files", default=False)
         http = str(http).strip().lower() in ["on", "yes", "true"]
@@ -679,14 +702,28 @@ class FileManager:
         # the user cannot just override certain settings.
         #
         if nos.is_http and http is not True:
-            msg = f"Cannot add {path} as {name} because loading files over HTTP is not allowed"
+            _ = {
+                "name": name,
+                "path": path,
+                "template": template,
+                "registration_uuid": registration_uuid,
+            }
+            self._registration_failed(_)
+            msg = f"[{registration_uuid}] Cannot add {path} as {name} because loading files over HTTP is not allowed"
             self.csvpaths.logger.warning(msg)
             self.csvpaths.error_manager.handle_error(source=self, msg=msg)
             if self.csvpaths.ecoms.do_i_raise():
                 raise FileException(msg)
             return
         if nos.is_local and local is not True:
-            msg = f"Cannot add {path} as {name} because loading local files is not allowed"
+            _ = {
+                "name": name,
+                "path": path,
+                "template": template,
+                "registration_uuid": registration_uuid,
+            }
+            self._registration_failed(_)
+            msg = f"[{registration_uuid}] Cannot add {path} as {name} because loading local files is not allowed"
             self.csvpaths.logger.warning(msg)
             self.csvpaths.error_manager.handle_error(source=self, msg=msg)
             if self.csvpaths.ecoms.do_i_raise():
@@ -715,7 +752,9 @@ class FileManager:
                 path, name=name, template=template, recurse=False
             )
         try:
-            self.csvpaths.logger.debug("Ready to register %s", path)
+            self.csvpaths.logger.debug(
+                "[%s] Ready to register %s", registration_uuid, path
+            )
             #
             # path must end up with only legal filesystem chars.
             # the read-only http backend will have ? and possibly other
@@ -750,13 +789,17 @@ class FileManager:
             # exp: moving docs and descriptor to above copy_in()
             #
             self.assure_docs_and_discriptor(name)
-            self.csvpaths.logger.debug("Assured docs and discriptor")
+            self.csvpaths.logger.debug(
+                "[%s] Assured docs and discriptor", registration_uuid
+            )
             #
             # copy file to its home location
             #
-            self.csvpaths.logger.debug("Path after removing mark, if any: %s", path)
+            self.csvpaths.logger.debug(
+                "[%s] Path after removing mark, if any: %s", registration_uuid, path
+            )
             self._copy_in(name=name, path=path, home=home, template=template)
-            self.csvpaths.logger.debug("Done copying in")
+            self.csvpaths.logger.debug("[%s] Done copying in", registration_uuid)
             #
             # self.assure_docs_and_discriptor(name)
             # self.csvpaths.logger.debug("Assured docs and discriptor")
@@ -766,9 +809,13 @@ class FileManager:
             # done here.
             #
             rpath, h = self._fingerprint(home)
-            self.csvpaths.logger.debug("Fingerprint of %s: %s", path, h)
+            self.csvpaths.logger.debug(
+                "[%s] Fingerprint of %s: %s", registration_uuid, path, h
+            )
             ret = f"${name}.files.{h}"
-            self.csvpaths.logger.debug("Reference to named-file: %s", ret)
+            self.csvpaths.logger.debug(
+                "[%s] Reference to named-file: %s", registration_uuid, ret
+            )
             #
             # ---------------------------
             # maybe move the metadata handling to its own method?
@@ -777,7 +824,9 @@ class FileManager:
             # create the metadata event for this registration
             #
             name_home = self.named_file_home(name)
-            self.csvpaths.logger.debug("Name home is %s", name_home)
+            self.csvpaths.logger.debug(
+                "[%s] Name home is %s", registration_uuid, name_home
+            )
             mdata = FileMetadata(self.csvpaths.config)
             #
             # add the ability to pass in a UUID. if received, use it here to
@@ -805,8 +854,8 @@ class FileManager:
             mdata.file_name = file_home[file_home.rfind(nos.sep) + 1 :]
             mdata.name_home = name_home
             mdata.mark = mark
-            mdata.template = template
-            self.csvpaths.logger.debug("Created metadata")
+            mdata.template = template or ""
+            self.csvpaths.logger.debug("[%s] Created metadata", registration_uuid)
             #
             # TODO: add file_size. move FileInfo into Nos. for now it is 0.
             #
@@ -815,23 +864,39 @@ class FileManager:
             # the fingerprint is the most precise way of referencing a particular
             # named-file version.
             #
-            self.csvpaths.logger.debug("Registered %s", ret)
+            self.csvpaths.logger.debug("[%s] Registered %s", registration_uuid, ret)
             return ret
         except Exception as ex:
+            _ = {
+                "name": name,
+                "path": path,
+                "template": template,
+                "registration_uuid": registration_uuid,
+            }
+            self._registration_failed(_)
             #
             # remove me! tho, why you'd want quiet is not sure.
             #
-            print(traceback.format_exc())
+            # print(traceback.format_exc())
             #
             #
-            #
-            msg = f"Error in loading named-file: {ex}"
+            msg = f"[{registration_uuid}] Error in loading named-file: {ex}"
             self.csvpaths.logger.error(msg)
             self.csvpaths.error_manager.handle_error(
                 source=traceback.format_exc(), msg=msg
             )
             if self.csvpaths.ecoms.do_i_raise():
                 raise
+
+    def _registration_failed(self, data: dict[str, str]) -> None:
+        lst = FilesListener(self.csvpaths)
+        mdata = FileMetadata(self.csvpaths.config)
+        mdata.named_file_name = data.get("name")
+        mdata.origin_path = data.get("path")
+        mdata.template = data.get("template") or ""
+        mdata.uuid_string = data.get("registration_uuid")
+        mdata.status = "Registration failed"
+        lst.metadata_update(mdata)
 
     def _validate_xlsx_mark(self, path: str, mark: str) -> None:
         if not XlsxReaderHelper.is_xlsx(path):

--- a/csvpath/managers/files/file_registrar.py
+++ b/csvpath/managers/files/file_registrar.py
@@ -1,6 +1,4 @@
 import os
-import json
-from datetime import datetime
 from csvpath.util.exceptions import InputException, FileException
 from csvpath.util.nos import Nos
 from csvpath.managers.registrar import Registrar
@@ -110,9 +108,9 @@ class FileRegistrar(Registrar, Listener):
         nos.path = old_home
         nos.rename(new_home)
         mani[index]["file_home"] = new_home
-        mani[index][
-            "file"
-        ] = f"{new_home}{sep}{mani[index]['fingerprint']}.{mani[index]['type']}"
+        mani[index]["file"] = (
+            f"{new_home}{sep}{mani[index]['fingerprint']}.{mani[index]['type']}"
+        )
 
     def metadata_update(self, mdata: Metadata) -> None:
         path = mdata.origin_path
@@ -132,8 +130,7 @@ class FileRegistrar(Registrar, Listener):
         mani["from"] = path
         if mark is not None:
             mani["mark"] = mark
-        if mdata.template is not None:
-            mani["template"] = mdata.template
+        mani["template"] = mdata.template or ""
         jdata = self.get_manifest(manifest_path)
         jdata.append(mani)
         self.intermediary.put_json(manifest_path, jdata)

--- a/csvpath/managers/files/files_listener.py
+++ b/csvpath/managers/files/files_listener.py
@@ -69,6 +69,8 @@ class FilesListener(Listener):  # Registrar,
         if mdata.mark is not None:
             mani["mark"] = mdata.mark
         mani["manifest_path"] = self.manifest_path()
+        if hasattr(mdata, "status"):
+            mani["status"] = mdata.status
         return mani
 
     def metadata_update(self, mdata: Metadata) -> None:

--- a/csvpath/managers/integrations/webhook/webhook_listener.py
+++ b/csvpath/managers/integrations/webhook/webhook_listener.py
@@ -165,4 +165,11 @@ class WebhookListener(Listener, threading.Thread):
             ...
 
     def _do_send(self, *, url: str, payload: dict, headers: dict, timeout: int):
+        #
+        # this is an expected occurance. any empty block captured by the FlightPath form
+        # will have no url but will exist so will be attempted. we just want to ignore
+        # those attempts
+        #
+        if not url:
+            return
         return requests.post(url, json=payload, headers=headers, timeout=timeout)

--- a/csvpath/managers/metadata.py
+++ b/csvpath/managers/metadata.py
@@ -1,7 +1,7 @@
 from uuid import uuid4, UUID
 import os
 from abc import ABC
-from datetime import datetime, timezone
+from datetime import datetime
 from dateutil import parser
 import getpass
 import socket
@@ -150,7 +150,6 @@ class Metadata(ABC):
 
     @time_started_string.setter
     def time_started_string(self, s: str) -> None:
-        # self._time_started = datetime.date.fromisoformat(s)
         self._time_started = parser.parse(s)
 
     @property

--- a/csvpath/managers/results/result.py
+++ b/csvpath/managers/results/result.py
@@ -1,5 +1,4 @@
 # pylint: disable=C0114
-import os
 from uuid import UUID
 import uuid
 import json
@@ -12,7 +11,7 @@ from csvpath.managers.listener import Listener
 from csvpath.managers.metadata import Metadata
 from csvpath.util.printer import Printer
 from csvpath.util.exceptions import CsvPathsException
-from csvpath.util.line_spooler import LineSpooler, CsvLineSpooler
+from csvpath.util.line_spooler import LineSpooler
 from .result_serializer import ResultSerializer
 from .readers.readers import ResultReadersFacade
 from csvpath.matching.util.expression_utility import ExpressionUtility
@@ -40,6 +39,7 @@ class Result(ErrorCollector, Printer, Listener):  # pylint: disable=R0902
         by_line: bool = False,
         run_uuid: UUID,
         method: str = None,
+        template: str = None,
     ):
         """@private"""
         ErrorCollector.__init__(self)
@@ -105,6 +105,7 @@ class Result(ErrorCollector, Printer, Listener):  # pylint: disable=R0902
         self._lines: list[list[Any]] = None
         self._readers_facade = ResultReadersFacade(self)
         self._run_uuid = run_uuid
+        self._template = template or ""
 
     @property
     def actual_data_file(self) -> str:
@@ -120,6 +121,10 @@ class Result(ErrorCollector, Printer, Listener):  # pylint: disable=R0902
                 self.file_name
             )
         return self._origin_data_file
+
+    @property
+    def template(self) -> str:
+        return self._template
 
     @property
     def uuid(self) -> UUID:

--- a/csvpath/managers/results/results_manager.py
+++ b/csvpath/managers/results/results_manager.py
@@ -365,6 +365,7 @@ class ResultsManager:  # pylint: disable=C0115
         mdata.named_paths_name = result.paths_name
         mdata.named_file_name = result.file_name
         mdata.method = result.method
+        mdata.template = result.template or ""
         rr = RunRegistrar(self.csvpaths)
         #
         # add any dynamic listeners to the registrar here

--- a/csvpath/managers/results/transfers_manager.py
+++ b/csvpath/managers/results/transfers_manager.py
@@ -13,6 +13,10 @@ class TransfersManager:
         self._results_manager = results_manager
 
     @property
+    def logger(self):
+        return self.csvpaths.logger
+
+    @property
     def csvpaths(self):
         return self.results_manager.csvpaths
 
@@ -22,21 +26,25 @@ class TransfersManager:
 
     def do_transfers_if(self, result) -> None:
         try:
+            self.logger.info(
+                "Checking for transfers from run: %s declared on named-paths group: %s for statement: %s",
+                result.run_uuid,
+                result.paths_name,
+                result.identity_or_index,
+            )
             self.do_transfer_mode_if(result)
-        except Exception as ex:
-            #
-            # handle better!
-            #
-            print(traceback.format_exc())
-            self.results_manager.csvpaths.logger.error(ex)
+        except Exception:
+            self.logger.error(traceback.format_exc())
         try:
+            self.logger.info(
+                "Checking for transfers from run: %s in named-paths group: %s declared by statement: %s",
+                result.run_uuid,
+                result.paths_name,
+                result.identity_or_index,
+            )
             self.do_description_transfers_if(result)
-        except Exception as ex:
-            #
-            # handle better!
-            #
-            print(traceback.format_exc())
-            self.results_manager.csvpaths.logger.error(ex)
+        except Exception:
+            self.logger.error(traceback.format_exc())
 
     def do_description_transfers_if(self, result) -> None:
         #
@@ -226,6 +234,12 @@ class TransfersManager:
         for t in tpaths:
             pathfrom = t[2]
             pathto = t[3]
+            self.logger.info(
+                "Attempting transfer of %s to %s for named-paths group %s",
+                pathfrom,
+                pathto,
+                name,
+            )
             try:
                 rmode = "rb" if "b" in t[4] else "r"
                 n = pathu.dir_name(pathto)
@@ -253,12 +267,17 @@ class TransfersManager:
                         writer.sink.write(pf.read())
                     finally:
                         writer.close()
-            except Exception:
-                print(traceback.format_exc())
-                logger = self.results_manager.csvpaths.logger
-                logger.warning(
-                    "Cannot transfer %s to %s", pathfrom, pathto, exc_info=True
+                self.logger.info(
+                    "Done transfering %s to %s for named-paths group %s",
+                    pathfrom,
+                    pathto,
+                    name,
                 )
+            except Exception:
+                self.logger.error(
+                    "Error in transfers of %s for named-paths group %s", tpaths, name
+                )
+                self.logger.error(traceback.format_exc())
 
     def _path_to_transfer_to(self, result, t) -> str:
         if result is None:

--- a/csvpath/managers/run/run_metadata.py
+++ b/csvpath/managers/run/run_metadata.py
@@ -1,6 +1,6 @@
 from csvpath.managers.metadata import Metadata
 
-from uuid import uuid4, UUID
+from uuid import UUID
 
 
 class RunMetadata(Metadata):
@@ -12,6 +12,15 @@ class RunMetadata(Metadata):
         self.identity: str = None
         self._run_uuid: UUID = None
         self._method: str = None
+        self._template: str = ""
+
+    @property
+    def template(self) -> str:
+        return self._template
+
+    @template.setter
+    def template(self, t: str) -> None:
+        self._template = t
 
     @property
     def run_uuid(self) -> UUID:

--- a/csvpath/managers/run/run_registrar.py
+++ b/csvpath/managers/run/run_registrar.py
@@ -1,8 +1,4 @@
-import os
-import time
 import json
-from abc import ABC, abstractmethod
-from csvpath.util.exceptions import FileException
 from csvpath.util.file_writers import DataFileWriter
 from csvpath.util.file_readers import DataFileReader
 from csvpath.util.nos import Nos
@@ -13,7 +9,6 @@ from ..metadata import Metadata
 
 class RunRegistrar(Registrar, Listener):
     def __init__(self, csvpaths):
-        # super().__init__(csvpaths)
         Registrar.__init__(self, csvpaths)
         Listener.__init__(self, csvpaths.config)
         self.type_name = "run"
@@ -22,7 +17,6 @@ class RunRegistrar(Registrar, Listener):
     @property
     def manifest_path(self) -> str:
         return Nos(self.archive).join("manifest.json")
-        # return os.path.join(self.archive, "manifest.json")
 
     @property
     def manifest(self) -> list:
@@ -54,6 +48,7 @@ class RunRegistrar(Registrar, Listener):
         m["base_path"] = mdata.base_path
         m["named_files_root"] = mdata.named_files_root
         m["named_paths_root"] = mdata.named_paths_root
+        m["template"] = mdata.template or ""
         #
         #
         #

--- a/csvpath/util/config.py
+++ b/csvpath/util/config.py
@@ -113,7 +113,11 @@ allow_http_files=True
 allow_local_files=True
 
 [listeners]
-# add listener group names to send events to the channel they represent
+#
+# add listener group names to send events to the channel they represent. default
+# tracks registrations, loads, and (soon) results at the highest level. it isn't
+# required, but it is highly recommended.
+#
 groups = default,activation
 #slack, openlineage, ckan, sftp, sftpplus, otlp, sqlite, sql
 

--- a/csvpath/util/log_utility.py
+++ b/csvpath/util/log_utility.py
@@ -294,7 +294,7 @@ class LogUtility:
         #
         # there will be 0, 1, or 2 handlers. we clear them and start fresh.
         #
-        for _ in logger.handlers:
+        for _ in logger.handlers[:]:
             _.flush()
             _.close()
             logger.removeHandler(_)

--- a/csvpath/util/template_util.py
+++ b/csvpath/util/template_util.py
@@ -145,12 +145,12 @@ class TemplateUtility:
         #
         # remove run_dir or filename for remaining tests
         #
-        t2 = template.rstrip(f"/{e}")
+        t2 = template.removesuffix(f"/{e}")
         #
         # cannot be just ":run_dir". covered this above, no?
         #
         if t2 == "/" or t2.strip() == "":
-            return (False, "Cannot be solely {e}")
+            return (False, f"Cannot be solely {e}")
         #
         # index pointers must be the only other uses of colon and
         # must have 1 or 2 integers, not 3
@@ -164,7 +164,11 @@ class TemplateUtility:
                     return False
                 ns = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
                 if t2[i + 1] not in ns:
-                    return (False, "Colon-led tokens must be numbers or :run_dir")
+                    t = ":filename" if file is True else ":run_dir"
+                    return (
+                        False,
+                        f"Colon-led tokens must be numbers, datetime tokens, or {t}",
+                    )
                 try:
                     if t2[i + 2] in ns and t2[i + 3] in ns:
                         return False

--- a/tests/csvpath/test_resources/deleteme/config.ini
+++ b/tests/csvpath/test_resources/deleteme/config.ini
@@ -1,0 +1,162 @@
+
+[extensions]
+csvpath_files = csvpath, csvpaths
+csv_files = csv, tsv, dat, tab, psv, ssv, xlsx, jsonl
+
+[errors]
+csvpath = collect, fail, print
+csvpaths = print, collect
+use_format = full
+pattern = {time}:{file}:{line}:{paths}:{instance}:{chain}:  {message}
+
+[logging]
+csvpath = info
+csvpaths = info
+log_file = logs/csvpath.log
+log_files_to_keep = 100
+log_file_size = 50000000
+# file or rotating
+handler = file
+
+[config]
+path = /Users/davidkershaw/dev/csvpath/tests/csvpath/test_resources/deleteme/config.ini
+allow_var_sub = True
+var_sub_source = env
+
+[functions]
+imports =
+
+[cache]
+path =
+
+[results]
+archive = archive
+transfers = transfers
+
+[inputs]
+files = inputs/named_files
+csvpaths = inputs/named_paths
+on_unmatched_file_fingerprints = halt
+allow_http_files=True
+allow_local_files=True
+
+[listeners]
+# add listener group names to send events to the channel they represent
+groups = default,activation
+#slack, openlineage, ckan, sftp, sftpplus, otlp, sqlite, sql
+
+# general purpose webhook caller
+webhook.results = from csvpath.managers.integrations.webhook.webhook_results_listener import WebhookResultsListener
+
+# add a listener to exec scripts at the end of named-paths group runs
+scripts.results = from csvpath.managers.integrations.scripts.scripts_results_listener import ScriptsResultsListener
+
+# add sql to capture results in mysql, postgres, ms sql server, or sqlite
+sql.file = from csvpath.managers.integrations.sql.sql_file_listener import SqlFileListener
+sql.paths = from csvpath.managers.integrations.sql.sql_paths_listener import SqlPathsListener
+sql.result = from csvpath.managers.integrations.sql.sql_result_listener import SqlResultListener
+sql.results = from csvpath.managers.integrations.sql.sql_results_listener import SqlResultsListener
+
+# add sqlite to capture results in a local sqlite file
+sqlite.results = from csvpath.managers.integrations.sqlite.sqlite_results_listener import SqliteResultsListener
+sqlite.result = from csvpath.managers.integrations.sqlite.sqlite_result_listener import SqliteResultListener
+
+# add to capture a history of all named-file stagings and all named-paths loads in
+# an [inputs] files and an[inputs] paths root manifest.json
+default.file = from csvpath.managers.files.files_listener import FilesListener
+default.paths = from csvpath.managers.paths.paths_listener import PathsListener
+
+# adds a listener that uses info in a named-file descriptor to create a run when data arrives
+activation.file = from csvpath.managers.files.files_activation_listener import FileActivationListener
+
+# add otlp to the list of groups above to push observability metrics to an OpenTelemetry endpoint
+otlp.result = from csvpath.managers.integrations.otlp.otlp_result_listener import OpenTelemetryResultListener
+otlp.results = from csvpath.managers.integrations.otlp.otlp_results_listener import OpenTelemetryResultsListener
+otlp.errors = from csvpath.managers.integrations.otlp.otlp_error_listener import OpenTelemetryErrorListener
+otlp.paths = from csvpath.managers.integrations.otlp.otlp_paths_listener import OpenTelemetryPathsListener
+otlp.file = from csvpath.managers.integrations.otlp.otlp_file_listener import OpenTelemetryFileListener
+
+# add sftp to the list of groups above to push content and metadata to an SFTP account
+sftp.results = from csvpath.managers.integrations.sftp.sftp_sender import SftpSender
+
+# add sftpplus to the list of groups above to automate registration and named-paths group runs on file arrival at an SFTPPlus server
+sftpplus.paths = from csvpath.managers.integrations.sftpplus.sftpplus_listener import SftpPlusListener
+
+# add ckan to the list of groups above to push content and metadata to CKAN
+ckan.results = from csvpath.managers.integrations.ckan.ckan_listener import CkanListener
+
+#add openlineage to the list of groups above for OpenLineage events to a Marquez server
+openlineage.file = from csvpath.managers.integrations.ol.file_listener_ol import OpenLineageFileListener
+openlineage.paths = from csvpath.managers.integrations.ol.paths_listener_ol import OpenLineagePathsListener
+openlineage.result = from csvpath.managers.integrations.ol.result_listener_ol import OpenLineageResultListener
+openlineage.results = from csvpath.managers.integrations.ol.results_listener_ol import OpenLineageResultsListener
+
+# add slack to the list of groups above for alerts to slack webhooks
+slack.file = from csvpath.managers.integrations.slack.sender import SlackSender
+slack.paths = from csvpath.managers.integrations.slack.sender import SlackSender
+slack.result = from csvpath.managers.integrations.slack.sender import SlackSender
+slack.results = from csvpath.managers.integrations.slack.sender import SlackSender
+
+[parquet]
+batch_size=100000
+
+[otlp]
+# add OTLP config here if not relying directly on the env vars
+
+[aws]
+#
+
+[azure]
+#
+
+[gcs]
+#
+
+[sqlite]
+db = archive/csvpath.db
+
+[sql]
+# mysql, postgres, sql_server, or sqlite
+dialect = sqlite
+connection_string = sqlite:///archive/csvpath-sqlite.db
+
+[sftp]
+server =
+port =
+username =
+password =
+
+[sftpplus]
+# these are only needed on the server
+admin_username = SFTPPLUS_ADMIN_USERNAME
+admin_password = SFTPPLUS_ADMIN_PASSWORD
+api_url = https://. . . :10020/json
+scripts_dir =
+execute_timeout = 300
+
+# these are only needed by the csvpath writer
+mailbox_user = mailbox
+mailbox_password = SFTPPLUS_MAILBOX_PASSWORD
+server = SFTPPLUS_SERVER
+port = SFTPPLUS_PORT
+
+[ckan]
+server = http://. . . :80
+api_token =
+
+[openlineage]
+base_url = http://. . . :5000
+endpoint = api/v1/lineage
+api_key = "none"
+timeout = 5
+verify = False
+
+[slack]
+# add your main webhook here. to set webhooks on a csvpath-by-csvpath basis add
+# on-valid-slack: webhook-minus-'https://' and/or
+# on-invalid-slack: webhook-minus-'https://'
+webhook_url =
+
+[scripts]
+run_scripts = no
+shell = /bin/bash

--- a/tests/csvpaths/managers/test_csvpaths_managers_files_manager.py
+++ b/tests/csvpaths/managers/test_csvpaths_managers_files_manager.py
@@ -2,6 +2,7 @@ import unittest
 import pytest
 import shutil
 import os
+import json
 from csvpath.util.nos import Nos
 from csvpath.managers.files.files_listener import FilesListener
 from csvpath.managers.files.file_metadata import FileMetadata
@@ -19,6 +20,30 @@ AMAZING = f"tests{os.sep}csvpaths{os.sep}test_resources{os.sep}lookup_names.csv"
 
 
 class TestCsvPathsManagersFileManager(unittest.TestCase):
+    def test_file_registration_failed(self) -> None:
+        paths = Builder().build()
+        if paths.file_manager.has_named_file("failed"):
+            paths.file_manager.remove_named_file("failed")
+        assert not paths.file_manager.has_named_file("failed")
+
+        with pytest.raises(ValueError):
+            paths.file_manager.add_named_file(name="failed", path="")
+        mpath = paths.config.get(section="inputs", name="files")
+        mpath = Nos(mpath).join("manifest.json")
+
+        self._find_in_mani(
+            paths, {"status": ["Registration failed", None], "template": [-9999]}
+        )
+
+    def _find_in_mani(self, csvpaths, keys: dict[str, str]) -> list[bool]:
+        mpath = csvpaths.config.get(section="inputs", name="files")
+        mpath = Nos(mpath).join("manifest.json")
+        with DataFileReader(mpath) as file:
+            js = json.load(file.source)
+            for _ in js:
+                for k, v in keys.items():
+                    assert _.get(k) in v or (-9999 in v and _.get(k) is not None)
+
     def test_files_named_file_template_1(self) -> None:
         paths = Builder().build()
         nf = "orders"
@@ -108,6 +133,13 @@ class TestCsvPathsManagersFileManager(unittest.TestCase):
         #
         paths.file_manager.add_named_file(name=nf, path=FILE)
         assert paths.file_manager.has_named_file(nf)
+        #
+        # check that we picked up a template key
+        #
+        self._find_in_mani(
+            paths, {"status": ["Registration failed", None], "template": [-9999]}
+        )
+
         #
         # clear what we just added
         #

--- a/tests/csvpaths/managers/test_csvpaths_managers_results_manager.py
+++ b/tests/csvpaths/managers/test_csvpaths_managers_results_manager.py
@@ -1,18 +1,20 @@
 import unittest
 import pytest
 import os
+import json
 from datetime import datetime
 from csvpath.managers.results.result import Result
 from csvpath.managers.results.result_serializer import ResultSerializer
+from csvpath.util.nos import Nos
+from csvpath.util.file_readers import DataFileReader
 from tests.csvpaths.builder import Builder
-
 
 FOODX = (
     f"tests{os.sep}csvpaths{os.sep}test_resources{os.sep}named_files{os.sep}foodx.csv"
 )
-FILES = {
-    "food": f"tests{os.sep}csvpaths{os.sep}test_resources{os.sep}named_files{os.sep}food.csv"
-}
+PATH = f"tests{os.sep}csvpaths{os.sep}test_resources{os.sep}named_files{os.sep}food.csv"
+FILES = {"food": PATH}
+
 NAMED_PATHS_DIR = (
     f"tests{os.sep}csvpaths{os.sep}test_resources{os.sep}named_paths{os.sep}"
 )
@@ -115,6 +117,29 @@ class TestCsvPathsManagersResultsManager(unittest.TestCase):
         paths.fast_forward_paths(pathsname="print_test", filename="food")
         results = paths.results_manager.get_named_results("print_test")
         assert results
+
+    def test_results_template_captured(self):
+        paths = Builder().build()
+
+        a = paths.config.get(section="results", name="archive")
+        print(f"archive: {a}")
+
+        paths.file_manager.add_named_file(name="food", path=PATH)
+        paths.paths_manager.add_named_paths(
+            name="template_capture",
+            paths=[""" ~ validation-mode: no-raise, print~ $[0][ print( "test" ) ]"""],
+        )
+        paths.fast_forward_paths(
+            pathsname="template_capture", filename="food", template=":0/:run_dir"
+        )
+        results = paths.results_manager.get_named_results("template_capture")
+        assert results
+
+        m = Nos(a).join("manifest.json")
+        with DataFileReader(m) as file:
+            js = json.load(file.source)
+            for _ in js:
+                assert "template" in _
 
     def test_results_named_results_home(self):
         paths = Builder().build()

--- a/tests/references/test_references_3_grammar.__
+++ b/tests/references/test_references_3_grammar.__
@@ -1,0 +1,78 @@
+from lark import UnexpectedInput
+from csvpath.references.reference_parser_3 import ReferenceParser3
+
+cases = [
+    ('$*.files.:name("acme").:data()', True),
+    ('$*.files.*.:data()', False),  # bare * NOT legal in name_one, only as root_major itself
+    ('$*.files.:name("Acme")/:year()/:q2():from(:version(1)):to(:version(3)).:data()', True),
+    ('$*.files.:name("*")/more/:name("*"):last().:data()', True),
+    ('$*.files.*/more/pathnames.:last()', False),
+    ('$q1-orders.results.:year(2024)/:run_dir().:data()', True),
+    ('$orders.csvpaths.:last().', False),  # trailing empty name_three -- illegal, + requires at least one item
+    ('$orders.csvpaths.:last()', False),   # only 3 dot-separated parts, not 4 -- illegal
+    ('$orders.csvpaths.:last().:all()', True),  # version selected, no specific member -- spelled explicitly
+    ('$orders.csvpaths.:last().q1-orders', True),   # last version of the group, member "q1-orders"
+    ('$orders.csvpaths.:index(2).q1-orders', True),  # explicit version, member "q1-orders"
+    ('$orders.csvpaths..', False),  # empty name_one -- illegal, must spell out :last() etc.
+    ('$*.files.:name(@customer).:data()', True),
+
+    # nested function args specifically
+    ('$*.files.:name("x"):from(:version(1)):to(:version(3)).:data()', True),
+    ('$orders.results.:from(:first()):to(:last()).:vars()', True),
+
+    # root_major must be EITHER "*" OR a name -- not both, not empty
+    ('$.files.:name("x").:data()', False),
+    ('$*orders.files.:name("x").:data()', False),
+
+    # minor names via "#"
+    # root_major stands alone -- no "#" at all (root_minor concept removed:
+    # it was attached to the wrong slot, and named-files don't have
+    # worksheets -- physical files do, which is what name_two is for).
+    ('$orders#sub.files.:name("x").:data()', False),
+    # name_one may carry #name_two -- the one surviving use case, worksheets
+    # within a physical file. This is the ONLY place "#" is legal now.
+    ('$orders.files.:name("x")#Sheet1.:data()', True),
+    # name_three never carries "#" -- name_four is cut, no surviving use case.
+    ('$orders.files.:name("x").:data()#four', False),
+
+    # path-text character rules: literal space preserved, %-encoding legal
+    ('$*.files.:name("Acme Corp")/folder name/here.:data()', True),
+    # the literal %% is an escapted %
+    ('$*.files.:name("100%%done").:data()', True),
+    # the lteral %20 is a url encoded space char. we can take a space char
+    # in a name, but this %20 is another way to include one and just a test
+    # that could have been any other encoded char.
+    ('$*.files.:name("100%20done").:data()', True),
+    # a literal \t/\r/\n adjacent to path text is stripped via %ignore WS,
+    # leaving the surrounding literal segments to concatenate -- verified
+    # this matches the spec's "strip \t \r \n, preserve a literal space"
+    # rule (confirmed by inspecting the parse tree directly, not asserted
+    # blindly): the lexer treats tab as an inter-token separator, so
+    # "fol<TAB>der" parses as two adjacent path_items that read as one
+    # continuous "folder" once concatenated by the resolver.
+
+    # name_one paths are always relative -- a leading "/" is a hard parse
+    # error, not silently stripped (stripping would make "/Acme" and "Acme"
+    # mean the same thing with no signal the input was altered).
+    ('$*.files./Acme.:data()', False),
+    ('$*.files.Acme.:data()', True),
+    ('$*.files.Acme/sub.:data()', True),  # internal slash still fine, not first position
+]
+
+paths = CsvPaths()
+for expr, expect_ok in cases:
+    err = ""
+    try:
+        ref = ReferenceParser3(reference=expr, csvpaths=paths)
+        ref.parse()
+        finder = ReferenceFinder3.finder_for_datatype(ref=ref)
+        results = finder.query()
+        assert len(results) != None and len(results) > -1
+        for _ in results:
+            ...
+        ok = True
+    except UnexpectedInput as e:
+        ok = False
+        err = str(e).split("\n")[0]
+    status = "PASS" if ok == expect_ok else "FAIL"
+    print(f"[{status}] expect_ok={str(expect_ok):5} got_ok={str(ok):5} | {expr}" + (f"  -- {err}" if err else ""))

--- a/tests/test_resources/temp/config.ini
+++ b/tests/test_resources/temp/config.ini
@@ -1,0 +1,162 @@
+
+[extensions]
+csvpath_files = csvpath, csvpaths
+csv_files = csv, tsv, dat, tab, psv, ssv, xlsx, jsonl
+
+[errors]
+csvpath = collect, fail, print
+csvpaths = print, collect
+use_format = full
+pattern = {time}:{file}:{line}:{paths}:{instance}:{chain}:  {message}
+
+[logging]
+csvpath = info
+csvpaths = info
+log_file = logs/csvpath.log
+log_files_to_keep = 100
+log_file_size = 50000000
+# file or rotating
+handler = file
+
+[config]
+path = /Users/davidkershaw/dev/csvpath/tests/test_resources/temp/config.ini
+allow_var_sub = True
+var_sub_source = env
+
+[functions]
+imports =
+
+[cache]
+path =
+
+[results]
+archive = archive
+transfers = transfers
+
+[inputs]
+files = inputs/named_files
+csvpaths = inputs/named_paths
+on_unmatched_file_fingerprints = halt
+allow_http_files=True
+allow_local_files=True
+
+[listeners]
+# add listener group names to send events to the channel they represent
+groups = default,activation
+#slack, openlineage, ckan, sftp, sftpplus, otlp, sqlite, sql
+
+# general purpose webhook caller
+webhook.results = from csvpath.managers.integrations.webhook.webhook_results_listener import WebhookResultsListener
+
+# add a listener to exec scripts at the end of named-paths group runs
+scripts.results = from csvpath.managers.integrations.scripts.scripts_results_listener import ScriptsResultsListener
+
+# add sql to capture results in mysql, postgres, ms sql server, or sqlite
+sql.file = from csvpath.managers.integrations.sql.sql_file_listener import SqlFileListener
+sql.paths = from csvpath.managers.integrations.sql.sql_paths_listener import SqlPathsListener
+sql.result = from csvpath.managers.integrations.sql.sql_result_listener import SqlResultListener
+sql.results = from csvpath.managers.integrations.sql.sql_results_listener import SqlResultsListener
+
+# add sqlite to capture results in a local sqlite file
+sqlite.results = from csvpath.managers.integrations.sqlite.sqlite_results_listener import SqliteResultsListener
+sqlite.result = from csvpath.managers.integrations.sqlite.sqlite_result_listener import SqliteResultListener
+
+# add to capture a history of all named-file stagings and all named-paths loads in
+# an [inputs] files and an[inputs] paths root manifest.json
+default.file = from csvpath.managers.files.files_listener import FilesListener
+default.paths = from csvpath.managers.paths.paths_listener import PathsListener
+
+# adds a listener that uses info in a named-file descriptor to create a run when data arrives
+activation.file = from csvpath.managers.files.files_activation_listener import FileActivationListener
+
+# add otlp to the list of groups above to push observability metrics to an OpenTelemetry endpoint
+otlp.result = from csvpath.managers.integrations.otlp.otlp_result_listener import OpenTelemetryResultListener
+otlp.results = from csvpath.managers.integrations.otlp.otlp_results_listener import OpenTelemetryResultsListener
+otlp.errors = from csvpath.managers.integrations.otlp.otlp_error_listener import OpenTelemetryErrorListener
+otlp.paths = from csvpath.managers.integrations.otlp.otlp_paths_listener import OpenTelemetryPathsListener
+otlp.file = from csvpath.managers.integrations.otlp.otlp_file_listener import OpenTelemetryFileListener
+
+# add sftp to the list of groups above to push content and metadata to an SFTP account
+sftp.results = from csvpath.managers.integrations.sftp.sftp_sender import SftpSender
+
+# add sftpplus to the list of groups above to automate registration and named-paths group runs on file arrival at an SFTPPlus server
+sftpplus.paths = from csvpath.managers.integrations.sftpplus.sftpplus_listener import SftpPlusListener
+
+# add ckan to the list of groups above to push content and metadata to CKAN
+ckan.results = from csvpath.managers.integrations.ckan.ckan_listener import CkanListener
+
+#add openlineage to the list of groups above for OpenLineage events to a Marquez server
+openlineage.file = from csvpath.managers.integrations.ol.file_listener_ol import OpenLineageFileListener
+openlineage.paths = from csvpath.managers.integrations.ol.paths_listener_ol import OpenLineagePathsListener
+openlineage.result = from csvpath.managers.integrations.ol.result_listener_ol import OpenLineageResultListener
+openlineage.results = from csvpath.managers.integrations.ol.results_listener_ol import OpenLineageResultsListener
+
+# add slack to the list of groups above for alerts to slack webhooks
+slack.file = from csvpath.managers.integrations.slack.sender import SlackSender
+slack.paths = from csvpath.managers.integrations.slack.sender import SlackSender
+slack.result = from csvpath.managers.integrations.slack.sender import SlackSender
+slack.results = from csvpath.managers.integrations.slack.sender import SlackSender
+
+[parquet]
+batch_size=100000
+
+[otlp]
+# add OTLP config here if not relying directly on the env vars
+
+[aws]
+#
+
+[azure]
+#
+
+[gcs]
+#
+
+[sqlite]
+db = archive/csvpath.db
+
+[sql]
+# mysql, postgres, sql_server, or sqlite
+dialect = sqlite
+connection_string = sqlite:///archive/csvpath-sqlite.db
+
+[sftp]
+server =
+port =
+username =
+password =
+
+[sftpplus]
+# these are only needed on the server
+admin_username = SFTPPLUS_ADMIN_USERNAME
+admin_password = SFTPPLUS_ADMIN_PASSWORD
+api_url = https://. . . :10020/json
+scripts_dir =
+execute_timeout = 300
+
+# these are only needed by the csvpath writer
+mailbox_user = mailbox
+mailbox_password = SFTPPLUS_MAILBOX_PASSWORD
+server = SFTPPLUS_SERVER
+port = SFTPPLUS_PORT
+
+[ckan]
+server = http://. . . :80
+api_token =
+
+[openlineage]
+base_url = http://. . . :5000
+endpoint = api/v1/lineage
+api_key = "none"
+timeout = 5
+verify = False
+
+[slack]
+# add your main webhook here. to set webhooks on a csvpath-by-csvpath basis add
+# on-valid-slack: webhook-minus-'https://' and/or
+# on-invalid-slack: webhook-minus-'https://'
+webhook_url =
+
+[scripts]
+run_scripts = no
+shell = /bin/bash

--- a/tests/test_resources/temp/env.json
+++ b/tests/test_resources/temp/env.json
@@ -1,0 +1,3 @@
+{
+    "BLUEFISH": "ha"
+}

--- a/tests/util/test_util_template_util.py
+++ b/tests/util/test_util_template_util.py
@@ -7,8 +7,15 @@ class TestUtilTemplateUtil(unittest.TestCase):
         #
         # goods
         #
-        temu.valid("a/b/:run_dir")
-        temu.valid("a/:1/:run_dir")
+        t = temu.validate("a/b/:run_dir")
+        print(f"11: {t}")
+        assert t[0]
+        t = temu.validate("a/:1/:run_dir")
+        print(f"11: {t}")
+        assert t[0]
+        t = temu.validate("a/:filename", file=True)
+        print(f"11: {t}")
+        assert t[0]
         #
         # bads
         #


### PR DESCRIPTION
…statements during add_named_file. Very important because we need to be able to track a failure by UUID, the only thing the caller has that is a real identity.

DONE		>> if file registration fails, could we have the registrar put an attempted-failed message in the top-level named_files manifest? DONE		>> we should log transfers in the csvpath log — and maybe also in a transfers manifest file in _extra_data? DONE:	> broken f-string on line just after the rstrip call — return (False, "Cannot be solely {e}") — also in template_util.py DONE 	> csvpath/util/template_util.py, line 148: t2 = template.rstrip(f"/{e}") - intent was removesuffix(f"/{e}") to strip substring DONE: 	> named-paths and named-files templates should be captured in the run and register manifests DONE >> webhook_listener.py168: attempts to send to ‘’ and blows up DONE:  >> LogUtility.setup_logger() modifies logger.handlers while iterating over it making old FileHandler instances accumulate DONE: >> message in Temu calls out Colon-led tokens must be numbers but doesn’t mention date tokens and says run_dir never :filename.