### PR TITLE
References v3: function registry (Function3/factory) + first-pass FilesReferenceFinder3

### DIFF
--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -1,0 +1,148 @@
+from .functions.function_3 import Function3
+from .functions.reference_function_factory_3 import ReferenceFunctionFactory
+from .reference_3 import FunctionCall3, Star3
+from .reference_exceptions_3 import ReferenceException3
+from .reference_finder_3 import ReferenceFinder3
+from .reference_results_3 import ReferenceResult3, ReferenceResults3
+
+
+class FilesReferenceFinder3(ReferenceFinder3):
+    #
+    # first pass, deliberately narrow:
+    #  - root_major is a literal named-file name. "*" (every named-file)
+    #    is a different traversal problem, not yet built.
+    #  - name_one is "*", a literal path segment, or :name("...") (for a
+    #    literal name containing characters -- e.g. a real filename's
+    #    "." -- that cannot appear in a bare PATH_SEGMENT). any other
+    #    function-valued segment (e.g. :quarter()) and the "#worksheet"
+    #    marker (name_two) are not yet supported.
+    #  - name_three must resolve to exactly one pointer function
+    #    (:first()/:last()/:index(n)). This matches the STRUCTURE table:
+    #    name_one picks *which file*, name_three picks *which version*.
+    #    A literal name_three body (bypassing a pointer function
+    #    entirely) is not yet supported either.
+    #
+    # storage facts this relies on (confirmed against FileManager/
+    # FileRegistrar and a real manifest.json, not assumed): a named-
+    # file's manifest.json is one flat, append-only JSON array covering
+    # every version of every distinct file ever registered under that
+    # name. Each entry's "file_home" is the directory shared by every
+    # version of the same logical file; arrival order is simply array
+    # order (not sorted by the "time" field).
+    #
+
+    def query(self) -> ReferenceResults3:
+        reference = self.ref.parsed
+        root_major = reference.root_major
+        if isinstance(root_major, Star3):
+            raise ReferenceException3(
+                "FilesReferenceFinder3 does not yet support '*' as root_major "
+                "(querying every named-file) -- use a literal named-file name."
+            )
+
+        name_one = reference.name_one
+        if name_one.name_two is not None:
+            raise ReferenceException3(
+                "FilesReferenceFinder3 does not yet support the '#worksheet' "
+                "marker (name_two)."
+            )
+        if name_one.functions:
+            raise ReferenceException3(
+                "FilesReferenceFinder3 does not yet support functions attached "
+                "directly to name_one -- put the version-selecting function in "
+                "name_three instead."
+            )
+        pattern = self._compile_path_pattern(name_one.path)
+
+        name_three = reference.name_three
+        if name_three.body is not None:
+            raise ReferenceException3(
+                "FilesReferenceFinder3 does not yet support a literal name_three "
+                "body -- name_three must resolve to a pointer function "
+                "(:first()/:last()/:index(n))."
+            )
+        built = ReferenceFunctionFactory.build_chain(name_three.functions)
+        pointers = [f for f in built if f.ROLE == Function3.POINTER]
+        if len(pointers) != 1:
+            raise ReferenceException3(
+                "FilesReferenceFinder3 requires name_three to resolve to "
+                "exactly one pointer function (:first()/:last()/:index(n))."
+            )
+        pointer = pointers[0]
+
+        manifest = self.csvpaths.file_manager.get_manifest(root_major)
+        home = self.csvpaths.file_manager.named_file_home(root_major).rstrip("/")
+        candidates = [
+            entry for entry in manifest if self._matches(entry, home, pattern)
+        ]
+
+        selected = self._apply_pointer(pointer, candidates)
+        results = []
+        if selected is not None:
+            results.append(
+                ReferenceResult3(path=selected["file"], uuid=selected["uuid"])
+            )
+        return ReferenceResults3(results=results)
+
+    def _extract_data(self, result: ReferenceResult3):
+        raise ReferenceException3(
+            "FilesReferenceFinder3 has no content to extract from -- "
+            "resolves_to_data should always be False for the files datatype "
+            "with the functions currently registered."
+        )
+
+    @staticmethod
+    def _compile_path_pattern(path: list) -> list:
+        """turns name_one.path into a list of str/Star3 to match against
+        real file_home segments. a literal str or Star3 segment passes
+        through unchanged; a :name("...") segment is compiled and
+        unwrapped to its literal string, so matching downstream doesn't
+        need to know the difference. any other function-valued segment
+        is explicitly not yet supported."""
+        pattern = []
+        for segment in path:
+            if isinstance(segment, FunctionCall3):
+                if segment.name != "name":
+                    raise ReferenceException3(
+                        f"FilesReferenceFinder3 does not yet support :{segment.name}() "
+                        "as a name_one path segment -- only :name(\"...\") and "
+                        "literal/'*' segments are supported."
+                    )
+                built = ReferenceFunctionFactory.build(segment)
+                pattern.append(built.arg)
+            elif isinstance(segment, (str, Star3)):
+                pattern.append(segment)
+            else:
+                raise ReferenceException3(f"Unsupported name_one path segment: {segment!r}")
+        return pattern
+
+    @staticmethod
+    def _matches(entry: dict, home: str, pattern: list) -> bool:
+        file_home = entry["file_home"].rstrip("/")
+        if not file_home.startswith(home):
+            return False
+        rel = file_home[len(home) :].lstrip("/")
+        segments = rel.split("/") if rel else []
+        if len(segments) != len(pattern):
+            return False
+        for actual, expected in zip(segments, pattern):
+            if isinstance(expected, Star3):
+                continue
+            if actual != expected:
+                return False
+        return True
+
+    @staticmethod
+    def _apply_pointer(pointer, candidates: list) -> dict | None:
+        if not candidates:
+            return None
+        if pointer.name == "first":
+            return candidates[0]
+        if pointer.name == "last":
+            return candidates[-1]
+        if pointer.name == "index":
+            try:
+                return candidates[pointer.arg]
+            except IndexError:
+                return None
+        raise ReferenceException3(f"Unsupported pointer function: {pointer.name}")

--- a/csvpath/references/functions/first_3.py
+++ b/csvpath/references/functions/first_3.py
@@ -1,0 +1,11 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class First3(Function3):
+    NAME = "first"
+    SUMMARY = "The earliest-arriving item in the current scope."
+    ROLE = Function3.POINTER
+    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False

--- a/csvpath/references/functions/function_3.py
+++ b/csvpath/references/functions/function_3.py
@@ -1,0 +1,91 @@
+from typing import Any
+
+from ..reference_exceptions_3 import ReferenceException3
+
+
+#
+# Function3 is the base class for real, behavior-having references-v3
+# functions -- distinct from FunctionCall3 (reference_3.py), which is
+# just the parsed name+arg shape the transformer builds. A Function3 is
+# constructed by ReferenceFunctionFactory.build(), given an already-
+# resolved arg (a nested FunctionCall3 gets compiled into a Function3
+# first -- see the factory).
+#
+# per "requirements for functions.txt": functions are looked up and
+# validated at runtime (not baked into the grammar), self validating,
+# self describing/inspectable, take at most 1 arg, and self-report
+# their role -- CONTEXT_SETTER (narrows/sets scope without resolving to
+# an item, e.g. :yesterday(), :all()) or POINTER (resolves scope to
+# exactly 0 or 1 item, e.g. :last(), :first(), :index(n)). There is
+# deliberately no code shared with csvpath.matching.functions -- this
+# class does not subclass or import anything from there.
+#
+class Function3:
+    CONTEXT_SETTER = "context_setter"
+    POINTER = "pointer"
+
+    #
+    # subclasses override all of these.
+    #
+    NAME: str = None
+    SUMMARY: str = None
+    ROLE: str = None
+    DATATYPES: tuple = ()
+    ARG_TYPES: tuple = ()
+    ARG_REQUIRED: bool = False
+
+    def __init__(self, *, arg: Any = None) -> None:
+        self._arg = arg
+
+    @property
+    def name(self) -> str:
+        return self.NAME
+
+    @property
+    def arg(self) -> Any:
+        return self._arg
+
+    def check_valid(self) -> None:
+        """structural check; doesn't test or use the arg's value. mirrors
+        csvpath.matching.productions.matchable.Matchable.check_valid()'s
+        parse-time-not-runtime-values pattern, scaled down for a single,
+        declaratively-typed arg instead of Args/ArgSet's multi-arg
+        overload sets."""
+        if self.ARG_REQUIRED and self._arg is None:
+            raise ReferenceException3(f":{self.NAME}() requires an argument")
+        if not self.ARG_TYPES and self._arg is not None:
+            raise ReferenceException3(f":{self.NAME}() does not take an argument")
+        if (
+            self.ARG_TYPES
+            and self._arg is not None
+            and not isinstance(self._arg, self.ARG_TYPES)
+        ):
+            raise ReferenceException3(
+                f":{self.NAME}() argument must be one of {self.ARG_TYPES}, "
+                f"got {type(self._arg)}"
+            )
+        if isinstance(self._arg, Function3):
+            self._arg.check_valid()
+
+    def describe(self) -> dict:
+        """machine-actionable self-description -- also human-readable
+        via SUMMARY. this is what a future type-ahead layer's registry
+        query is meant to read (see references_notes/
+        autocomplete_prototype.py's registry shape: name/summary/
+        datatypes)."""
+        return {
+            "name": self.NAME,
+            "summary": self.SUMMARY,
+            "role": self.ROLE,
+            "datatypes": self.DATATYPES,
+        }
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, Function3)
+            and other.name == self.name
+            and other.arg == self._arg
+        )
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(arg={self._arg!r})"

--- a/csvpath/references/functions/index_3.py
+++ b/csvpath/references/functions/index_3.py
@@ -1,0 +1,14 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class Index3(Function3):
+    NAME = "index"
+    SUMMARY = (
+        "The item at a 0-based position in the current scope, in "
+        "arrival/registration order."
+    )
+    ROLE = Function3.POINTER
+    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+    ARG_TYPES = (int,)
+    ARG_REQUIRED = True

--- a/csvpath/references/functions/last_3.py
+++ b/csvpath/references/functions/last_3.py
@@ -1,0 +1,11 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class Last3(Function3):
+    NAME = "last"
+    SUMMARY = "The most-recently-arriving item in the current scope."
+    ROLE = Function3.POINTER
+    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False

--- a/csvpath/references/functions/name_3.py
+++ b/csvpath/references/functions/name_3.py
@@ -1,0 +1,23 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class Name3(Function3):
+    #
+    # matches an exact literal name at this position -- specifically for
+    # names that cannot appear as a bare PATH_SEGMENT (e.g. a real
+    # filename with a "." in it, which the grammar reserves as the
+    # name_one/name_three separator). str arg only for now -- the
+    # grammar also allows "*", "@var", and a regex here, but those need
+    # machinery (wildcard-as-arg semantics, runtime variable lookup,
+    # regex matching) this first pass does not need yet.
+    #
+    NAME = "name"
+    SUMMARY = (
+        "Matches an exact literal name at this position -- for names "
+        "(e.g. a filename) that cannot appear in a bare path segment."
+    )
+    ROLE = Function3.CONTEXT_SETTER
+    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+    ARG_TYPES = (str,)
+    ARG_REQUIRED = True

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -1,0 +1,74 @@
+from ..reference_3 import FunctionCall3
+from ..reference_exceptions_3 import ReferenceException3
+from .function_3 import Function3
+
+
+class ReferenceFunctionFactory:
+    #
+    # name-keyed registry turning FunctionCall3 (parsed name+arg shape)
+    # into real Function3 instances -- conceptually similar to
+    # csvpath.matching.functions.function_factory.FunctionFactory, per
+    # "requirements for functions.txt", but far smaller: references-v3
+    # functions take at most 1 arg and have no argset overloads, so
+    # there is no per-name construction complexity to speak of.
+    #
+    _FUNCTIONS: dict = {}
+
+    @classmethod
+    def _load(cls) -> None:
+        from .first_3 import First3
+        from .last_3 import Last3
+
+        cls._FUNCTIONS = {
+            First3.NAME: First3,
+            Last3.NAME: Last3,
+        }
+
+    @classmethod
+    def add_function(cls, function_cls: type) -> None:
+        """registers a function class at runtime -- e.g. for a custom,
+        user-added function (see "requirements for functions.txt"'s
+        possible-requirements section). overrides an existing name."""
+        if function_cls is None:
+            raise ValueError("function_cls cannot be None")
+        if not cls._FUNCTIONS:
+            cls._load()
+        cls._FUNCTIONS[function_cls.NAME] = function_cls
+
+    @classmethod
+    def build(cls, call: FunctionCall3) -> Function3:
+        """compiles one FunctionCall3 into a real, validated Function3.
+        recurses first if call.arg is itself a FunctionCall3, so a
+        nested function is always compiled (and check_valid()'d) before
+        the function that takes it as an argument."""
+        if call is None:
+            raise ValueError("FunctionCall3 cannot be None")
+        if not cls._FUNCTIONS:
+            cls._load()
+        arg = call.arg
+        if isinstance(arg, FunctionCall3):
+            arg = cls.build(arg)
+        function_cls = cls._FUNCTIONS.get(call.name)
+        if function_cls is None:
+            raise ReferenceException3(f"Unknown reference function: {call.name}")
+        instance = function_cls(arg=arg)
+        instance.check_valid()
+        return instance
+
+    @classmethod
+    def build_chain(cls, calls: list) -> list:
+        """compiles a whole function chain (NameOne3/NameThree3's
+        .functions list) and enforces "at most one pointer function per
+        chain, per nesting level" -- see "requirements for
+        functions.txt". a pointer nested inside another function's
+        argument (already compiled by build() above) does not count
+        here; only these direct siblings do."""
+        built = [cls.build(call) for call in calls]
+        pointers = [f for f in built if f.ROLE == Function3.POINTER]
+        if len(pointers) > 1:
+            names = ", ".join(f":{f.name}()" for f in pointers)
+            raise ReferenceException3(
+                f"At most one pointer function is allowed per function chain, "
+                f"found {len(pointers)}: {names}"
+            )
+        return built

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -19,11 +19,13 @@ class ReferenceFunctionFactory:
         from .first_3 import First3
         from .index_3 import Index3
         from .last_3 import Last3
+        from .name_3 import Name3
 
         cls._FUNCTIONS = {
             First3.NAME: First3,
             Last3.NAME: Last3,
             Index3.NAME: Index3,
+            Name3.NAME: Name3,
         }
 
     @classmethod

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -17,11 +17,13 @@ class ReferenceFunctionFactory:
     @classmethod
     def _load(cls) -> None:
         from .first_3 import First3
+        from .index_3 import Index3
         from .last_3 import Last3
 
         cls._FUNCTIONS = {
             First3.NAME: First3,
             Last3.NAME: Last3,
+            Index3.NAME: Index3,
         }
 
     @classmethod

--- a/tests/references/functions/test_first_3.py
+++ b/tests/references/functions/test_first_3.py
@@ -1,0 +1,22 @@
+import pytest
+
+from csvpath.references.functions.first_3 import First3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = First3()
+    assert f.name == "first"
+    assert f.ROLE == Function3.POINTER
+    assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+
+
+def test_no_arg_is_valid():
+    First3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        First3(arg="x").check_valid()

--- a/tests/references/functions/test_function_3.py
+++ b/tests/references/functions/test_function_3.py
@@ -1,0 +1,91 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+class _NoArgFunction(Function3):
+    NAME = "noarg"
+    SUMMARY = "takes nothing"
+    ROLE = Function3.CONTEXT_SETTER
+    DATATYPES = ("files",)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+
+
+class _RequiredIntArgFunction(Function3):
+    NAME = "needsint"
+    SUMMARY = "takes a required int"
+    ROLE = Function3.POINTER
+    DATATYPES = ("files",)
+    ARG_TYPES = (int,)
+    ARG_REQUIRED = True
+
+
+class _OptionalStrArgFunction(Function3):
+    NAME = "optstr"
+    SUMMARY = "takes an optional str"
+    ROLE = Function3.CONTEXT_SETTER
+    DATATYPES = ("files",)
+    ARG_TYPES = (str,)
+    ARG_REQUIRED = False
+
+
+class TestCheckValid:
+    def test_no_arg_function_accepts_no_arg(self):
+        _NoArgFunction().check_valid()  # should not raise
+
+    def test_no_arg_function_rejects_any_arg(self):
+        with pytest.raises(ReferenceException3):
+            _NoArgFunction(arg="x").check_valid()
+
+    def test_required_arg_missing_raises(self):
+        with pytest.raises(ReferenceException3):
+            _RequiredIntArgFunction().check_valid()
+
+    def test_required_arg_present_and_correct_type_passes(self):
+        _RequiredIntArgFunction(arg=5).check_valid()  # should not raise
+
+    def test_wrong_arg_type_raises(self):
+        with pytest.raises(ReferenceException3):
+            _RequiredIntArgFunction(arg="not an int").check_valid()
+
+    def test_optional_arg_absent_passes(self):
+        _OptionalStrArgFunction().check_valid()  # should not raise
+
+    def test_optional_arg_present_and_correct_type_passes(self):
+        _OptionalStrArgFunction(arg="ok").check_valid()  # should not raise
+
+    def test_nested_function3_arg_is_recursively_checked(self):
+        class _AcceptsFunctionArg(Function3):
+            NAME = "wraps"
+            SUMMARY = "takes a nested function"
+            ROLE = Function3.CONTEXT_SETTER
+            DATATYPES = ("files",)
+            ARG_TYPES = (Function3,)
+            ARG_REQUIRED = False
+
+        bad_nested = _RequiredIntArgFunction()  # missing its own required arg
+        with pytest.raises(ReferenceException3):
+            _AcceptsFunctionArg(arg=bad_nested).check_valid()
+
+
+class TestProperties:
+    def test_name_and_arg(self):
+        f = _RequiredIntArgFunction(arg=7)
+        assert f.name == "needsint"
+        assert f.arg == 7
+
+    def test_describe(self):
+        f = _NoArgFunction()
+        assert f.describe() == {
+            "name": "noarg",
+            "summary": "takes nothing",
+            "role": Function3.CONTEXT_SETTER,
+            "datatypes": ("files",),
+        }
+
+    def test_equality(self):
+        assert _RequiredIntArgFunction(arg=1) == _RequiredIntArgFunction(arg=1)
+        assert _RequiredIntArgFunction(arg=1) != _RequiredIntArgFunction(arg=2)
+        assert _RequiredIntArgFunction(arg=1) != _NoArgFunction()

--- a/tests/references/functions/test_index_3.py
+++ b/tests/references/functions/test_index_3.py
@@ -1,0 +1,31 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.index_3 import Index3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Index3(arg=0)
+    assert f.name == "index"
+    assert f.ROLE == Function3.POINTER
+    assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+
+
+def test_zero_based_first_item_is_valid():
+    Index3(arg=0).check_valid()  # should not raise
+
+
+def test_positive_index_is_valid():
+    Index3(arg=7).check_valid()  # should not raise
+
+
+def test_missing_arg_raises():
+    with pytest.raises(ReferenceException3):
+        Index3().check_valid()
+
+
+def test_non_int_arg_raises():
+    with pytest.raises(ReferenceException3):
+        Index3(arg="7").check_valid()

--- a/tests/references/functions/test_last_3.py
+++ b/tests/references/functions/test_last_3.py
@@ -1,0 +1,22 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.last_3 import Last3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Last3()
+    assert f.name == "last"
+    assert f.ROLE == Function3.POINTER
+    assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+
+
+def test_no_arg_is_valid():
+    Last3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Last3(arg="x").check_valid()

--- a/tests/references/functions/test_name_3.py
+++ b/tests/references/functions/test_name_3.py
@@ -1,0 +1,27 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.name_3 import Name3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Name3(arg="zero.csv")
+    assert f.name == "name"
+    assert f.ROLE == Function3.CONTEXT_SETTER
+    assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+
+
+def test_str_arg_is_valid():
+    Name3(arg="zero.csv").check_valid()  # should not raise
+
+
+def test_missing_arg_raises():
+    with pytest.raises(ReferenceException3):
+        Name3().check_valid()
+
+
+def test_non_str_arg_raises():
+    with pytest.raises(ReferenceException3):
+        Name3(arg=5).check_valid()

--- a/tests/references/functions/test_reference_function_factory_3.py
+++ b/tests/references/functions/test_reference_function_factory_3.py
@@ -4,6 +4,7 @@ from csvpath.references.functions.first_3 import First3
 from csvpath.references.functions.function_3 import Function3
 from csvpath.references.functions.index_3 import Index3
 from csvpath.references.functions.last_3 import Last3
+from csvpath.references.functions.name_3 import Name3
 from csvpath.references.functions.reference_function_factory_3 import (
     ReferenceFunctionFactory,
 )
@@ -28,6 +29,11 @@ class TestBuild:
         f = ReferenceFunctionFactory.build(FunctionCall3(name="index", arg=0))
         assert isinstance(f, Index3)
         assert f.arg == 0
+
+    def test_builds_name(self):
+        f = ReferenceFunctionFactory.build(FunctionCall3(name="name", arg="zero.csv"))
+        assert isinstance(f, Name3)
+        assert f.arg == "zero.csv"
 
     def test_unknown_function_raises(self):
         with pytest.raises(ReferenceException3):
@@ -84,3 +90,13 @@ class TestBuildChain:
 
     def test_empty_chain_is_fine(self):
         assert ReferenceFunctionFactory.build_chain([]) == []
+
+    def test_a_context_setter_alongside_a_pointer_is_fine(self):
+        # name() is CONTEXT_SETTER, not POINTER -- it does not count
+        # toward the at-most-one-pointer budget.
+        built = ReferenceFunctionFactory.build_chain(
+            [FunctionCall3(name="name", arg="zero.csv"), FunctionCall3(name="first")]
+        )
+        assert len(built) == 2
+        assert isinstance(built[0], Name3)
+        assert isinstance(built[1], First3)

--- a/tests/references/functions/test_reference_function_factory_3.py
+++ b/tests/references/functions/test_reference_function_factory_3.py
@@ -2,6 +2,7 @@ import pytest
 
 from csvpath.references.functions.first_3 import First3
 from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.index_3 import Index3
 from csvpath.references.functions.last_3 import Last3
 from csvpath.references.functions.reference_function_factory_3 import (
     ReferenceFunctionFactory,
@@ -22,6 +23,11 @@ class TestBuild:
     def test_builds_last(self):
         f = ReferenceFunctionFactory.build(FunctionCall3(name="last"))
         assert isinstance(f, Last3)
+
+    def test_builds_index(self):
+        f = ReferenceFunctionFactory.build(FunctionCall3(name="index", arg=0))
+        assert isinstance(f, Index3)
+        assert f.arg == 0
 
     def test_unknown_function_raises(self):
         with pytest.raises(ReferenceException3):
@@ -68,6 +74,12 @@ class TestBuildChain:
         with pytest.raises(ReferenceException3):
             ReferenceFunctionFactory.build_chain(
                 [FunctionCall3(name="first"), FunctionCall3(name="last")]
+            )
+
+    def test_index_and_last_in_the_same_chain_also_raises(self):
+        with pytest.raises(ReferenceException3):
+            ReferenceFunctionFactory.build_chain(
+                [FunctionCall3(name="index", arg=0), FunctionCall3(name="last")]
             )
 
     def test_empty_chain_is_fine(self):

--- a/tests/references/functions/test_reference_function_factory_3.py
+++ b/tests/references/functions/test_reference_function_factory_3.py
@@ -1,0 +1,74 @@
+import pytest
+
+from csvpath.references.functions.first_3 import First3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.last_3 import Last3
+from csvpath.references.functions.reference_function_factory_3 import (
+    ReferenceFunctionFactory,
+)
+from csvpath.references.reference_3 import FunctionCall3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+class TestBuild:
+    def test_rejects_none(self):
+        with pytest.raises(ValueError):
+            ReferenceFunctionFactory.build(None)
+
+    def test_builds_first(self):
+        f = ReferenceFunctionFactory.build(FunctionCall3(name="first"))
+        assert isinstance(f, First3)
+
+    def test_builds_last(self):
+        f = ReferenceFunctionFactory.build(FunctionCall3(name="last"))
+        assert isinstance(f, Last3)
+
+    def test_unknown_function_raises(self):
+        with pytest.raises(ReferenceException3):
+            ReferenceFunctionFactory.build(FunctionCall3(name="not_a_real_function"))
+
+    def test_built_function_is_check_valid_already(self):
+        # last() takes no arg -- passing one should surface as a
+        # ReferenceException3 from build(), not silently construct an
+        # unvalidated instance.
+        with pytest.raises(ReferenceException3):
+            ReferenceFunctionFactory.build(FunctionCall3(name="last", arg="x"))
+
+    def test_recursively_compiles_a_nested_function_call_arg(self):
+        # neither first() nor last() takes a nested function arg, so a
+        # temporary function is registered here to exercise build()'s
+        # recursion for real: the outer function's arg must arrive as
+        # an already-compiled, already-validated Function3 instance --
+        # not the raw FunctionCall3 the transformer produced.
+        class _Wraps3(Function3):
+            NAME = "wraps_for_test"
+            SUMMARY = "test-only: takes a nested function"
+            ROLE = Function3.CONTEXT_SETTER
+            DATATYPES = ()
+            ARG_TYPES = (Function3,)
+            ARG_REQUIRED = True
+
+        ReferenceFunctionFactory.add_function(_Wraps3)
+        try:
+            call = FunctionCall3(name="wraps_for_test", arg=FunctionCall3(name="first"))
+            built = ReferenceFunctionFactory.build(call)
+            assert isinstance(built, _Wraps3)
+            assert isinstance(built.arg, First3)
+        finally:
+            del ReferenceFunctionFactory._FUNCTIONS["wraps_for_test"]
+
+
+class TestBuildChain:
+    def test_single_pointer_is_fine(self):
+        built = ReferenceFunctionFactory.build_chain([FunctionCall3(name="first")])
+        assert len(built) == 1
+        assert isinstance(built[0], First3)
+
+    def test_two_pointers_in_the_same_chain_raises(self):
+        with pytest.raises(ReferenceException3):
+            ReferenceFunctionFactory.build_chain(
+                [FunctionCall3(name="first"), FunctionCall3(name="last")]
+            )
+
+    def test_empty_chain_is_fine(self):
+        assert ReferenceFunctionFactory.build_chain([]) == []

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -1,0 +1,189 @@
+import pytest
+
+from csvpath.references.files_reference_finder_3 import FilesReferenceFinder3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+from csvpath.references.reference_parser_3 import ReferenceParser3
+
+
+#
+# fixture modeled directly on the spec's own EXAMPLE SCENARIO in
+# "creating references v3.txt": named-file alpha has two distinct files
+# (zero.csv, one.csv), one.csv has two versions, listed in arrival
+# order. real file_home values always include the source filename's
+# extension (confirmed against a real manifest.json), which is exactly
+# why literal PATH_SEGMENT can't reach them and :name("...") exists.
+#
+ALPHA_HOME = "inputs/named_files/alpha"
+ALPHA_MANIFEST = [
+    {
+        "file": "inputs/named_files/alpha/zero.csv/0000000000000000.csv",
+        "file_home": "inputs/named_files/alpha/zero.csv",
+        "uuid": "u-zero-1",
+    },
+    {
+        "file": "inputs/named_files/alpha/one.csv/1111111111abcdef.csv",
+        "file_home": "inputs/named_files/alpha/one.csv",
+        "uuid": "u-one-1",
+    },
+    {
+        "file": "inputs/named_files/alpha/one.csv/0000000000abcdef.csv",
+        "file_home": "inputs/named_files/alpha/one.csv",
+        "uuid": "u-one-2",
+    },
+]
+
+TEMPLATED_HOME = "inputs/named_files/acme"
+TEMPLATED_MANIFEST = [
+    {
+        "file": "inputs/named_files/acme/Q2/test-data/aaaa.csv",
+        "file_home": "inputs/named_files/acme/Q2/test-data",
+        "uuid": "u-q2-1",
+    },
+]
+
+
+class _FakeFileManager:
+    def __init__(self, home, manifest):
+        self._home = home
+        self._manifest = manifest
+
+    def named_file_home(self, name):
+        return self._home
+
+    def get_manifest(self, name):
+        return self._manifest
+
+
+class _FakeCsvPaths:
+    def __init__(self, file_manager):
+        self.file_manager = file_manager
+
+
+def _finder(reference: str, home: str, manifest: list) -> FilesReferenceFinder3:
+    csvpaths = _FakeCsvPaths(_FakeFileManager(home, manifest))
+    ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
+    return FilesReferenceFinder3(csvpaths=csvpaths, ref=ref)
+
+
+class TestStarFlattensAcrossAllFiles:
+    # matches "creating references v3.txt"'s EXAMPLE SCENARIO exactly.
+    def test_last_across_everything_under_alpha(self):
+        finder = _finder("$alpha.files.*.:last()", ALPHA_HOME, ALPHA_MANIFEST)
+        results = finder.query()
+        assert results.files == [
+            "inputs/named_files/alpha/one.csv/0000000000abcdef.csv"
+        ]
+
+    def test_all_functions_flatten_to_last_manifest_entry(self):
+        # :all() isn't built yet, but bare "*" already exercises the
+        # same flattening behavior the spec describes for it.
+        finder = _finder("$alpha.files.*.:first()", ALPHA_HOME, ALPHA_MANIFEST)
+        results = finder.query()
+        assert results.files == [
+            "inputs/named_files/alpha/zero.csv/0000000000000000.csv"
+        ]
+
+
+class TestNameFunctionAsPathSegment:
+    def test_name_selects_one_logical_file(self):
+        finder = _finder(
+            '$alpha.files.:name("zero.csv").:first()', ALPHA_HOME, ALPHA_MANIFEST
+        )
+        assert finder.query().files == [
+            "inputs/named_files/alpha/zero.csv/0000000000000000.csv"
+        ]
+
+    def test_name_with_index(self):
+        finder = _finder(
+            '$alpha.files.:name("one.csv").:index(0)', ALPHA_HOME, ALPHA_MANIFEST
+        )
+        assert finder.query().files == [
+            "inputs/named_files/alpha/one.csv/1111111111abcdef.csv"
+        ]
+
+    def test_name_with_negative_index(self):
+        finder = _finder(
+            '$alpha.files.:name("one.csv").:index(-1)', ALPHA_HOME, ALPHA_MANIFEST
+        )
+        assert finder.query().files == [
+            "inputs/named_files/alpha/one.csv/0000000000abcdef.csv"
+        ]
+
+    def test_name_matching_nothing_returns_empty(self):
+        finder = _finder(
+            '$alpha.files.:name("nope.csv").:first()', ALPHA_HOME, ALPHA_MANIFEST
+        )
+        assert finder.query().files == []
+
+
+class TestLiteralMultiSegmentPath:
+    def test_extensionless_template_path_matches(self):
+        finder = _finder(
+            "$acme.files.Q2/test-data.:first()", TEMPLATED_HOME, TEMPLATED_MANIFEST
+        )
+        assert finder.query().files == [
+            "inputs/named_files/acme/Q2/test-data/aaaa.csv"
+        ]
+
+    def test_wrong_segment_count_does_not_match(self):
+        finder = _finder(
+            "$acme.files.Q2.:first()", TEMPLATED_HOME, TEMPLATED_MANIFEST
+        )
+        assert finder.query().files == []
+
+    def test_star_in_a_multi_segment_path(self):
+        finder = _finder(
+            "$acme.files.*/test-data.:first()", TEMPLATED_HOME, TEMPLATED_MANIFEST
+        )
+        assert finder.query().files == [
+            "inputs/named_files/acme/Q2/test-data/aaaa.csv"
+        ]
+
+
+class TestIndexOutOfRange:
+    def test_out_of_range_index_returns_empty_not_an_error(self):
+        finder = _finder("$alpha.files.*.:index(99)", ALPHA_HOME, ALPHA_MANIFEST)
+        assert finder.query().files == []
+
+
+class TestScopeLimits:
+    def test_star_root_major_not_yet_supported(self):
+        finder = _finder("$*.files.*.:last()", ALPHA_HOME, ALPHA_MANIFEST)
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_name_two_worksheet_marker_not_yet_supported(self):
+        finder = _finder(
+            '$alpha.files.*#sheet1.:last()', ALPHA_HOME, ALPHA_MANIFEST
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_functions_directly_on_name_one_not_yet_supported(self):
+        finder = _finder("$alpha.files.*:last().v1", ALPHA_HOME, ALPHA_MANIFEST)
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_unsupported_function_valued_path_segment(self):
+        finder = _finder(
+            "$acme.files.:quarter()/x.:first()", TEMPLATED_HOME, TEMPLATED_MANIFEST
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_literal_name_three_body_not_yet_supported(self):
+        finder = _finder("$alpha.files.*.v1", ALPHA_HOME, ALPHA_MANIFEST)
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_two_pointers_in_name_three_raises(self):
+        finder = _finder(
+            "$alpha.files.*.:first():last()", ALPHA_HOME, ALPHA_MANIFEST
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_extract_data_is_not_reachable_for_files(self):
+        finder = _finder("$alpha.files.*.:first()", ALPHA_HOME, ALPHA_MANIFEST)
+        with pytest.raises(ReferenceException3):
+            finder._extract_data(None)


### PR DESCRIPTION
## Summary
- `Function3` base class (`csvpath/references/functions/function_3.py`): real, behavior-having reference functions, distinct from `FunctionCall3` (the transformer's raw parsed name+arg shape). Declarative per-subclass metadata (`SUMMARY`, `ROLE`, `DATATYPES`, `ARG_TYPES`, `ARG_REQUIRED`) instead of porting `Args`/`ArgSet` — that solves multi-arg-overload problems these ≤1-arg functions don't have. `check_valid()` validates generically from that metadata; `describe()` feeds a future type-ahead registry.
- `ReferenceFunctionFactory`: name-keyed registry. `build()` compiles a `FunctionCall3` into a validated `Function3`, recursing into a nested function arg first. `build_chain()` compiles a whole function chain and enforces "at most one pointer function per chain, per nesting level" — a pointer nested inside another function's own argument does not count toward its outer chain's budget.
- Concrete functions: `First3`/`Last3` (POINTER, no arg), `Index3` (POINTER, required int arg, 0-based — the spec doc's own "index(7) means the seventh file" wording was a documentation mistake, corrected to "eighth file"), `Name3` (CONTEXT_SETTER, required str arg).
- `Name3` exists because of a real discovery made via direct testing: a literal dotted filename (`"zero.csv"`) cannot be written as a bare `name_one` path segment — `PATH_SEGMENT`'s charset excludes `.`, and `.` is the grammar's own `name_one`/`name_three` separator, so it fails to parse past that point, not just parses wrong. v1/v2 solved this with a lossy "swap `.` for `_`" convention; we used `:name("...")` instead (a quoted `STRING` already handles a literal `.` with zero ambiguity, and avoids the collision risk of the underscore approach).
- `FilesReferenceFinder3`: first concrete finder, grounded in the real on-disk manifest schema (confirmed against `FileManager`/`FileRegistrar` and a real `manifest.json` fixture, not assumed). `name_one` narrows to *which file* (literal segments, `*`, or `:name("...")`); `name_three` must reduce, via `build_chain()`, to exactly one pointer function that narrows *which version* — matching the STRUCTURE table's division of labor. Deliberately out of scope for this pass (each raises a clear `ReferenceException3`): `root_major == "*"`, the `#worksheet` marker, function-valued `name_one` segments other than `:name()`, and a literal `name_three` body.

## Test plan
- [x] `tests/references/` — 286 tests, all passing
- [x] Full suite — 1866 passed, 11 failed (known SFTP/S3/remote-backend baseline, unrelated to this change)
- [x] `FilesReferenceFinder3` verified directly against the spec's own EXAMPLE SCENARIO in "creating references v3.txt" (`$alpha.files.*.:last()` resolves to the exact file the spec says it should)
