### PR TITLE
References v3: transformer, finder ABC, and results container

### DIFF
--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -222,24 +222,30 @@ class NameThree3:
 #
 # PLACEHOLDER pending the real function registry (see "requirements for
 # functions.txt" -- functions are looked up/validated at runtime by a
-# registry that does not exist yet). Once it does, this trait belongs on
-# Function3 itself as self-description metadata, not here as a bare name
-# list. For now this is the minimum needed to answer the one
-# function-semantics question ReferenceFinder3 needs today: does this
-# reference resolve to a whole file/thing (path+uuid), or a specific
-# extracted value?
+# registry that does not exist yet). Once it does, this belongs on
+# Function3 itself as self-description metadata (each function will
+# self-report whether it is a "context setter" or a "pointer" -- see
+# that doc), not here as a bare name list.
 #
-# per "creating references v3.txt": a well-known-file function like
-# :errors() returns the file itself; giving it an argument that is a
-# VALUE-LOCATOR function like :idchain(...) means "pull a specific value
-# out of that file" instead. the signal is deliberately narrow -- it is
-# NOT "any nested function arg" (plenty of ordinary selector functions
-# take one, e.g. :from(:index(0)) is still a file/version selector, not
-# a value extraction) -- it is specifically whether a value-locator
-# function appears anywhere in the terminal function chain's argument
-# tree.
+# there is no separate "value extracting" category of function: a
+# pointer resolves the current scope to exactly 0 or 1 item, full stop.
+# in name_one that item is a physical file/version/run; in name_three
+# it is a well-known file (e.g. :errors()) UNLESS that pointer itself
+# takes another pointer as its argument, in which case the outer
+# pointer resolves to a specific value inside the file rather than the
+# file as a whole (e.g. :errors(:idchain("add[0]string[2]"))). so what
+# this constant actually names is: pointer functions currently known to
+# be used this way -- nested inside another function, in name_three,
+# meaning "a value" rather than "a file." it is deliberately NOT "any
+# pointer nested inside another function" -- name_one already nests
+# pointers inside functions all the time for ordinary version/range
+# selection (e.g. :from(:index(0)) is still picking a file/version, not
+# extracting a value), and name_three may end up doing the same for its
+# own result-file listing once more functions exist. this list will be
+# replaced by real trait lookups once Function3 exists; treat it as
+# provisional, not as a general rule for "nested pointer means value."
 #
-_VALUE_LOCATOR_FUNCTIONS = ("idchain",)
+_CONTENT_POINTER_FUNCTIONS = ("idchain",)
 
 
 class Reference3:
@@ -308,16 +314,17 @@ class Reference3:
 
     @property
     def resolves_to_data(self) -> bool:
-        """does this reference ask for a specific extracted value
-        (True), or the referenced file/thing as-is (False)? see the
-        _VALUE_LOCATOR_FUNCTIONS placeholder comment above -- this is a
-        stand-in for a trait the future function registry will own."""
+        """does this reference ask for a specific value inside a
+        well-known file (True), or the file/thing as-is (False)? see
+        the _CONTENT_POINTER_FUNCTIONS placeholder comment above -- this
+        is a stand-in for a trait the future function registry will
+        own (a pointer nested inside another pointer, in name_three)."""
         if self._name_three is None:
             return False
         return any(
             f.contains_function_named(name)
             for f in self._name_three.functions
-            for name in _VALUE_LOCATOR_FUNCTIONS
+            for name in _CONTENT_POINTER_FUNCTIONS
         )
 
     def __eq__(self, other) -> bool:

--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -1,0 +1,294 @@
+import logging
+
+from .reference_exceptions_3 import ReferenceException3
+
+
+#
+# object graph built by Reference3Transformer (reference_transformer_3.py)
+# from a references-v3 parse tree (see reference_grammar_3.py). these are
+# plain value objects -- no execution/query context, no filesystem access.
+# ReferenceParser3 (reference_parser_3.py) is the thing that pairs a
+# Reference3 with a CsvPaths context; a ReferenceFinder3 (not yet built)
+# is what actually runs a query against storage.
+#
+
+
+class Star3:
+    """a bare "*" wildcard token. there is no state beyond "this position
+    was a wildcard" so every instance is equal to every other."""
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Star3)
+
+    def __repr__(self) -> str:
+        return "Star3()"
+
+    def __str__(self) -> str:
+        return "*"
+
+
+class Variable3:
+    """an "@name" runtime-bound variable reference."""
+
+    def __init__(self, *, name: str) -> None:
+        if not name:
+            raise ValueError("Variable3 name cannot be None or empty")
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Variable3) and other.name == self._name
+
+    def __repr__(self) -> str:
+        return f"Variable3(name={self._name!r})"
+
+    def __str__(self) -> str:
+        return f"@{self._name}"
+
+
+class Regex3:
+    """a slash-delimited regex literal, e.g. /^(?:Mon|Tue)day$/. pattern
+    is held without the delimiting slashes."""
+
+    def __init__(self, *, pattern: str) -> None:
+        if pattern is None:
+            raise ValueError("Regex3 pattern cannot be None")
+        self._pattern = pattern
+
+    @property
+    def pattern(self) -> str:
+        return self._pattern
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Regex3) and other.pattern == self._pattern
+
+    def __repr__(self) -> str:
+        return f"Regex3(pattern={self._pattern!r})"
+
+    def __str__(self) -> str:
+        return f"/{self._pattern}/"
+
+
+def _arg_to_string(value) -> str:
+    if isinstance(value, str):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return str(value)
+
+
+class FunctionCall3:
+    """a single ":name(arg)" function call. arg is None (no arg), a str,
+    an int, a Star3, a Variable3, a Regex3, or a nested FunctionCall3 --
+    whatever the arg rule's child transformed to. functions are looked up
+    and validated at runtime by a registry, not here -- see
+    "requirements for functions.txt"; this class only holds the parsed
+    shape, it does not know what functions exist."""
+
+    def __init__(self, *, name: str, arg=None) -> None:
+        if not name:
+            raise ValueError("FunctionCall3 name cannot be None or empty")
+        self._name = name
+        self._arg = arg
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def arg(self):
+        return self._arg
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, FunctionCall3)
+            and other.name == self._name
+            and other.arg == self._arg
+        )
+
+    def __repr__(self) -> str:
+        return f"FunctionCall3(name={self._name!r}, arg={self._arg!r})"
+
+    def __str__(self) -> str:
+        arg = "" if self._arg is None else _arg_to_string(self._arg)
+        return f":{self._name}({arg})"
+
+
+class NameOne3:
+    """name_one: a "/"-joined path (literal names, "*", and/or functions
+    each occupying a whole segment), an optional "#name_two" worksheet
+    marker, and a trailing function chain. a path-less, function(s)-only
+    name_one (e.g. ":all()") still has a non-empty path -- see
+    reference_grammar_3.py's module docstring -- its single segment is
+    just a FunctionCall3 rather than a literal or Star3."""
+
+    def __init__(
+        self,
+        *,
+        path: list,
+        name_two: str | None = None,
+        functions: list | None = None,
+    ) -> None:
+        if not path:
+            raise ValueError("NameOne3 path cannot be None or empty")
+        self._path = path
+        self._name_two = name_two
+        self._functions = functions or []
+
+    @property
+    def path(self) -> list:
+        return self._path
+
+    @property
+    def name_two(self) -> str | None:
+        return self._name_two
+
+    @property
+    def functions(self) -> list:
+        return self._functions
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, NameOne3)
+            and other.path == self._path
+            and other.name_two == self._name_two
+            and other.functions == self._functions
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"NameOne3(path={self._path!r}, name_two={self._name_two!r}, "
+            f"functions={self._functions!r})"
+        )
+
+    def __str__(self) -> str:
+        s = "/".join(str(p) for p in self._path)
+        if self._name_two is not None:
+            s = f"{s}#{self._name_two}"
+        for f in self._functions:
+            s = f"{s}{f}"
+        return s
+
+
+class NameThree3:
+    """name_three: an optional single body (a literal name or "*", no
+    path building), plus a trailing function chain. body and functions
+    can't both be absent -- the grammar requires at least one."""
+
+    def __init__(self, *, body=None, functions: list | None = None) -> None:
+        self._body = body
+        self._functions = functions or []
+        if self._body is None and not self._functions:
+            raise ValueError("NameThree3 must have a body, functions, or both")
+
+    @property
+    def body(self):
+        return self._body
+
+    @property
+    def functions(self) -> list:
+        return self._functions
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, NameThree3)
+            and other.body == self._body
+            and other.functions == self._functions
+        )
+
+    def __repr__(self) -> str:
+        return f"NameThree3(body={self._body!r}, functions={self._functions!r})"
+
+    def __str__(self) -> str:
+        s = "" if self._body is None else str(self._body)
+        for f in self._functions:
+            s = f"{s}{f}"
+        return s
+
+
+class Reference3:
+    """the parsed object graph for one references-v3 reference. holds no
+    execution context (see ReferenceParser3 for that) -- just the parsed
+    shape, validated against the datatype-dependent name_three
+    requirement the grammar deliberately leaves out (see
+    reference_grammar_3.py's module docstring)."""
+
+    FILES = "files"
+    CSVPATHS = "csvpaths"
+    RESULTS = "results"
+
+    def __init__(
+        self,
+        *,
+        root_major,
+        datatype: str,
+        name_one: NameOne3,
+        name_three: NameThree3 | None = None,
+    ) -> None:
+        if root_major is None:
+            raise ValueError("Reference3 root_major cannot be None")
+        if datatype not in (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS):
+            raise ValueError(f"Unknown datatype: {datatype}")
+        if name_one is None:
+            raise ValueError("Reference3 name_one cannot be None")
+        self._root_major = root_major
+        self._datatype = datatype
+        self._name_one = name_one
+        self._name_three = name_three
+
+    def check_valid(self) -> None:
+        """structural check deferred out of the grammar (see
+        reference_grammar_3.py's module docstring): name_three is
+        required for files/csvpaths, optional for results. called
+        explicitly by ReferenceParser3 right after the transformer
+        builds this object -- not from __init__, so that a violation
+        raises ReferenceException3 as itself rather than being wrapped
+        in lark's VisitError (which is what happens to any exception
+        raised from inside a Transformer rule method)."""
+        if self._name_three is None and self._datatype in (
+            Reference3.FILES,
+            Reference3.CSVPATHS,
+        ):
+            logger = logging.getLogger(self.__class__.__name__)
+            msg = f"name_three is required for datatype '{self._datatype}'"
+            logger.error(msg)
+            raise ReferenceException3(msg)
+
+    @property
+    def root_major(self):
+        return self._root_major
+
+    @property
+    def datatype(self) -> str:
+        return self._datatype
+
+    @property
+    def name_one(self) -> NameOne3:
+        return self._name_one
+
+    @property
+    def name_three(self) -> NameThree3 | None:
+        return self._name_three
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, Reference3)
+            and other.root_major == self._root_major
+            and other.datatype == self._datatype
+            and other.name_one == self._name_one
+            and other.name_three == self._name_three
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"Reference3(root_major={self._root_major!r}, datatype={self._datatype!r}, "
+            f"name_one={self._name_one!r}, name_three={self._name_three!r})"
+        )
+
+    def __str__(self) -> str:
+        s = f"${self._root_major}.{self._datatype}.{self._name_one}"
+        if self._name_three is not None:
+            s = f"{s}.{self._name_three}"
+        return s

--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -115,6 +115,17 @@ class FunctionCall3:
         arg = "" if self._arg is None else _arg_to_string(self._arg)
         return f":{self._name}({arg})"
 
+    def contains_function_named(self, name: str) -> bool:
+        """true if this function, or any function nested in its
+        argument chain, is named `name`. a purely structural query --
+        no function-registry knowledge involved. see Reference3.
+        resolves_to_data for what this is used for."""
+        if self._name == name:
+            return True
+        if isinstance(self._arg, FunctionCall3):
+            return self._arg.contains_function_named(name)
+        return False
+
 
 class NameOne3:
     """name_one: a "/"-joined path (literal names, "*", and/or functions
@@ -208,6 +219,29 @@ class NameThree3:
         return s
 
 
+#
+# PLACEHOLDER pending the real function registry (see "requirements for
+# functions.txt" -- functions are looked up/validated at runtime by a
+# registry that does not exist yet). Once it does, this trait belongs on
+# Function3 itself as self-description metadata, not here as a bare name
+# list. For now this is the minimum needed to answer the one
+# function-semantics question ReferenceFinder3 needs today: does this
+# reference resolve to a whole file/thing (path+uuid), or a specific
+# extracted value?
+#
+# per "creating references v3.txt": a well-known-file function like
+# :errors() returns the file itself; giving it an argument that is a
+# VALUE-LOCATOR function like :idchain(...) means "pull a specific value
+# out of that file" instead. the signal is deliberately narrow -- it is
+# NOT "any nested function arg" (plenty of ordinary selector functions
+# take one, e.g. :from(:index(0)) is still a file/version selector, not
+# a value extraction) -- it is specifically whether a value-locator
+# function appears anywhere in the terminal function chain's argument
+# tree.
+#
+_VALUE_LOCATOR_FUNCTIONS = ("idchain",)
+
+
 class Reference3:
     """the parsed object graph for one references-v3 reference. holds no
     execution context (see ReferenceParser3 for that) -- just the parsed
@@ -271,6 +305,20 @@ class Reference3:
     @property
     def name_three(self) -> NameThree3 | None:
         return self._name_three
+
+    @property
+    def resolves_to_data(self) -> bool:
+        """does this reference ask for a specific extracted value
+        (True), or the referenced file/thing as-is (False)? see the
+        _VALUE_LOCATOR_FUNCTIONS placeholder comment above -- this is a
+        stand-in for a trait the future function registry will own."""
+        if self._name_three is None:
+            return False
+        return any(
+            f.contains_function_named(name)
+            for f in self._name_three.functions
+            for name in _VALUE_LOCATOR_FUNCTIONS
+        )
 
     def __eq__(self, other) -> bool:
         return (

--- a/csvpath/references/reference_exceptions_3.py
+++ b/csvpath/references/reference_exceptions_3.py
@@ -1,0 +1,6 @@
+class ReferenceException3(Exception):
+    """raised for semantic problems with a parsed references-v3
+    reference that the grammar deliberately doesn't enforce -- e.g. a
+    missing name_three where the reference's datatype requires one. see
+    reference_grammar_3.py's module docstring for why that check is
+    deferred out of the grammar."""

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -1,0 +1,71 @@
+from abc import ABC, abstractmethod
+
+from .reference_parser_3 import ReferenceParser3
+from .reference_results_3 import ReferenceResult3, ReferenceResults3
+
+
+class ReferenceFinder3(ABC):
+    #
+    # one concrete subclass per v3 reference datatype (files, csvpaths,
+    # results) -- each datatype's storage layout differs enough (files:
+    # SHA256-named version files; csvpaths: manifest-array-index
+    # versions; results: run-directory versions) that query() has no
+    # generic implementation and is left abstract. resolve()/
+    # resolve_from() are shared here: "call query(), then maybe extract
+    # a value" is the same shape regardless of datatype.
+    #
+    def __init__(self, *, csvpaths, ref: ReferenceParser3) -> None:
+        if csvpaths is None:
+            raise ValueError("Csvpaths cannot be None")
+        if ref is None:
+            raise ValueError("Reference cannot be None")
+        self._csvpaths = csvpaths
+        self._ref = ref
+
+    @property
+    def ref(self) -> ReferenceParser3:
+        return self._ref
+
+    @property
+    def csvpaths(self):
+        return self._csvpaths
+
+    @abstractmethod
+    def query(self) -> ReferenceResults3:
+        """finds the path+uuid of everything this reference matches.
+        does not fetch any data -- see resolve()/resolve_from()."""
+
+    def resolve(self) -> ReferenceResults3:
+        """query(), then resolve every result found. for a caller that
+        wants to narrow down first, see resolve_from()."""
+        return self.resolve_from(self.query())
+
+    def resolve_from(self, selection: ReferenceResults3 | list) -> ReferenceResults3:
+        """
+        resolves a selection rather than always re-querying and
+        resolving everything -- this is what keeps "cheap search, then
+        selective fetch" real: a caller can query(), narrow down
+        externally (or just eyeball the paths/uuids), and only pay for
+        resolving the part they actually want.
+
+        selection is either a ReferenceResults3 (resolve all of it) or
+        a list[str | UUID] of specific paths/uuids to pull out of a
+        fresh query() first.
+        """
+        if isinstance(selection, ReferenceResults3):
+            results = selection
+        else:
+            results = self.query().select(selection)
+        if not self.ref.parsed.resolves_to_data:
+            return results
+        for result in results.results:
+            result.data = self._extract_data(result)
+        return results
+
+    @abstractmethod
+    def _extract_data(self, result: ReferenceResult3):
+        """pulls the specific value this reference's terminal function
+        chain asks for (see Reference3.resolves_to_data) out of the
+        well-known file at result.path. datatype-specific -- reading
+        errors.json vs vars.json vs a csv payload differs enough there
+        is no generic implementation."""

--- a/csvpath/references/reference_grammar_3.py
+++ b/csvpath/references/reference_grammar_3.py
@@ -37,12 +37,29 @@ from lark import Lark, Tree, UnexpectedInput
 #   is a semantic reading enforced by the transformer, not a grammar-level
 #   concern.
 #
-# - name_one is: an optional "/"-joined path (segments are a literal name,
-#   "*", or a single function occupying the whole segment), optionally
-#   followed by a "#name_two" worksheet marker, optionally followed by a
-#   function chain (functions ANDed together with no separator between
-#   them) -- or, when there's no literal/wildcard path at all, just a bare
-#   function chain (e.g. ":all()", ":before(:yesterday()):index(3)").
+# - name_one is: a "/"-joined path (segments are a literal name, "*", or a
+#   single function occupying the whole segment), optionally followed by a
+#   "#name_two" worksheet marker, optionally followed by a function chain
+#   (functions ANDed together with no separator between them). there is no
+#   separate "bare function chain" alternative: a name_one with no literal/
+#   wildcard path at all (e.g. ":all()", ":before(:yesterday()):index(3)")
+#   is produced by path_prefix reducing to a single function-segment,
+#   followed by the rest of the functions as the trailing func_chain. an
+#   earlier version of this grammar had `name_one: path_prefix (...)
+#   func_chain? | func_chain` as two alternatives, but the second was
+#   redundant with the first (any string it could produce, the first
+#   branch already produces via its single-function-segment case) *and* it
+#   made the grammar genuinely ambiguous -- Earley silently picked one of
+#   two valid parse trees for any bare function chain, and the ambiguity
+#   also blocked LALR (a reduce/reduce collision on COLON, since the
+#   parser couldn't decide with one token of lookahead whether an upcoming
+#   function was "the sole path segment" or "the start of the bare
+#   func_chain" branch). removing the redundant alternative fixed both:
+#   one parse tree per string, and LALR compiles/parses cleanly (confirmed
+#   against the full positive/negative test corpus before switching
+#   QueryParser3 over). name_three has no equivalent issue -- its literal/
+#   wildcard body can't itself be a function, so there's no analogous
+#   ambiguity to remove there.
 #
 # - name_three is: an optional single body (a literal name or "*", no path
 #   building -- "name_three cannot have free-standing forward slashes" per
@@ -75,13 +92,14 @@ REFERENCE_GRAMMAR_3 = r"""
     RESULTS: "results"
 
     //========================================
-    // name_one: optional "/"-joined path, optional #worksheet (files
-    // only, but not restricted here -- see module docstring), optional
-    // trailing function chain. or, with no path at all, a bare function
-    // chain.
+    // name_one: "/"-joined path, optional #worksheet (files only, but not
+    // restricted here -- see module docstring), optional trailing function
+    // chain. a path-less, function(s)-only name_one (e.g. ":all()") is
+    // produced by path_prefix reducing to a single function-segment --
+    // see module docstring for why there is no separate bare-func_chain
+    // alternative here (there was; it was redundant and ambiguous).
 
     name_one: path_prefix ("#" name_two)? func_chain?
-            | func_chain
 
     path_prefix: segment ("/" segment)*
     segment: STAR
@@ -142,8 +160,16 @@ class QueryParser3:
     # being required for files/csvpaths) -- that is deferred to the
     # transformer, not yet built. see module docstring.
     #
+    # lalr, not earley: the grammar is unambiguous (see module docstring's
+    # note on the removed bare-func_chain alternative), so lalr is
+    # available and is what a later type-ahead layer will need -- lalr
+    # parsing is deterministic one state at a time, which is what makes
+    # Lark's parse_interactive()/InteractiveParser.choices() able to
+    # answer "what's legal next" from actual parser state. earley has no
+    # equivalent single-state mechanism.
+    #
     def __init__(self) -> None:
-        self.parser = Lark(REFERENCE_GRAMMAR_3, parser="earley")
+        self.parser = Lark(REFERENCE_GRAMMAR_3, parser="lalr")
 
     def parse(self, query: str) -> Tree:
         if not query:

--- a/csvpath/references/reference_grammar_3.py
+++ b/csvpath/references/reference_grammar_3.py
@@ -24,10 +24,18 @@ from lark import Lark, Tree, UnexpectedInput
 #   avoids the combinatorial rule explosion of the v1/v2 grammar
 #   (reference_grammar.py's files_names alone has ~25 alternatives).
 #
-# - "*" and a bare ":all()" function are interchangeable at a path-segment
-#   position (both mean "everything at this level"). the grammar treats
-#   them as distinct tokens/productions; the equivalence is a semantic
-#   reading, not a grammar-level rewrite.
+# - "*" and a bare ":all()" function are NOT interchangeable, despite both
+#   being legal at a path-segment position. "*" flattens: it pools every
+#   wildcard position into a single search space that a terminal function
+#   (e.g. :last()) reduces to one answer. ":all()" anywhere in the
+#   reference switches the whole reference into grouped mode: every
+#   wildcard position -- root_major included -- becomes a dimension of a
+#   composite group key, and the terminal function distributes across the
+#   resulting cross-product. see "creating references v3.txt"'s EXAMPLE
+#   SCENARIO for a worked-out case. the grammar treats "*" and ":all()" as
+#   distinct tokens/productions either way; this flatten-vs-group behavior
+#   is a semantic reading enforced by the transformer, not a grammar-level
+#   concern.
 #
 # - name_one is: an optional "/"-joined path (segments are a literal name,
 #   "*", or a single function occupying the whole segment), optionally

--- a/csvpath/references/reference_parser_3.py
+++ b/csvpath/references/reference_parser_3.py
@@ -1,0 +1,97 @@
+import logging
+
+from .reference_3 import Reference3
+from .reference_grammar_3 import QueryParser3
+from .reference_transformer_3 import Reference3Transformer
+
+
+#
+# ReferenceParser3 wraps a references-v3 query string: parses it (via
+# QueryParser3 + Reference3Transformer) into a Reference3 object graph
+# (reference_3.py) and holds the CsvPaths context a ReferenceFinder3
+# (not yet built) will need to actually run the query.
+#
+# workflow (see "creating references v3.txt"):
+#   ref = ReferenceParser3(string="$acme.files.*.:last()", csvpaths=paths)
+#   finder = FilesReferenceFinder3(ref)
+#   results = finder.query()
+#   data = finder.resolve()
+#
+class ReferenceParser3:
+    FILES = Reference3.FILES
+    CSVPATHS = Reference3.CSVPATHS
+    RESULTS = Reference3.RESULTS
+
+    _query_parser: QueryParser3 | None = None
+
+    @classmethod
+    def _get_query_parser(cls) -> QueryParser3:
+        # built once and shared -- QueryParser3() compiles the LALR
+        # grammar, no need to redo that on every ReferenceParser3 built.
+        if cls._query_parser is None:
+            cls._query_parser = QueryParser3()
+        return cls._query_parser
+
+    def __init__(self, *, string: str, csvpaths=None) -> None:
+        if not string:
+            raise ValueError("ReferenceParser3 string cannot be None or empty")
+        self._csvpaths = csvpaths
+        self._reference: str = string
+        self._parsed: Reference3 | None = None
+        self.parse(string)
+
+    def __str__(self) -> str:
+        return f"ReferenceParser3(reference={self._reference!r})"
+
+    @property
+    def csvpaths(self):
+        return self._csvpaths
+
+    @csvpaths.setter
+    def csvpaths(self, csvpaths) -> None:
+        self._csvpaths = csvpaths
+
+    @property
+    def reference(self) -> str:
+        return self._reference
+
+    @property
+    def parsed(self) -> Reference3:
+        return self._parsed
+
+    @property
+    def ref_string(self) -> str:
+        return str(self._parsed)
+
+    @property
+    def root_major(self):
+        return self._parsed.root_major
+
+    @property
+    def datatype(self) -> str:
+        return self._parsed.datatype
+
+    @property
+    def name_one(self):
+        return self._parsed.name_one
+
+    @property
+    def name_two(self) -> str | None:
+        return self._parsed.name_one.name_two
+
+    @property
+    def name_three(self):
+        return self._parsed.name_three
+
+    def parse(self, string: str) -> None:
+        if not string:
+            raise ValueError("ReferenceParser3 string cannot be None or empty")
+        logger = logging.getLogger(self.__class__.__name__)
+        try:
+            tree = self._get_query_parser().parse(string)
+            self._parsed = Reference3Transformer().transform(tree)
+            self._parsed.check_valid()
+        except Exception as e:
+            logger.error("Failed to parse reference '%s': %s", string, e)
+            raise
+        self._reference = string

--- a/csvpath/references/reference_parser_3.py
+++ b/csvpath/references/reference_parser_3.py
@@ -32,9 +32,11 @@ class ReferenceParser3:
             cls._query_parser = QueryParser3()
         return cls._query_parser
 
-    def __init__(self, *, string: str, csvpaths=None) -> None:
+    def __init__(self, *, string: str, csvpaths) -> None:
         if not string:
             raise ValueError("ReferenceParser3 string cannot be None or empty")
+        if csvpaths is None:
+            raise ValueError("ReferenceParser3 csvpaths cannot be None")
         self._csvpaths = csvpaths
         self._reference: str = string
         self._parsed: Reference3 | None = None

--- a/csvpath/references/reference_results_3.py
+++ b/csvpath/references/reference_results_3.py
@@ -1,0 +1,115 @@
+from typing import Any
+from uuid import UUID
+
+
+#
+# ReferenceResult3/ReferenceResults3 are pure value containers -- a
+# path+uuid (+ optionally data, once resolved) and a list of the same.
+# deliberately not modeled on v2's ReferenceResults, which holds ref and
+# csvpaths and does its own filesystem/manifest lookups (.manifest,
+# .runs_manifest_path) -- that mixes "holds the output" with "knows how
+# to reach storage." here, only ReferenceFinder3 (and its concrete
+# per-datatype subclasses) ever talks to storage; these two classes just
+# hold what was found.
+#
+
+
+class ReferenceResult3:
+    def __init__(self, *, path: str, uuid: str, data: Any = None) -> None:
+        if not path:
+            raise ValueError("ReferenceResult3 path cannot be None or empty")
+        if not uuid:
+            raise ValueError("ReferenceResult3 uuid cannot be None or empty")
+        self._path = path
+        self._uuid = uuid
+        self._data = data
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    @property
+    def uuid(self) -> str:
+        return self._uuid
+
+    @property
+    def data(self) -> Any:
+        return self._data
+
+    @data.setter
+    def data(self, data: Any) -> None:
+        # the only mutable field -- query() finds path+uuid, resolve()
+        # fills data in afterward on the same instances.
+        self._data = data
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, ReferenceResult3)
+            and other.path == self._path
+            and other.uuid == self._uuid
+            and other.data == self._data
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"ReferenceResult3(path={self._path!r}, uuid={self._uuid!r}, "
+            f"data={self._data!r})"
+        )
+
+
+class ReferenceResults3:
+    def __init__(self, *, results: list[ReferenceResult3] | None = None) -> None:
+        self._results = results or []
+
+    @property
+    def results(self) -> list[ReferenceResult3]:
+        return self._results
+
+    @property
+    def files(self) -> list[str]:
+        return [r.path for r in self._results]
+
+    @property
+    def uuids(self) -> list[str]:
+        return [r.uuid for r in self._results]
+
+    def file_for_uuid(self, uuid: str | UUID) -> str | None:
+        uuid = str(uuid)
+        for r in self._results:
+            if r.uuid == uuid:
+                return r.path
+        return None
+
+    def uuid_for_file(self, file: str) -> str | None:
+        for r in self._results:
+            if r.path == file:
+                return r.uuid
+        return None
+
+    def data_for_uuid(self, uuid: str | UUID) -> Any:
+        uuid = str(uuid)
+        for r in self._results:
+            if r.uuid == uuid:
+                return r.data
+        return None
+
+    def select(self, identifiers: list) -> "ReferenceResults3":
+        """a new ReferenceResults3 holding only the entries whose path
+        or uuid matches one of `identifiers` -- how resolve_from() turns
+        a caller-narrowed list[str | UUID] back into a subset to
+        resolve, without re-touching storage."""
+        wanted = {str(i) for i in identifiers}
+        selected = [r for r in self._results if r.path in wanted or r.uuid in wanted]
+        return ReferenceResults3(results=selected)
+
+    def __len__(self) -> int:
+        return len(self._results)
+
+    def __iter__(self):
+        return iter(self._results)
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, ReferenceResults3) and other.results == self._results
+
+    def __repr__(self) -> str:
+        return f"ReferenceResults3(results={self._results!r})"

--- a/csvpath/references/reference_results_3.py
+++ b/csvpath/references/reference_results_3.py
@@ -102,11 +102,23 @@ class ReferenceResults3:
         selected = [r for r in self._results if r.path in wanted or r.uuid in wanted]
         return ReferenceResults3(results=selected)
 
+    def remove(self, result: ReferenceResult3) -> None:
+        """drops one result in place -- for the "iterate, decide, trim"
+        workflow: walk the results, remove the ones you do not want,
+        then hand what is left straight to a finder's resolve_from().
+        raises ValueError if result is not present (same as
+        list.remove()). safe to call from inside a `for r in results:`
+        loop -- see __iter__."""
+        self._results.remove(result)
+
     def __len__(self) -> int:
         return len(self._results)
 
     def __iter__(self):
-        return iter(self._results)
+        # a snapshot, not the live list: iterating and calling remove()
+        # on the same result within one loop must not skip entries the
+        # way iterating-while-mutating a list normally would.
+        return iter(list(self._results))
 
     def __eq__(self, other) -> bool:
         return isinstance(other, ReferenceResults3) and other.results == self._results

--- a/csvpath/references/reference_transformer_3.py
+++ b/csvpath/references/reference_transformer_3.py
@@ -1,0 +1,149 @@
+import re
+
+from lark import Transformer, v_args
+
+from .reference_3 import (
+    FunctionCall3,
+    NameOne3,
+    NameThree3,
+    Reference3,
+    Regex3,
+    Star3,
+    Variable3,
+)
+
+#
+# turns a references-v3 Lark parse tree (see reference_grammar_3.py) into
+# a Reference3 object graph. one method per grammar rule, mirroring the
+# established convention in csvpath/matching/lark_transformer.py -- in
+# deliberate contrast to v1/v2's reference_transformer.py, which has one
+# method per grammar-rule *combination* and mutates a shared flat object.
+# see reference_grammar_3.py's module docstring for why v3's grammar
+# doesn't need that.
+#
+# name_one and name_three each have two independently-optional trailing
+# children (name_two/func_chain, and body/func_chain, respectively).
+# with v_args(inline=True), an absent optional child just shortens the
+# positional children list rather than leaving a None placeholder, so a
+# fixed-position signature would silently misassign children whenever
+# one of the two is missing but not the other. those two methods take
+# *children and dispatch by type instead of by position; every other
+# rule has at most one trailing optional child, which plain positional
+# defaults handle safely (fewer children always means the rightmost
+# param(s) are missing, never a reshuffle).
+#
+
+
+class _PathPrefixResult:
+    """transform-internal marker distinguishing path_prefix's segment
+    list from func_chain's function-call list. both are plain lists of
+    values, so without a distinct wrapper type, name_one's *children
+    dispatch couldn't tell them apart positionally when one of the two
+    is absent."""
+
+    def __init__(self, segments: list) -> None:
+        self.segments = segments
+
+
+class _FuncChainResult:
+    """see _PathPrefixResult -- the func_chain counterpart."""
+
+    def __init__(self, calls: list) -> None:
+        self.calls = calls
+
+
+@v_args(inline=True)
+class Reference3Transformer(Transformer):
+    def reference(self, root_major, datatype, name_one, name_three=None):
+        return Reference3(
+            root_major=root_major,
+            datatype=datatype,
+            name_one=name_one,
+            name_three=name_three,
+        )
+
+    def root_major(self, value):
+        return value
+
+    def datatype(self, token) -> str:
+        return str(token)
+
+    def name_one(self, *children) -> NameOne3:
+        path_prefix = None
+        name_two = None
+        func_chain = None
+        for child in children:
+            if isinstance(child, _PathPrefixResult):
+                path_prefix = child
+            elif isinstance(child, _FuncChainResult):
+                func_chain = child
+            else:
+                name_two = child
+        return NameOne3(
+            path=path_prefix.segments,
+            name_two=name_two,
+            functions=func_chain.calls if func_chain else [],
+        )
+
+    def path_prefix(self, *segments) -> _PathPrefixResult:
+        return _PathPrefixResult(list(segments))
+
+    def segment(self, value):
+        return value
+
+    def name_two(self, token) -> str:
+        return str(token)
+
+    def name_three(self, *children) -> NameThree3:
+        body = None
+        func_chain = None
+        for child in children:
+            if isinstance(child, _FuncChainResult):
+                func_chain = child
+            else:
+                body = child
+        return NameThree3(
+            body=body,
+            functions=func_chain.calls if func_chain else [],
+        )
+
+    def func_chain(self, *functions) -> _FuncChainResult:
+        return _FuncChainResult(list(functions))
+
+    def function(self, fname, arg=None) -> FunctionCall3:
+        return FunctionCall3(name=str(fname), arg=arg)
+
+    def arg(self, value):
+        return value
+
+    # ----------------------------
+    # terminals
+    # ----------------------------
+
+    def STAR(self, token) -> Star3:  # noqa: N802
+        return Star3()
+
+    def AT_VAR(self, token) -> Variable3:  # noqa: N802
+        return Variable3(name=str(token)[1:])
+
+    def PATH_SEGMENT(self, token) -> str:  # noqa: N802
+        return str(token)
+
+    def IDENTIFIER(self, token) -> str:  # noqa: N802
+        return str(token)
+
+    def STRING(self, token) -> str:  # noqa: N802
+        # grammar's STRING allows "\." to escape any character (not just
+        # quote/backslash) -- undo that generically rather than special
+        # casing \" and \\.
+        raw = str(token)[1:-1]
+        return re.sub(r"\\(.)", r"\1", raw)
+
+    def SIGNED_INT(self, token) -> int:  # noqa: N802
+        return int(token)
+
+    def REGEX(self, token) -> Regex3:  # noqa: N802
+        return Regex3(pattern=str(token)[1:-1])
+
+    def FNAME(self, token) -> str:  # noqa: N802
+        return str(token)

--- a/tests/references/test_reference_3.py
+++ b/tests/references/test_reference_3.py
@@ -1,0 +1,277 @@
+import pytest
+
+from csvpath.references.reference_3 import (
+    FunctionCall3,
+    NameOne3,
+    NameThree3,
+    Reference3,
+    Regex3,
+    Star3,
+    Variable3,
+)
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+#
+# low-level unit tests for the references-v3 object graph itself --
+# construction, equality, and str rendering -- independent of the Lark
+# grammar/transformer. these are the building blocks the transformer
+# tests and ReferenceParser3 tests build on.
+#
+
+
+class TestStar3:
+    def test_all_instances_equal(self):
+        assert Star3() == Star3()
+
+    def test_not_equal_to_other_types(self):
+        assert Star3() != "*"
+        assert Star3() != None  # noqa: E711
+
+    def test_str(self):
+        assert str(Star3()) == "*"
+
+
+class TestVariable3:
+    def test_holds_name(self):
+        assert Variable3(name="customer").name == "customer"
+
+    @pytest.mark.parametrize("bad_name", [None, ""])
+    def test_rejects_none_or_empty_name(self, bad_name):
+        with pytest.raises(ValueError):
+            Variable3(name=bad_name)
+
+    def test_equality(self):
+        assert Variable3(name="x") == Variable3(name="x")
+        assert Variable3(name="x") != Variable3(name="y")
+
+    def test_str(self):
+        assert str(Variable3(name="customer")) == "@customer"
+
+
+class TestRegex3:
+    def test_holds_pattern(self):
+        assert Regex3(pattern="^abc$").pattern == "^abc$"
+
+    def test_rejects_none_pattern(self):
+        with pytest.raises(ValueError):
+            Regex3(pattern=None)
+
+    def test_allows_empty_pattern(self):
+        # an empty regex, "//", is structurally odd but not this class's
+        # job to reject -- only None is a bounds violation here.
+        assert Regex3(pattern="").pattern == ""
+
+    def test_equality(self):
+        assert Regex3(pattern="a.*b") == Regex3(pattern="a.*b")
+        assert Regex3(pattern="a.*b") != Regex3(pattern="c.*d")
+
+    def test_str_adds_delimiters(self):
+        assert str(Regex3(pattern="^abc$")) == "/^abc$/"
+
+
+class TestFunctionCall3:
+    def test_rejects_none_or_empty_name(self):
+        with pytest.raises(ValueError):
+            FunctionCall3(name="")
+        with pytest.raises(ValueError):
+            FunctionCall3(name=None)
+
+    def test_no_arg(self):
+        f = FunctionCall3(name="all")
+        assert f.name == "all"
+        assert f.arg is None
+        assert str(f) == ":all()"
+
+    def test_string_arg_renders_quoted(self):
+        f = FunctionCall3(name="name", arg="Acme")
+        assert str(f) == ':name("Acme")'
+
+    def test_string_arg_with_quote_and_backslash_escapes_on_render(self):
+        f = FunctionCall3(name="name", arg='say "hi" \\ bye')
+        assert str(f) == ':name("say \\"hi\\" \\\\ bye")'
+
+    def test_int_arg_renders_bare(self):
+        f = FunctionCall3(name="index", arg=7)
+        assert str(f) == ":index(7)"
+
+    def test_star_arg(self):
+        f = FunctionCall3(name="name", arg=Star3())
+        assert str(f) == ":name(*)"
+
+    def test_variable_arg(self):
+        f = FunctionCall3(name="index", arg=Variable3(name="which"))
+        assert str(f) == ":index(@which)"
+
+    def test_regex_arg(self):
+        f = FunctionCall3(name="name", arg=Regex3(pattern="^abc$"))
+        assert str(f) == ":name(/^abc$/)"
+
+    def test_nested_function_arg(self):
+        inner = FunctionCall3(name="index", arg=0)
+        f = FunctionCall3(name="from", arg=inner)
+        assert str(f) == ":from(:index(0))"
+
+    def test_equality(self):
+        assert FunctionCall3(name="last") == FunctionCall3(name="last")
+        assert FunctionCall3(name="last") != FunctionCall3(name="first")
+        assert FunctionCall3(name="index", arg=7) != FunctionCall3(name="index", arg=8)
+
+
+class TestNameOne3:
+    def test_rejects_empty_path(self):
+        with pytest.raises(ValueError):
+            NameOne3(path=[])
+        with pytest.raises(ValueError):
+            NameOne3(path=None)
+
+    def test_literal_path_only(self):
+        n = NameOne3(path=["Q2", "test-data"])
+        assert str(n) == "Q2/test-data"
+
+    def test_path_with_star(self):
+        n = NameOne3(path=[Star3()])
+        assert str(n) == "*"
+
+    def test_path_with_function_segment(self):
+        n = NameOne3(path=[FunctionCall3(name="all")])
+        assert str(n) == ":all()"
+
+    def test_with_name_two(self):
+        n = NameOne3(path=[Star3()], name_two="my_worksheet")
+        assert str(n) == "*#my_worksheet"
+
+    def test_with_trailing_functions(self):
+        n = NameOne3(
+            path=["Q2"],
+            functions=[FunctionCall3(name="last"), FunctionCall3(name="first")],
+        )
+        assert str(n) == "Q2:last():first()"
+
+    def test_full_shape(self):
+        n = NameOne3(
+            path=[Star3()],
+            name_two="ws",
+            functions=[FunctionCall3(name="type", arg="xlsx")]
+        )
+        assert str(n) == '*#ws:type("xlsx")'
+
+    def test_equality(self):
+        assert NameOne3(path=["a"]) == NameOne3(path=["a"])
+        assert NameOne3(path=["a"]) != NameOne3(path=["b"])
+        assert NameOne3(path=["a"], name_two="w") != NameOne3(path=["a"])
+
+
+class TestNameThree3:
+    def test_rejects_empty_body_and_functions(self):
+        with pytest.raises(ValueError):
+            NameThree3()
+
+    def test_body_only(self):
+        n = NameThree3(body="invoices")
+        assert str(n) == "invoices"
+
+    def test_body_star(self):
+        n = NameThree3(body=Star3())
+        assert str(n) == "*"
+
+    def test_functions_only(self):
+        n = NameThree3(functions=[FunctionCall3(name="all")])
+        assert str(n) == ":all()"
+
+    def test_body_and_functions(self):
+        n = NameThree3(body="invoices", functions=[FunctionCall3(name="data")])
+        assert str(n) == "invoices:data()"
+
+    def test_equality(self):
+        assert NameThree3(body="a") == NameThree3(body="a")
+        assert NameThree3(body="a") != NameThree3(body="b")
+
+
+class TestReference3:
+    def _name_one(self, *path):
+        return NameOne3(path=list(path))
+
+    def test_rejects_none_root_major(self):
+        with pytest.raises(ValueError):
+            Reference3(
+                root_major=None,
+                datatype=Reference3.FILES,
+                name_one=self._name_one("a"),
+                name_three=NameThree3(body="v1"),
+            )
+
+    def test_rejects_unknown_datatype(self):
+        with pytest.raises(ValueError):
+            Reference3(
+                root_major="acme",
+                datatype="bogus",
+                name_one=self._name_one("a"),
+            )
+
+    def test_rejects_none_name_one(self):
+        with pytest.raises(ValueError):
+            Reference3(root_major="acme", datatype=Reference3.FILES, name_one=None)
+
+    @pytest.mark.parametrize("datatype", [Reference3.FILES, Reference3.CSVPATHS])
+    def test_check_valid_requires_name_three_for_files_and_csvpaths(self, datatype):
+        r = Reference3(
+            root_major="acme", datatype=datatype, name_one=self._name_one("a")
+        )
+        with pytest.raises(ReferenceException3):
+            r.check_valid()
+
+    def test_check_valid_allows_missing_name_three_for_results(self):
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.RESULTS,
+            name_one=self._name_one("a"),
+        )
+        r.check_valid()  # should not raise
+
+    def test_check_valid_passes_when_name_three_present(self):
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.FILES,
+            name_one=self._name_one("a"),
+            name_three=NameThree3(body="v1"),
+        )
+        r.check_valid()  # should not raise
+
+    def test_str_without_name_three(self):
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.RESULTS,
+            name_one=self._name_one("a"),
+        )
+        assert str(r) == "$acme.results.a"
+
+    def test_str_with_name_three(self):
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.FILES,
+            name_one=self._name_one("a"),
+            name_three=NameThree3(body="v1"),
+        )
+        assert str(r) == "$acme.files.a.v1"
+
+    def test_str_with_star_root_major(self):
+        r = Reference3(
+            root_major=Star3(),
+            datatype=Reference3.RESULTS,
+            name_one=self._name_one("a"),
+        )
+        assert str(r) == "$*.results.a"
+
+    def test_equality(self):
+        a = Reference3(
+            root_major="acme", datatype=Reference3.RESULTS, name_one=self._name_one("a")
+        )
+        b = Reference3(
+            root_major="acme", datatype=Reference3.RESULTS, name_one=self._name_one("a")
+        )
+        c = Reference3(
+            root_major="acme", datatype=Reference3.RESULTS, name_one=self._name_one("b")
+        )
+        assert a == b
+        assert a != c

--- a/tests/references/test_reference_3.py
+++ b/tests/references/test_reference_3.py
@@ -117,6 +117,21 @@ class TestFunctionCall3:
         assert FunctionCall3(name="last") != FunctionCall3(name="first")
         assert FunctionCall3(name="index", arg=7) != FunctionCall3(name="index", arg=8)
 
+    def test_contains_function_named_matches_self(self):
+        assert FunctionCall3(name="idchain", arg="x").contains_function_named("idchain")
+
+    def test_contains_function_named_matches_nested(self):
+        f = FunctionCall3(name="errors", arg=FunctionCall3(name="idchain", arg="x"))
+        assert f.contains_function_named("idchain")
+        assert not f.contains_function_named("data")
+
+    def test_contains_function_named_false_when_arg_not_a_function(self):
+        f = FunctionCall3(name="from", arg=FunctionCall3(name="index", arg=0))
+        assert not f.contains_function_named("idchain")
+
+    def test_contains_function_named_false_with_no_arg(self):
+        assert not FunctionCall3(name="all").contains_function_named("idchain")
+
 
 class TestNameOne3:
     def test_rejects_empty_path(self):
@@ -275,3 +290,55 @@ class TestReference3:
         )
         assert a == b
         assert a != c
+
+
+class TestResolvesToData:
+    def _name_one(self, *path):
+        return NameOne3(path=list(path))
+
+    def test_false_when_no_name_three(self):
+        r = Reference3(
+            root_major="acme", datatype=Reference3.RESULTS, name_one=self._name_one("a")
+        )
+        assert r.resolves_to_data is False
+
+    def test_false_for_plain_well_known_file_function(self):
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.RESULTS,
+            name_one=self._name_one("a"),
+            name_three=NameThree3(functions=[FunctionCall3(name="errors")]),
+        )
+        assert r.resolves_to_data is False
+
+    def test_true_when_value_locator_nested_in_terminal_function(self):
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.RESULTS,
+            name_one=self._name_one("a"),
+            name_three=NameThree3(
+                functions=[
+                    FunctionCall3(
+                        name="errors",
+                        arg=FunctionCall3(name="idchain", arg="add[0]string[2]"),
+                    )
+                ]
+            ),
+        )
+        assert r.resolves_to_data is True
+
+    def test_false_for_ordinary_selector_function_with_nested_arg(self):
+        # :from(:index(0)) is still a version/range selector, not a
+        # value extraction -- a nested function arg alone must not
+        # trigger resolves_to_data.
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.FILES,
+            name_one=self._name_one("a"),
+            name_three=NameThree3(
+                functions=[
+                    FunctionCall3(name="from", arg=FunctionCall3(name="index", arg=0))
+                ]
+            ),
+        )
+        assert r.resolves_to_data is False

--- a/tests/references/test_reference_finder_3.py
+++ b/tests/references/test_reference_finder_3.py
@@ -1,0 +1,100 @@
+import pytest
+
+from csvpath.references.reference_finder_3 import ReferenceFinder3
+from csvpath.references.reference_parser_3 import ReferenceParser3
+from csvpath.references.reference_results_3 import ReferenceResult3, ReferenceResults3
+
+CSVPATHS = object()
+
+
+class _DummyFinder(ReferenceFinder3):
+    """minimal concrete finder for exercising the shared resolve()/
+    resolve_from() logic on the ABC -- query() and _extract_data() are
+    the only datatype-specific hooks, so a fixed fake result set and a
+    deterministic extraction are enough."""
+
+    def __init__(self, *, csvpaths, ref) -> None:
+        super().__init__(csvpaths=csvpaths, ref=ref)
+        self.query_call_count = 0
+
+    def query(self) -> ReferenceResults3:
+        self.query_call_count += 1
+        return ReferenceResults3(
+            results=[
+                ReferenceResult3(path="p1", uuid="u1"),
+                ReferenceResult3(path="p2", uuid="u2"),
+            ]
+        )
+
+    def _extract_data(self, result: ReferenceResult3):
+        return f"data-for-{result.path}"
+
+
+def _ref(reference: str) -> ReferenceParser3:
+    return ReferenceParser3(string=reference, csvpaths=CSVPATHS)
+
+
+class TestConstruction:
+    def test_rejects_none_csvpaths(self):
+        with pytest.raises(ValueError):
+            _DummyFinder(csvpaths=None, ref=_ref("$acme.results.a"))
+
+    def test_rejects_none_ref(self):
+        with pytest.raises(ValueError):
+            _DummyFinder(csvpaths=CSVPATHS, ref=None)
+
+    def test_cannot_instantiate_the_abc_directly(self):
+        with pytest.raises(TypeError):
+            ReferenceFinder3(csvpaths=CSVPATHS, ref=_ref("$acme.results.a"))
+
+    def test_holds_ref_and_csvpaths(self):
+        ref = _ref("$acme.results.a")
+        f = _DummyFinder(csvpaths=CSVPATHS, ref=ref)
+        assert f.ref is ref
+        assert f.csvpaths is CSVPATHS
+
+
+class TestResolveWithoutDataExtraction:
+    # "$acme.results.a.:errors()" -- a plain well-known-file function,
+    # no value-locator nested in it, so resolves_to_data is False.
+    def test_resolve_leaves_data_none(self):
+        f = _DummyFinder(csvpaths=CSVPATHS, ref=_ref("$acme.results.a.:errors()"))
+        results = f.resolve()
+        assert results.files == ["p1", "p2"]
+        assert all(r.data is None for r in results.results)
+
+    def test_resolve_from_list_narrows_without_extracting(self):
+        f = _DummyFinder(csvpaths=CSVPATHS, ref=_ref("$acme.results.a.:errors()"))
+        results = f.resolve_from(["p1"])
+        assert results.files == ["p1"]
+        assert results.results[0].data is None
+        assert f.query_call_count == 1
+
+
+class TestResolveWithDataExtraction:
+    # ":errors(:idchain(...))" -- a value-locator nested in the
+    # well-known-file function's arg, so resolves_to_data is True.
+    REF = '$acme.results.a.:errors(:idchain("add[0]string[2]"))'
+
+    def test_resolve_extracts_data_for_every_result(self):
+        f = _DummyFinder(csvpaths=CSVPATHS, ref=_ref(self.REF))
+        results = f.resolve()
+        assert results.data_for_uuid("u1") == "data-for-p1"
+        assert results.data_for_uuid("u2") == "data-for-p2"
+
+    def test_resolve_from_narrows_then_only_extracts_the_selection(self):
+        f = _DummyFinder(csvpaths=CSVPATHS, ref=_ref(self.REF))
+        results = f.resolve_from(["u2"])
+        assert results.files == ["p2"]
+        assert results.results[0].data == "data-for-p2"
+        assert f.query_call_count == 1
+
+    def test_resolve_from_a_results3_does_not_requery(self):
+        f = _DummyFinder(csvpaths=CSVPATHS, ref=_ref(self.REF))
+        preselected = ReferenceResults3(
+            results=[ReferenceResult3(path="only-this-one", uuid="uX")]
+        )
+        results = f.resolve_from(preselected)
+        assert results.files == ["only-this-one"]
+        assert results.results[0].data == "data-for-only-this-one"
+        assert f.query_call_count == 0

--- a/tests/references/test_reference_parser_3.py
+++ b/tests/references/test_reference_parser_3.py
@@ -1,0 +1,139 @@
+import pytest
+
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+from csvpath.references.reference_parser_3 import ReferenceParser3
+
+
+#
+# every positive example from "creating references v3.txt" / the grammar
+# test corpus (test_references_3_grammar.py), run through the full
+# string -> Reference3 -> ref_string round trip. these are the same
+# strings the grammar already validated at the syntax level; here we
+# confirm the transformer builds something and that rendering it back
+# out reproduces the original exactly.
+#
+SPEC_EXAMPLES = [
+    '$*.files.Q2/test-data.:last()',
+    '$acme.files.Q2/:name(*).:last()',
+    '$acme.files.Q2/:name(@customer).:last()',
+    '$acme.files.Q2/test-data.:last()',
+    '$acme.files.:quarter()/:name("live data").:last()',
+    '$acme.files.:date("2026-01-20").:to(:index(5))',
+    '$acme.files.*.:last()',
+    '$acme.files.:all().:first()',
+    '$acme.files.*#my_worksheet.:type("xlsx")',
+    '$acme.files.*#my_worksheet.:at(-1)',
+    '$acme.files.*.:uuid("a4ff-82b9-...")',
+    '$acme.files.*.:index(7)',
+    '$acme.files.*.:from(:index(0)):to(@index)',
+    '$acme.files.*.:last():before(:today())',
+    '$*.files.*/more/pathnames.:last()',
+    '$acme.csvpaths.:before(:yesterday()):after(:date("2024-08-01")):index(3).company-names',
+    '$acme.csvpaths.:last().company_names',
+    '$*.csvpaths.*.:uuid("a901-33b9-...")',
+    '$acme.csvpaths.:uuid("a901-33b9-...").:index(3)',
+    '$acme.csvpaths.:uuid("a901-33b9-...").:index(@which)',
+    '$acme.csvpaths.:last().:all()',
+    '$acme.results.:all()',
+    '$acme.results.:last()',
+    '$acme.results.customers/2025:first()',
+    '$acme.results.customers/2025:first().invoices',
+    '$acme.results.*/2025:first().invoices',
+    '$acme.results.*/*/2025:first().invoices',
+    '$acme.results.:choice("acme|star|general")/2025:first().invoices',
+    '$acme.results.:names(*)/2025:first().invoices:type("csv")',
+    '$acme.results.:names(*)/2025:first().invoices:name("report.txt")',
+    '$acme.results.customers/2025:first().invoices:data()',
+    '$acme.results.customers/2025:first().invoices:vars()',
+    '$acme.results.customers/2025:first().invoices:meta()',
+    '$acme.results.customers/2025:first().:all():data()',
+    '$acme.results.customers/2025:first().:from(2):unmatched()',
+    '$acme.results.customers/:year():first().:from(2):unmatched()',
+    '$acme.results.customers/:date("2025-01-01"):first().:from(2):unmatched()',
+    '$acme.results.customers/:from(:date("2025-01-01")):first().:from(2):unmatched()',
+    '$acme.results.customers/:from(:index(-1)).:from(2):unmatched()',
+    '$acme.results.customers/:from(:index(-1)).*:type("parquet")',
+    '$acme.files.:name("100%%done").:data()',
+    '$acme.files.:name("100%20done").:data()',
+    '$acme.files.:name("say \\"hi\\"").:data()',
+    '$acme.results.:name(/^[^M].*/)/2025:first().invoices',
+    '$acme.results.:name(/^(?:Mon|Tue)day$/)/2025:first().invoices',
+    '$acme.results.:name(/^(Mon|Tue)day$/)/2025:first().invoices',
+    '$acme.results.:name(/contains"quote/)/2025:first().invoices',
+]
+
+
+@pytest.mark.parametrize("reference", SPEC_EXAMPLES)
+def test_spec_examples_round_trip(reference):
+    r = ReferenceParser3(string=reference)
+    assert r.ref_string == reference
+
+
+class TestConstruction:
+    @pytest.mark.parametrize("bad_string", [None, ""])
+    def test_rejects_none_or_empty_string(self, bad_string):
+        with pytest.raises(ValueError):
+            ReferenceParser3(string=bad_string)
+
+    def test_holds_original_reference_string(self):
+        r = ReferenceParser3(string="$acme.results.a")
+        assert r.reference == "$acme.results.a"
+
+    def test_csvpaths_defaults_to_none(self):
+        r = ReferenceParser3(string="$acme.results.a")
+        assert r.csvpaths is None
+
+    def test_csvpaths_can_be_passed_in(self):
+        sentinel = object()
+        r = ReferenceParser3(string="$acme.results.a", csvpaths=sentinel)
+        assert r.csvpaths is sentinel
+
+    def test_csvpaths_settable_after_construction(self):
+        r = ReferenceParser3(string="$acme.results.a")
+        sentinel = object()
+        r.csvpaths = sentinel
+        assert r.csvpaths is sentinel
+
+
+class TestProperties:
+    def test_top_level_properties(self):
+        r = ReferenceParser3(string="$acme.files.Q2/test-data.:last()")
+        assert r.root_major == "acme"
+        assert r.datatype == "files"
+        assert r.name_one.path == ["Q2", "test-data"]
+        assert r.name_three.functions[0].name == "last"
+
+    def test_name_two_passthrough_from_name_one(self):
+        r = ReferenceParser3(string='$acme.files.*#my_worksheet.:type("xlsx")')
+        assert r.name_two == "my_worksheet"
+
+    def test_name_two_none_when_absent(self):
+        r = ReferenceParser3(string="$acme.results.a")
+        assert r.name_two is None
+
+    def test_parsed_is_a_reference3(self):
+        r = ReferenceParser3(string="$acme.results.a")
+        assert isinstance(r.parsed, Reference3)
+
+
+class TestNameThreeRequiredness:
+    @pytest.mark.parametrize("datatype", ["files", "csvpaths"])
+    def test_missing_name_three_raises_for_files_and_csvpaths(self, datatype):
+        with pytest.raises(ReferenceException3):
+            ReferenceParser3(string=f"$acme.{datatype}.a")
+
+    def test_missing_name_three_is_fine_for_results(self):
+        r = ReferenceParser3(string="$acme.results.a")
+        assert r.name_three is None
+
+    def test_reference_exception_is_not_wrapped_by_lark(self):
+        # regression: check_valid() runs outside Transformer.transform(),
+        # specifically so a violation surfaces as ReferenceException3
+        # itself, not wrapped in lark.exceptions.VisitError.
+        try:
+            ReferenceParser3(string="$acme.files.a")
+        except ReferenceException3:
+            pass
+        else:
+            pytest.fail("expected ReferenceException3")

--- a/tests/references/test_reference_parser_3.py
+++ b/tests/references/test_reference_parser_3.py
@@ -4,6 +4,12 @@ from csvpath.references.reference_3 import Reference3
 from csvpath.references.reference_exceptions_3 import ReferenceException3
 from csvpath.references.reference_parser_3 import ReferenceParser3
 
+#
+# csvpaths is required (no default) on ReferenceParser3 -- these tests
+# do not exercise any csvpaths behavior, so a plain sentinel stands in
+# for a real CsvPaths context throughout.
+#
+CSVPATHS = object()
 
 #
 # every positive example from "creating references v3.txt" / the grammar
@@ -66,7 +72,7 @@ SPEC_EXAMPLES = [
 
 @pytest.mark.parametrize("reference", SPEC_EXAMPLES)
 def test_spec_examples_round_trip(reference):
-    r = ReferenceParser3(string=reference)
+    r = ReferenceParser3(string=reference, csvpaths=CSVPATHS)
     assert r.ref_string == reference
 
 
@@ -74,23 +80,23 @@ class TestConstruction:
     @pytest.mark.parametrize("bad_string", [None, ""])
     def test_rejects_none_or_empty_string(self, bad_string):
         with pytest.raises(ValueError):
-            ReferenceParser3(string=bad_string)
+            ReferenceParser3(string=bad_string, csvpaths=CSVPATHS)
+
+    def test_rejects_none_csvpaths(self):
+        with pytest.raises(ValueError):
+            ReferenceParser3(string="$acme.results.a", csvpaths=None)
 
     def test_holds_original_reference_string(self):
-        r = ReferenceParser3(string="$acme.results.a")
+        r = ReferenceParser3(string="$acme.results.a", csvpaths=CSVPATHS)
         assert r.reference == "$acme.results.a"
 
-    def test_csvpaths_defaults_to_none(self):
-        r = ReferenceParser3(string="$acme.results.a")
-        assert r.csvpaths is None
-
-    def test_csvpaths_can_be_passed_in(self):
+    def test_csvpaths_is_held(self):
         sentinel = object()
         r = ReferenceParser3(string="$acme.results.a", csvpaths=sentinel)
         assert r.csvpaths is sentinel
 
     def test_csvpaths_settable_after_construction(self):
-        r = ReferenceParser3(string="$acme.results.a")
+        r = ReferenceParser3(string="$acme.results.a", csvpaths=CSVPATHS)
         sentinel = object()
         r.csvpaths = sentinel
         assert r.csvpaths is sentinel
@@ -98,22 +104,26 @@ class TestConstruction:
 
 class TestProperties:
     def test_top_level_properties(self):
-        r = ReferenceParser3(string="$acme.files.Q2/test-data.:last()")
+        r = ReferenceParser3(
+            string="$acme.files.Q2/test-data.:last()", csvpaths=CSVPATHS
+        )
         assert r.root_major == "acme"
         assert r.datatype == "files"
         assert r.name_one.path == ["Q2", "test-data"]
         assert r.name_three.functions[0].name == "last"
 
     def test_name_two_passthrough_from_name_one(self):
-        r = ReferenceParser3(string='$acme.files.*#my_worksheet.:type("xlsx")')
+        r = ReferenceParser3(
+            string='$acme.files.*#my_worksheet.:type("xlsx")', csvpaths=CSVPATHS
+        )
         assert r.name_two == "my_worksheet"
 
     def test_name_two_none_when_absent(self):
-        r = ReferenceParser3(string="$acme.results.a")
+        r = ReferenceParser3(string="$acme.results.a", csvpaths=CSVPATHS)
         assert r.name_two is None
 
     def test_parsed_is_a_reference3(self):
-        r = ReferenceParser3(string="$acme.results.a")
+        r = ReferenceParser3(string="$acme.results.a", csvpaths=CSVPATHS)
         assert isinstance(r.parsed, Reference3)
 
 
@@ -121,10 +131,10 @@ class TestNameThreeRequiredness:
     @pytest.mark.parametrize("datatype", ["files", "csvpaths"])
     def test_missing_name_three_raises_for_files_and_csvpaths(self, datatype):
         with pytest.raises(ReferenceException3):
-            ReferenceParser3(string=f"$acme.{datatype}.a")
+            ReferenceParser3(string=f"$acme.{datatype}.a", csvpaths=CSVPATHS)
 
     def test_missing_name_three_is_fine_for_results(self):
-        r = ReferenceParser3(string="$acme.results.a")
+        r = ReferenceParser3(string="$acme.results.a", csvpaths=CSVPATHS)
         assert r.name_three is None
 
     def test_reference_exception_is_not_wrapped_by_lark(self):
@@ -132,7 +142,7 @@ class TestNameThreeRequiredness:
         # specifically so a violation surfaces as ReferenceException3
         # itself, not wrapped in lark.exceptions.VisitError.
         try:
-            ReferenceParser3(string="$acme.files.a")
+            ReferenceParser3(string="$acme.files.a", csvpaths=CSVPATHS)
         except ReferenceException3:
             pass
         else:

--- a/tests/references/test_reference_results_3.py
+++ b/tests/references/test_reference_results_3.py
@@ -88,3 +88,61 @@ class TestReferenceResults3:
 
     def test_equality(self):
         assert self._results() == self._results()
+
+
+class TestRemove:
+    def _results(self, n=3):
+        return ReferenceResults3(
+            results=[ReferenceResult3(path=f"p{i}", uuid=f"u{i}") for i in range(n)]
+        )
+
+    def test_remove_drops_the_entry(self):
+        r = self._results()
+        target = r.results[1]
+        r.remove(target)
+        assert r.files == ["p0", "p2"]
+        assert len(r) == 2
+
+    def test_remove_missing_result_raises(self):
+        r = self._results()
+        stranger = ReferenceResult3(path="nope", uuid="nope")
+        with pytest.raises(ValueError):
+            r.remove(stranger)
+
+    def test_iterate_and_remove_in_the_same_loop_skips_nothing(self):
+        # the exact workflow this method exists for: walk the results,
+        # remove the ones you do not want, keep the rest. if __iter__
+        # returned the live list instead of a snapshot, removing p1
+        # while iterating would shift p2 into p1's old slot and the
+        # loop would skip over it.
+        r = self._results()
+        seen = []
+        for result in r:
+            seen.append(result.path)
+            if result.path == "p1":
+                r.remove(result)
+        assert seen == ["p0", "p1", "p2"]
+        assert r.files == ["p0", "p2"]
+
+    def test_trimmed_results_can_be_handed_to_resolve_from(self):
+        # the end-to-end shape David described: iterate, remove some,
+        # then pass the trimmed object straight to a finder.
+        from csvpath.references.reference_finder_3 import ReferenceFinder3
+        from csvpath.references.reference_parser_3 import ReferenceParser3
+
+        class _DummyFinder(ReferenceFinder3):
+            def query(self):
+                raise AssertionError("resolve_from(a ReferenceResults3) must not requery")
+
+            def _extract_data(self, result):
+                return f"data-for-{result.path}"
+
+        ref = ReferenceParser3(string="$acme.results.a.:errors()", csvpaths=object())
+        results = self._results()
+        for result in results:
+            if result.path == "p1":
+                results.remove(result)
+
+        finder = _DummyFinder(csvpaths=object(), ref=ref)
+        resolved = finder.resolve_from(results)
+        assert resolved.files == ["p0", "p2"]

--- a/tests/references/test_reference_results_3.py
+++ b/tests/references/test_reference_results_3.py
@@ -1,0 +1,90 @@
+import pytest
+
+from csvpath.references.reference_results_3 import ReferenceResult3, ReferenceResults3
+
+
+class TestReferenceResult3:
+    @pytest.mark.parametrize("bad_path", [None, ""])
+    def test_rejects_none_or_empty_path(self, bad_path):
+        with pytest.raises(ValueError):
+            ReferenceResult3(path=bad_path, uuid="u1")
+
+    @pytest.mark.parametrize("bad_uuid", [None, ""])
+    def test_rejects_none_or_empty_uuid(self, bad_uuid):
+        with pytest.raises(ValueError):
+            ReferenceResult3(path="p1", uuid=bad_uuid)
+
+    def test_data_defaults_to_none(self):
+        r = ReferenceResult3(path="p1", uuid="u1")
+        assert r.data is None
+
+    def test_data_is_settable(self):
+        r = ReferenceResult3(path="p1", uuid="u1")
+        r.data = {"a": 1}
+        assert r.data == {"a": 1}
+
+    def test_equality(self):
+        a = ReferenceResult3(path="p1", uuid="u1")
+        b = ReferenceResult3(path="p1", uuid="u1")
+        c = ReferenceResult3(path="p2", uuid="u1")
+        assert a == b
+        assert a != c
+
+
+class TestReferenceResults3:
+    def _results(self):
+        return ReferenceResults3(
+            results=[
+                ReferenceResult3(path="p1", uuid="u1"),
+                ReferenceResult3(path="p2", uuid="u2"),
+            ]
+        )
+
+    def test_defaults_to_empty(self):
+        r = ReferenceResults3()
+        assert r.results == []
+        assert len(r) == 0
+
+    def test_files_and_uuids(self):
+        r = self._results()
+        assert r.files == ["p1", "p2"]
+        assert r.uuids == ["u1", "u2"]
+
+    def test_file_for_uuid(self):
+        r = self._results()
+        assert r.file_for_uuid("u2") == "p2"
+        assert r.file_for_uuid("nope") is None
+
+    def test_uuid_for_file(self):
+        r = self._results()
+        assert r.uuid_for_file("p1") == "u1"
+        assert r.uuid_for_file("nope") is None
+
+    def test_data_for_uuid(self):
+        results = [
+            ReferenceResult3(path="p1", uuid="u1", data="d1"),
+            ReferenceResult3(path="p2", uuid="u2"),
+        ]
+        r = ReferenceResults3(results=results)
+        assert r.data_for_uuid("u1") == "d1"
+        assert r.data_for_uuid("u2") is None
+        assert r.data_for_uuid("nope") is None
+
+    def test_select_by_path_or_uuid(self):
+        r = self._results()
+        selected = r.select(["p1", "u2"])
+        assert selected.files == ["p1", "p2"]
+        assert len(selected) == 2
+
+    def test_select_returns_empty_for_no_matches(self):
+        r = self._results()
+        selected = r.select(["nope"])
+        assert len(selected) == 0
+
+    def test_len_and_iter(self):
+        r = self._results()
+        assert len(r) == 2
+        assert [x.path for x in r] == ["p1", "p2"]
+
+    def test_equality(self):
+        assert self._results() == self._results()

--- a/tests/references/test_reference_transformer_3.py
+++ b/tests/references/test_reference_transformer_3.py
@@ -1,0 +1,180 @@
+import pytest
+
+from csvpath.references.reference_3 import (
+    FunctionCall3,
+    Regex3,
+    Star3,
+    Variable3,
+)
+from csvpath.references.reference_grammar_3 import QueryParser3
+from csvpath.references.reference_transformer_3 import Reference3Transformer
+
+
+#
+# tests that a parse tree actually gets turned into the structure we
+# expect -- one representative case per interesting grammar shape,
+# rather than re-running the whole grammar-level corpus (that's already
+# covered, at the syntax-only level, by test_references_3_grammar.py).
+#
+
+
+@pytest.fixture(scope="module")
+def parser() -> QueryParser3:
+    return QueryParser3()
+
+
+def build(parser, query):
+    tree = parser.parse(query)
+    return Reference3Transformer().transform(tree)
+
+
+class TestRootMajorAndDatatype:
+    def test_literal_root_major(self, parser):
+        r = build(parser, "$acme.results.a")
+        assert r.root_major == "acme"
+        assert r.datatype == "results"
+
+    def test_star_root_major(self, parser):
+        r = build(parser, "$*.results.a")
+        assert r.root_major == Star3()
+
+
+class TestNameOnePath:
+    def test_single_literal_segment(self, parser):
+        r = build(parser, "$acme.files.somefile.v1")
+        assert r.name_one.path == ["somefile"]
+
+    def test_multi_segment_literal_path(self, parser):
+        r = build(parser, "$acme.files.Q2/test-data.v1")
+        assert r.name_one.path == ["Q2", "test-data"]
+
+    def test_star_segment(self, parser):
+        r = build(parser, "$acme.files.*.v1")
+        assert r.name_one.path == [Star3()]
+
+    def test_function_as_sole_segment_no_trailing_chain(self, parser):
+        # this is exactly the shape that used to be ambiguous (bare
+        # func_chain vs. path_prefix's single function-segment) before
+        # the grammar fix -- confirm it builds a single-segment path,
+        # not a two-item path or something split oddly.
+        r = build(parser, "$acme.files.:all().v1")
+        assert r.name_one.path == [FunctionCall3(name="all")]
+        assert r.name_one.functions == []
+
+    def test_function_segment_mixed_with_literal_path(self, parser):
+        r = build(parser, '$acme.files.:quarter()/:name("live data").v1')
+        assert r.name_one.path == [
+            FunctionCall3(name="quarter"),
+            FunctionCall3(name="name", arg="live data"),
+        ]
+
+    def test_multiple_functions_no_path_split_between_segment_and_chain(self, parser):
+        # ":before():after():index(3)" as name_one: no slashes at all, so
+        # this can only come from path_prefix's one-segment case (the
+        # first function) plus a trailing func_chain (the rest) -- there
+        # is no other way to produce it now that the ambiguous bare
+        # func_chain alternative is gone.
+        r = build(
+            parser,
+            '$acme.csvpaths.:before(:yesterday()):after(:date("2024-08-01")):index(3).v1',
+        )
+        assert r.name_one.path == [FunctionCall3(name="before", arg=FunctionCall3(name="yesterday"))]
+        assert r.name_one.functions == [
+            FunctionCall3(name="after", arg=FunctionCall3(name="date", arg="2024-08-01")),
+            FunctionCall3(name="index", arg=3),
+        ]
+
+
+class TestNameOneWorksheetAndFunctions:
+    def test_name_two_worksheet(self, parser):
+        r = build(parser, '$acme.files.*#my_worksheet.:type("xlsx")')
+        assert r.name_one.name_two == "my_worksheet"
+
+    def test_trailing_function_chain(self, parser):
+        # note the dot before the functions here puts them in name_three,
+        # not name_one -- see test_name_one_can_carry_its_own_trailing_
+        # function_chain below for functions attached to name_one itself.
+        r = build(parser, "$acme.files.*.:last():before(:today())")
+        assert r.name_one.path == [Star3()]
+        assert r.name_one.functions == []
+        assert r.name_three.functions == [
+            FunctionCall3(name="last"),
+            FunctionCall3(name="before", arg=FunctionCall3(name="today")),
+        ]
+
+    def test_name_one_can_carry_its_own_trailing_function_chain(self, parser):
+        # no dot between "*" and the functions -- these belong to
+        # name_one, with "v1" as a separate name_three.
+        r = build(parser, "$acme.files.*:last():before(:today()).v1")
+        assert r.name_one.path == [Star3()]
+        assert r.name_one.functions == [
+            FunctionCall3(name="last"),
+            FunctionCall3(name="before", arg=FunctionCall3(name="today")),
+        ]
+        assert r.name_three.body == "v1"
+
+
+class TestNameThree:
+    def test_literal_body_only(self, parser):
+        r = build(parser, "$acme.files.a.invoices")
+        assert r.name_three.body == "invoices"
+        assert r.name_three.functions == []
+
+    def test_star_body(self, parser):
+        r = build(parser, "$acme.results.customers/:from(:index(-1)).*:type(\"parquet\")")
+        assert r.name_three.body == Star3()
+        assert r.name_three.functions == [FunctionCall3(name="type", arg="parquet")]
+
+    def test_bare_function_chain(self, parser):
+        r = build(parser, "$acme.results.a.:all()")
+        assert r.name_three.body is None
+        assert r.name_three.functions == [FunctionCall3(name="all")]
+
+    def test_body_with_trailing_functions(self, parser):
+        r = build(parser, "$acme.results.customers/2025:first().invoices:data()")
+        assert r.name_three.body == "invoices"
+        assert r.name_three.functions == [FunctionCall3(name="data")]
+
+    def test_absent_name_three(self, parser):
+        r = build(parser, "$acme.results.a")
+        assert r.name_three is None
+
+
+class TestFunctionArgs:
+    def test_string_arg(self, parser):
+        r = build(parser, '$acme.files.a.:name("Acme")')
+        assert r.name_three.functions[0].arg == "Acme"
+
+    def test_signed_int_arg(self, parser):
+        r = build(parser, "$acme.files.*.:index(7)")
+        assert r.name_three.functions[0].arg == 7
+
+    def test_negative_signed_int_arg(self, parser):
+        # the dot before :at(-1) puts it in name_three, not name_one.
+        r = build(parser, "$acme.files.*#w.:at(-1)")
+        assert r.name_three.functions[0].arg == -1
+
+    def test_variable_arg(self, parser):
+        r = build(parser, "$acme.files.Q2/:name(@customer).v1")
+        assert r.name_one.path[1].arg == Variable3(name="customer")
+
+    def test_star_arg(self, parser):
+        r = build(parser, "$acme.files.Q2/:name(*).v1")
+        assert r.name_one.path[1].arg == Star3()
+
+    def test_regex_arg(self, parser):
+        r = build(parser, "$acme.results.:name(/^[^M].*/)/2025:first().invoices")
+        assert r.name_one.path[0].arg == Regex3(pattern="^[^M].*")
+
+    def test_nested_function_arg(self, parser):
+        r = build(parser, "$acme.files.*.:from(:index(0)):to(@index)")
+        assert r.name_three.functions[0] == FunctionCall3(
+            name="from", arg=FunctionCall3(name="index", arg=0)
+        )
+        assert r.name_three.functions[1] == FunctionCall3(
+            name="to", arg=Variable3(name="index")
+        )
+
+    def test_string_with_escaped_quote_and_backslash(self, parser):
+        r = build(parser, '$acme.files.a.:name("say \\"hi\\"")')
+        assert r.name_three.functions[0].arg == 'say "hi"'


### PR DESCRIPTION
## Summary
- References v3 transformer: turns the grammar's parse tree into a `Reference3` object graph (`Reference3`, `NameOne3`, `NameThree3`, `FunctionCall3`, `Star3`, `Variable3`, `Regex3`), following `csvpath/matching/lark_transformer.py`'s convention (one method per grammar rule) rather than v1/v2's one-method-per-rule-combination approach.
- Fixed a genuine grammar ambiguity in `name_one` (a redundant bare `func_chain` alternative let a path-less, function(s)-only body parse two different ways) and switched `QueryParser3` to `parser="lalr"` as a result — unblocks a future type-ahead layer, which needs LALR's single-state determinism.
- `ReferenceFinder3` (ABC) + `ReferenceResults3`/`ReferenceResult3` (pure value containers), built from an initial strawman: `query()` abstract per datatype, shared `resolve()`/`resolve_from()` supporting a caller-narrowed selection so "cheap search, then selective fetch" is real, `ReferenceResults3.select()`/`remove()` for narrowing/trimming without re-touching storage.
- `Reference3.resolves_to_data` + `FunctionCall3.contains_function_named()` answer whether a reference asks for a whole file/thing vs. a specific extracted value, structurally, without needing the function registry to exist yet.
- `name_three`'s datatype-dependent requiredness (required for files/csvpaths, optional for results) is enforced via `Reference3.check_valid()`, called explicitly after the transform completes (not from `__init__`) so the resulting `ReferenceException3` isn't swallowed by lark's `VisitError` wrapping.

## Test plan
- [x] `tests/references/` — 230 tests, all passing (grammar, transformer, object graph, results container, finder ABC)
- [x] Full suite — 1810 passed, 11 failed (known SFTP/S3/remote-backend baseline, unrelated to this change)
- [x] All 47 positive examples from the frozen spec doc / grammar test corpus round-trip through `ReferenceParser3` back to the exact original string
