### PR TITLE
References v3: name_three optional everywhere, resolve_kind, bare-* rule, file-home dedup

### DIFF
--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -23,11 +23,13 @@ class FilesReferenceFinder3(ReferenceFinder3):
     #    STRUCTURE table: name_one picks *which file*, name_three picks
     #    *which version*. A literal name_three body (bypassing a
     #    pointer function entirely) is not yet supported. name_three is
-    #    optional (per the STRUCTURE section's later update): when
-    #    absent, name_one alone is the whole reference and query()
-    #    returns every version currently matched, not narrowed to one --
-    #    mirrors the analogous csvpaths case, which the STRUCTURE table
-    #    describes explicitly as "a list of (path, uuid)".
+    #    optional: when absent, name_one alone is a prefix search that
+    #    returns zero or more paths to file-home directories (one per
+    #    distinct file matched, deduplicated across versions) -- per
+    #    "creating references v3.txt"'s "Query Vs. Resolve" section.
+    #    These directory-level results carry uuid=None: a directory
+    #    isn't a specific registered version, so it has no uuid of its
+    #    own in the manifest schema.
     #
     # storage facts this relies on (confirmed against FileManager/
     # FileRegistrar and a real manifest.json, not assumed): a named-
@@ -69,10 +71,14 @@ class FilesReferenceFinder3(ReferenceFinder3):
 
         name_three = reference.name_three
         if name_three is None:
+            file_homes = []
+            for entry in candidates:
+                if entry["file_home"] not in file_homes:
+                    file_homes.append(entry["file_home"])
             return ReferenceResults3(
                 results=[
-                    ReferenceResult3(path=entry["file"], uuid=entry["uuid"])
-                    for entry in candidates
+                    ReferenceResult3(path=file_home, uuid=None)
+                    for file_home in file_homes
                 ]
             )
 
@@ -100,8 +106,16 @@ class FilesReferenceFinder3(ReferenceFinder3):
         return ReferenceResults3(results=results)
 
     def _extract_data(self, result: ReferenceResult3):
-        kind = self.ref.parsed.resolve_kind
+        reference = self.ref.parsed
+        kind = reference.resolve_kind
         if kind == Reference3.FIRST_PARTY:
+            if reference.name_three is None:
+                # name_one-terminal (prefix search) result: result.path
+                # is a file-home directory, not a version file -- no
+                # single unambiguous payload to return, per "creating
+                # references v3.txt"'s "Resolve terminating at
+                # name_one, with no pointer: no default" rule.
+                return None
             with DataFileReader(path=result.path, mode="rb") as reader:
                 return reader.source.read()
         raise ReferenceException3(

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -1,6 +1,8 @@
+from csvpath.util.file_readers import DataFileReader
+
 from .functions.function_3 import Function3
 from .functions.reference_function_factory_3 import ReferenceFunctionFactory
-from .reference_3 import FunctionCall3, Star3
+from .reference_3 import FunctionCall3, Reference3, Star3
 from .reference_exceptions_3 import ReferenceException3
 from .reference_finder_3 import ReferenceFinder3
 from .reference_results_3 import ReferenceResult3, ReferenceResults3
@@ -16,11 +18,16 @@ class FilesReferenceFinder3(ReferenceFinder3):
     #    "." -- that cannot appear in a bare PATH_SEGMENT). any other
     #    function-valued segment (e.g. :quarter()) and the "#worksheet"
     #    marker (name_two) are not yet supported.
-    #  - name_three must resolve to exactly one pointer function
-    #    (:first()/:last()/:index(n)). This matches the STRUCTURE table:
-    #    name_one picks *which file*, name_three picks *which version*.
-    #    A literal name_three body (bypassing a pointer function
-    #    entirely) is not yet supported either.
+    #  - name_three, if present, must resolve to exactly one pointer
+    #    function (:first()/:last()/:index(n)) -- matching the
+    #    STRUCTURE table: name_one picks *which file*, name_three picks
+    #    *which version*. A literal name_three body (bypassing a
+    #    pointer function entirely) is not yet supported. name_three is
+    #    optional (per the STRUCTURE section's later update): when
+    #    absent, name_one alone is the whole reference and query()
+    #    returns every version currently matched, not narrowed to one --
+    #    mirrors the analogous csvpaths case, which the STRUCTURE table
+    #    describes explicitly as "a list of (path, uuid)".
     #
     # storage facts this relies on (confirmed against FileManager/
     # FileRegistrar and a real manifest.json, not assumed): a named-
@@ -54,7 +61,21 @@ class FilesReferenceFinder3(ReferenceFinder3):
             )
         pattern = self._compile_path_pattern(name_one.path)
 
+        manifest = self.csvpaths.file_manager.get_manifest(root_major)
+        home = self.csvpaths.file_manager.named_file_home(root_major).rstrip("/")
+        candidates = [
+            entry for entry in manifest if self._matches(entry, home, pattern)
+        ]
+
         name_three = reference.name_three
+        if name_three is None:
+            return ReferenceResults3(
+                results=[
+                    ReferenceResult3(path=entry["file"], uuid=entry["uuid"])
+                    for entry in candidates
+                ]
+            )
+
         if name_three.body is not None:
             raise ReferenceException3(
                 "FilesReferenceFinder3 does not yet support a literal name_three "
@@ -70,12 +91,6 @@ class FilesReferenceFinder3(ReferenceFinder3):
             )
         pointer = pointers[0]
 
-        manifest = self.csvpaths.file_manager.get_manifest(root_major)
-        home = self.csvpaths.file_manager.named_file_home(root_major).rstrip("/")
-        candidates = [
-            entry for entry in manifest if self._matches(entry, home, pattern)
-        ]
-
         selected = self._apply_pointer(pointer, candidates)
         results = []
         if selected is not None:
@@ -85,10 +100,14 @@ class FilesReferenceFinder3(ReferenceFinder3):
         return ReferenceResults3(results=results)
 
     def _extract_data(self, result: ReferenceResult3):
+        kind = self.ref.parsed.resolve_kind
+        if kind == Reference3.FIRST_PARTY:
+            with DataFileReader(path=result.path, mode="rb") as reader:
+                return reader.source.read()
         raise ReferenceException3(
-            "FilesReferenceFinder3 has no content to extract from -- "
-            "resolves_to_data should always be False for the files datatype "
-            "with the functions currently registered."
+            f"FilesReferenceFinder3 does not yet support resolve_kind={kind!r} "
+            "-- no metadata-file/metadata-field functions are registered for "
+            "files yet."
         )
 
     @staticmethod

--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -1,3 +1,5 @@
+from .reference_exceptions_3 import ReferenceException3
+
 #
 # object graph built by Reference3Transformer (reference_transformer_3.py)
 # from a references-v3 parse tree (see reference_grammar_3.py). these are
@@ -295,13 +297,39 @@ class Reference3:
     def check_valid(self) -> None:
         """structural check, called explicitly by ReferenceParser3
         right after the transformer builds this object -- not from
-        __init__, so that a violation would raise ReferenceException3
-        as itself rather than being wrapped in lark's VisitError (which
-        is what happens to any exception raised from inside a
-        Transformer rule method). nothing to check right now -- kept
-        as a hook for whatever semantic rule comes next, matching
-        matchable.py's Matchable.check_valid(), which is also a no-op
-        at the base level."""
+        __init__, so that a violation raises ReferenceException3 as
+        itself rather than being wrapped in lark's VisitError (which is
+        what happens to any exception raised from inside a Transformer
+        rule method).
+
+        one rule so far: a bare "*" cannot be the terminal element of a
+        reference. "*" is a fragment -- "any of the data that ___" --
+        and needs something after it to complete the sentence:
+        :all() does NOT have this problem ("get me all of them!" is
+        already a complete instruction, not a dangling clause -- * and
+        :all() are not equivalent, see reference_grammar_3.py). A
+        literal path segment doesn't have this problem either, since
+        naming an exact thing isn't matching against an open set to
+        begin with. So the only violation is: no name_three, no
+        trailing function chain of its own on name_one, AND name_one's
+        own last path segment is a bare "*" -- e.g. "$alpha.files.*" is
+        illegal, but "$alpha.files.*/orders" (more path completes it),
+        "$alpha.files.*:first()" (name_one's own chain completes it),
+        "$alpha.files.*.:first()" (name_three completes it), and
+        "$alpha.files.:all()" (already complete on its own) are all
+        fine."""
+        if (
+            self._name_three is None
+            and not self._name_one.functions
+            and isinstance(self._name_one.path[-1], Star3)
+        ):
+            msg = (
+                "A bare '*' cannot be the last element of a reference -- "
+                "it needs a function (on name_one or name_three) or more "
+                "path to complete it, e.g. '*:first()' or '*.name_three', "
+                "not '*' alone."
+            )
+            raise ReferenceException3(msg)
 
     @property
     def root_major(self):

--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -1,8 +1,3 @@
-import logging
-
-from .reference_exceptions_3 import ReferenceException3
-
-
 #
 # object graph built by Reference3Transformer (reference_transformer_3.py)
 # from a references-v3 parse tree (see reference_grammar_3.py). these are
@@ -119,7 +114,7 @@ class FunctionCall3:
         """true if this function, or any function nested in its
         argument chain, is named `name`. a purely structural query --
         no function-registry knowledge involved. see Reference3.
-        resolves_to_data for what this is used for."""
+        resolve_kind for what this is used for."""
         if self._name == name:
             return True
         if isinstance(self._arg, FunctionCall3):
@@ -223,41 +218,60 @@ class NameThree3:
 # PLACEHOLDER pending the real function registry (see "requirements for
 # functions.txt" -- functions are looked up/validated at runtime by a
 # registry that does not exist yet). Once it does, this belongs on
-# Function3 itself as self-description metadata (each function will
-# self-report whether it is a "context setter" or a "pointer" -- see
-# that doc), not here as a bare name list.
+# Function3 itself as self-description metadata, not here as bare name
+# lists.
 #
-# there is no separate "value extracting" category of function: a
-# pointer resolves the current scope to exactly 0 or 1 item, full stop.
-# in name_one that item is a physical file/version/run; in name_three
-# it is a well-known file (e.g. :errors()) UNLESS that pointer itself
-# takes another pointer as its argument, in which case the outer
-# pointer resolves to a specific value inside the file rather than the
-# file as a whole (e.g. :errors(:idchain("add[0]string[2]"))). so what
-# this constant actually names is: pointer functions currently known to
-# be used this way -- nested inside another function, in name_three,
-# meaning "a value" rather than "a file." it is deliberately NOT "any
-# pointer nested inside another function" -- name_one already nests
-# pointers inside functions all the time for ordinary version/range
-# selection (e.g. :from(:index(0)) is still picking a file/version, not
-# extracting a value), and name_three may end up doing the same for its
-# own result-file listing once more functions exist. this list will be
-# replaced by real trait lookups once Function3 exists; treat it as
-# provisional, not as a general rule for "nested pointer means value."
+# per "creating references v3.txt"'s "Query vs. Resolve" section, a
+# reference resolves to exactly one of three things:
+#   - first-party data: the actual underlying bytes/content, when no
+#     function points at metadata at all (e.g. a plain files reference
+#     with no special function -- resolves to the version file's raw
+#     bytes).
+#   - a whole metadata file: when a function names a known metadata
+#     file (e.g. :errors(), or an arbitrary-named one via :file(...))
+#     with no further drilling.
+#   - one metadata field: when that metadata-file function itself takes
+#     another pointer as its argument, to pull one value out of the
+#     file rather than the file as a whole (e.g.
+#     :errors(:idchain("add[0]string[2]"))).
 #
-_CONTENT_POINTER_FUNCTIONS = ("idchain",)
+# these two lists are deliberately narrow placeholders, not a general
+# rule -- e.g. _METADATA_FIELD_FUNCTIONS is NOT "any nested function
+# arg": name_one already nests pointers inside functions all the time
+# for ordinary version/range selection (:from(:index(0)) is still
+# picking a file/version, not extracting a value). both lists will be
+# replaced by real per-function trait lookups once Function3 exists.
+#
+_METADATA_FILE_FUNCTIONS = (
+    "errors",
+    "vars",
+    "meta",
+    "data",
+    "unmatched",
+    "file",
+    "definition",
+    "manifest",
+)
+_METADATA_FIELD_FUNCTIONS = ("idchain",)
 
 
 class Reference3:
     """the parsed object graph for one references-v3 reference. holds no
-    execution context (see ReferenceParser3 for that) -- just the parsed
-    shape, validated against the datatype-dependent name_three
-    requirement the grammar deliberately leaves out (see
-    reference_grammar_3.py's module docstring)."""
+    execution context (see ReferenceParser3 for that) -- just the
+    parsed shape. name_three is optional for every datatype (per the
+    STRUCTURE section of "creating references v3.txt": name_one alone
+    is a legal, resolvable reference on its own -- there is no
+    datatype-dependent name_three requirement to enforce here anymore;
+    check_valid() is kept as a hook for whatever semantic checks come
+    next, not removed outright)."""
 
     FILES = "files"
     CSVPATHS = "csvpaths"
     RESULTS = "results"
+
+    FIRST_PARTY = "first_party"
+    METADATA_FILE = "metadata_file"
+    METADATA_FIELD = "metadata_field"
 
     def __init__(
         self,
@@ -279,22 +293,15 @@ class Reference3:
         self._name_three = name_three
 
     def check_valid(self) -> None:
-        """structural check deferred out of the grammar (see
-        reference_grammar_3.py's module docstring): name_three is
-        required for files/csvpaths, optional for results. called
-        explicitly by ReferenceParser3 right after the transformer
-        builds this object -- not from __init__, so that a violation
-        raises ReferenceException3 as itself rather than being wrapped
-        in lark's VisitError (which is what happens to any exception
-        raised from inside a Transformer rule method)."""
-        if self._name_three is None and self._datatype in (
-            Reference3.FILES,
-            Reference3.CSVPATHS,
-        ):
-            logger = logging.getLogger(self.__class__.__name__)
-            msg = f"name_three is required for datatype '{self._datatype}'"
-            logger.error(msg)
-            raise ReferenceException3(msg)
+        """structural check, called explicitly by ReferenceParser3
+        right after the transformer builds this object -- not from
+        __init__, so that a violation would raise ReferenceException3
+        as itself rather than being wrapped in lark's VisitError (which
+        is what happens to any exception raised from inside a
+        Transformer rule method). nothing to check right now -- kept
+        as a hook for whatever semantic rule comes next, matching
+        matchable.py's Matchable.check_valid(), which is also a no-op
+        at the base level."""
 
     @property
     def root_major(self):
@@ -313,19 +320,32 @@ class Reference3:
         return self._name_three
 
     @property
-    def resolves_to_data(self) -> bool:
-        """does this reference ask for a specific value inside a
-        well-known file (True), or the file/thing as-is (False)? see
-        the _CONTENT_POINTER_FUNCTIONS placeholder comment above -- this
-        is a stand-in for a trait the future function registry will
-        own (a pointer nested inside another pointer, in name_three)."""
-        if self._name_three is None:
-            return False
-        return any(
-            f.contains_function_named(name)
-            for f in self._name_three.functions
-            for name in _CONTENT_POINTER_FUNCTIONS
+    def resolve_kind(self) -> str:
+        """which of the three resolve outcomes this reference asks for
+        -- FIRST_PARTY (the underlying bytes/content, the default),
+        METADATA_FILE (a whole well-known/named file), or
+        METADATA_FIELD (one value drilled out of such a file). computed
+        from whichever function chain is terminal: name_three's if
+        name_three is present, else name_one's own trailing chain (a
+        legal terminus now that name_three is optional everywhere).
+        see the _METADATA_FILE_FUNCTIONS/_METADATA_FIELD_FUNCTIONS
+        placeholder comment above -- both lists are stand-ins for traits
+        the future function registry will own."""
+        terminal_functions = (
+            self._name_three.functions
+            if self._name_three is not None
+            else self._name_one.functions
         )
+        for f in terminal_functions:
+            if any(
+                f.contains_function_named(name)
+                for name in _METADATA_FIELD_FUNCTIONS
+            ):
+                return Reference3.METADATA_FIELD
+        for f in terminal_functions:
+            if f.name in _METADATA_FILE_FUNCTIONS:
+                return Reference3.METADATA_FILE
+        return Reference3.FIRST_PARTY
 
     def __eq__(self, other) -> bool:
         return (

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -56,16 +56,15 @@ class ReferenceFinder3(ABC):
             results = selection
         else:
             results = self.query().select(selection)
-        if not self.ref.parsed.resolves_to_data:
-            return results
         for result in results.results:
             result.data = self._extract_data(result)
         return results
 
     @abstractmethod
     def _extract_data(self, result: ReferenceResult3):
-        """pulls the specific value this reference's terminal function
-        chain asks for (see Reference3.resolves_to_data) out of the
-        well-known file at result.path. datatype-specific -- reading
-        errors.json vs vars.json vs a csv payload differs enough there
-        is no generic implementation."""
+        """returns whatever this reference's resolve_kind calls for --
+        first-party data (raw bytes/content), a whole metadata file, or
+        one metadata field (see Reference3.resolve_kind) -- for the
+        given already-queried result. datatype-specific -- reading raw
+        file bytes vs errors.json vs vars.json differs enough there is
+        no generic implementation."""

--- a/csvpath/references/reference_results_3.py
+++ b/csvpath/references/reference_results_3.py
@@ -15,11 +15,15 @@ from uuid import UUID
 
 
 class ReferenceResult3:
-    def __init__(self, *, path: str, uuid: str, data: Any = None) -> None:
+    def __init__(self, *, path: str, uuid: str | None, data: Any = None) -> None:
         if not path:
             raise ValueError("ReferenceResult3 path cannot be None or empty")
-        if not uuid:
-            raise ValueError("ReferenceResult3 uuid cannot be None or empty")
+        if uuid is not None and not uuid:
+            raise ValueError(
+                "ReferenceResult3 uuid cannot be empty -- use None if there "
+                "is no uuid (e.g. a directory-level, name_three-absent result "
+                "has no single version/registration to identify)"
+            )
         self._path = path
         self._uuid = uuid
         self._data = data
@@ -29,7 +33,7 @@ class ReferenceResult3:
         return self._path
 
     @property
-    def uuid(self) -> str:
+    def uuid(self) -> str | None:
         return self._uuid
 
     @property
@@ -70,7 +74,7 @@ class ReferenceResults3:
         return [r.path for r in self._results]
 
     @property
-    def uuids(self) -> list[str]:
+    def uuids(self) -> list[str | None]:
         return [r.uuid for r in self._results]
 
     def file_for_uuid(self, uuid: str | UUID) -> str | None:

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -3,6 +3,7 @@ import pytest
 from csvpath.references.files_reference_finder_3 import FilesReferenceFinder3
 from csvpath.references.reference_exceptions_3 import ReferenceException3
 from csvpath.references.reference_parser_3 import ReferenceParser3
+from csvpath.references.reference_results_3 import ReferenceResult3
 
 
 #
@@ -146,6 +147,29 @@ class TestIndexOutOfRange:
         assert finder.query().files == []
 
 
+class TestNameThreeAbsent:
+    # name_three is optional now (STRUCTURE section update): name_one
+    # alone is a legal reference, and returns every version it matched
+    # rather than narrowing to one -- mirrors how the STRUCTURE table
+    # describes the analogous csvpaths case as "a list of (path, uuid)".
+    def test_name_one_alone_returns_every_matched_version(self):
+        finder = _finder("$alpha.files.*", ALPHA_HOME, ALPHA_MANIFEST)
+        results = finder.query()
+        assert results.files == [
+            "inputs/named_files/alpha/zero.csv/0000000000000000.csv",
+            "inputs/named_files/alpha/one.csv/1111111111abcdef.csv",
+            "inputs/named_files/alpha/one.csv/0000000000abcdef.csv",
+        ]
+
+    def test_name_one_alone_narrowed_by_name_function(self):
+        finder = _finder('$alpha.files.:name("one.csv")', ALPHA_HOME, ALPHA_MANIFEST)
+        results = finder.query()
+        assert results.files == [
+            "inputs/named_files/alpha/one.csv/1111111111abcdef.csv",
+            "inputs/named_files/alpha/one.csv/0000000000abcdef.csv",
+        ]
+
+
 class TestScopeLimits:
     def test_star_root_major_not_yet_supported(self):
         finder = _finder("$*.files.*.:last()", ALPHA_HOME, ALPHA_MANIFEST)
@@ -183,7 +207,39 @@ class TestScopeLimits:
         with pytest.raises(ReferenceException3):
             finder.query()
 
-    def test_extract_data_is_not_reachable_for_files(self):
-        finder = _finder("$alpha.files.*.:first()", ALPHA_HOME, ALPHA_MANIFEST)
+
+class TestExtractData:
+    def test_first_party_returns_raw_file_bytes(self, tmp_path):
+        # resolve_kind is FIRST_PARTY by default (no metadata-file/
+        # field function present) -- resolving a plain files reference
+        # should give the version file's actual raw bytes.
+        content = b"a,b\n1,2\n"
+        file_path = tmp_path / "0000000000000000.csv"
+        file_path.write_bytes(content)
+        manifest = [
+            {
+                "file": str(file_path),
+                "file_home": f"{ALPHA_HOME}/zero.csv",
+                "uuid": "u-zero-1",
+            }
+        ]
+        finder = _finder("$alpha.files.*.:first()", ALPHA_HOME, manifest)
+        results = finder.resolve()
+        assert results.results[0].data == content
+
+    def test_metadata_file_kind_not_yet_supported(self):
+        # :meta() is not a registered function yet, so a real
+        # query()/resolve() would already reject this reference earlier
+        # (unknown function, in build_chain()). calling _extract_data()
+        # directly tests its own resolve_kind branching in isolation,
+        # ahead of any metadata-file function actually existing.
+        finder = _finder("$alpha.files.*.:meta()", ALPHA_HOME, ALPHA_MANIFEST)
         with pytest.raises(ReferenceException3):
-            finder._extract_data(None)
+            finder._extract_data(ReferenceResult3(path="p", uuid="u"))
+
+    def test_metadata_field_kind_not_yet_supported(self):
+        finder = _finder(
+            '$alpha.files.*.:meta(:idchain("a[0]"))', ALPHA_HOME, ALPHA_MANIFEST
+        )
+        with pytest.raises(ReferenceException3):
+            finder._extract_data(ReferenceResult3(path="p", uuid="u"))

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -148,14 +148,15 @@ class TestIndexOutOfRange:
 
 
 class TestNameThreeAbsent:
-    # name_three is optional now (STRUCTURE section update): name_one
-    # alone is a legal reference when it is already narrowed to one
-    # specific thing (a literal name or :name(...)) -- it returns every
-    # version it matched rather than narrowing to one. A bare,
-    # unqualified "*" with nothing else is NOT one of these cases --
-    # see test_star_alone_is_rejected_before_the_finder_even_runs below
-    # -- Reference3.check_valid() rejects it at construction, before
-    # the finder ever gets a chance to query().
+    # name_three is optional now: name_one alone is a prefix search that
+    # returns zero or more paths to file-home directories -- one per
+    # distinct file matched, deduplicated across versions, each with
+    # uuid=None (a directory isn't a specific registered version, so it
+    # has no uuid of its own). A bare, unqualified "*" with nothing else
+    # is NOT one of these cases -- see
+    # test_star_alone_is_rejected_before_the_finder_even_runs below --
+    # Reference3.check_valid() rejects it at construction, before the
+    # finder ever gets a chance to query().
     def test_star_alone_is_rejected_before_the_finder_even_runs(self):
         with pytest.raises(ReferenceException3):
             _finder("$alpha.files.*", ALPHA_HOME, ALPHA_MANIFEST)
@@ -163,10 +164,16 @@ class TestNameThreeAbsent:
     def test_name_one_alone_narrowed_by_name_function(self):
         finder = _finder('$alpha.files.:name("one.csv")', ALPHA_HOME, ALPHA_MANIFEST)
         results = finder.query()
-        assert results.files == [
-            "inputs/named_files/alpha/one.csv/1111111111abcdef.csv",
-            "inputs/named_files/alpha/one.csv/0000000000abcdef.csv",
-        ]
+        assert results.files == ["inputs/named_files/alpha/one.csv"]
+        assert results.results[0].uuid is None
+
+    def test_resolving_a_name_one_terminal_result_gives_none(self):
+        # "no default" per "creating references v3.txt"'s "Resolve
+        # terminating at name_one, with no pointer" rule -- a directory
+        # has no single unambiguous first-party payload.
+        finder = _finder('$alpha.files.:name("one.csv")', ALPHA_HOME, ALPHA_MANIFEST)
+        results = finder.resolve()
+        assert results.results[0].data is None
 
 
 class TestScopeLimits:

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -149,17 +149,16 @@ class TestIndexOutOfRange:
 
 class TestNameThreeAbsent:
     # name_three is optional now (STRUCTURE section update): name_one
-    # alone is a legal reference, and returns every version it matched
-    # rather than narrowing to one -- mirrors how the STRUCTURE table
-    # describes the analogous csvpaths case as "a list of (path, uuid)".
-    def test_name_one_alone_returns_every_matched_version(self):
-        finder = _finder("$alpha.files.*", ALPHA_HOME, ALPHA_MANIFEST)
-        results = finder.query()
-        assert results.files == [
-            "inputs/named_files/alpha/zero.csv/0000000000000000.csv",
-            "inputs/named_files/alpha/one.csv/1111111111abcdef.csv",
-            "inputs/named_files/alpha/one.csv/0000000000abcdef.csv",
-        ]
+    # alone is a legal reference when it is already narrowed to one
+    # specific thing (a literal name or :name(...)) -- it returns every
+    # version it matched rather than narrowing to one. A bare,
+    # unqualified "*" with nothing else is NOT one of these cases --
+    # see test_star_alone_is_rejected_before_the_finder_even_runs below
+    # -- Reference3.check_valid() rejects it at construction, before
+    # the finder ever gets a chance to query().
+    def test_star_alone_is_rejected_before_the_finder_even_runs(self):
+        with pytest.raises(ReferenceException3):
+            _finder("$alpha.files.*", ALPHA_HOME, ALPHA_MANIFEST)
 
     def test_name_one_alone_narrowed_by_name_function(self):
         finder = _finder('$alpha.files.:name("one.csv")', ALPHA_HOME, ALPHA_MANIFEST)

--- a/tests/references/test_reference_3.py
+++ b/tests/references/test_reference_3.py
@@ -9,6 +9,7 @@ from csvpath.references.reference_3 import (
     Star3,
     Variable3,
 )
+from csvpath.references.reference_exceptions_3 import ReferenceException3
 
 
 #
@@ -246,6 +247,68 @@ class TestReference3:
             datatype=Reference3.FILES,
             name_one=self._name_one("a"),
             name_three=NameThree3(body="v1"),
+        )
+        r.check_valid()  # should not raise
+
+    def test_check_valid_rejects_bare_trailing_star(self):
+        # "*" alone: "any of the data that ___" with nothing to
+        # complete it -- no name_three, no trailing function on
+        # name_one, and the star is name_one's last path segment.
+        r = Reference3(
+            root_major="acme", datatype=Reference3.FILES, name_one=self._name_one(Star3())
+        )
+        with pytest.raises(ReferenceException3):
+            r.check_valid()
+
+    def test_check_valid_rejects_star_trailing_after_a_literal_segment(self):
+        # the star being last is what matters, not whether it is alone
+        # -- "orders/*" still dangles the same way "*" does.
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.FILES,
+            name_one=self._name_one("orders", Star3()),
+        )
+        with pytest.raises(ReferenceException3):
+            r.check_valid()
+
+    def test_check_valid_allows_star_followed_by_a_literal_segment(self):
+        # "*/orders" completes the sentence with the literal segment
+        # that follows the star -- only a *trailing*, un-followed star
+        # is a problem.
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.FILES,
+            name_one=self._name_one(Star3(), "orders"),
+        )
+        r.check_valid()  # should not raise
+
+    def test_check_valid_allows_star_with_name_ones_own_trailing_function(self):
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.FILES,
+            name_one=NameOne3(
+                path=[Star3()], functions=[FunctionCall3(name="first")]
+            ),
+        )
+        r.check_valid()  # should not raise
+
+    def test_check_valid_allows_star_with_name_three(self):
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.FILES,
+            name_one=self._name_one(Star3()),
+            name_three=NameThree3(functions=[FunctionCall3(name="first")]),
+        )
+        r.check_valid()  # should not raise
+
+    def test_check_valid_allows_bare_all_function(self):
+        # :all() is not equivalent to "*" -- it is already a complete
+        # instruction ("get me all of them!"), not a dangling clause,
+        # so it is fine bare with no name_three and no other function.
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.FILES,
+            name_one=self._name_one(FunctionCall3(name="all")),
         )
         r.check_valid()  # should not raise
 

--- a/tests/references/test_reference_3.py
+++ b/tests/references/test_reference_3.py
@@ -9,7 +9,6 @@ from csvpath.references.reference_3 import (
     Star3,
     Variable3,
 )
-from csvpath.references.reference_exceptions_3 import ReferenceException3
 
 
 #
@@ -228,19 +227,16 @@ class TestReference3:
         with pytest.raises(ValueError):
             Reference3(root_major="acme", datatype=Reference3.FILES, name_one=None)
 
-    @pytest.mark.parametrize("datatype", [Reference3.FILES, Reference3.CSVPATHS])
-    def test_check_valid_requires_name_three_for_files_and_csvpaths(self, datatype):
+    @pytest.mark.parametrize(
+        "datatype", [Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS]
+    )
+    def test_check_valid_allows_missing_name_three_for_every_datatype(self, datatype):
+        # name_three is optional everywhere (per "creating references
+        # v3.txt"'s STRUCTURE section) -- name_one alone is a legal,
+        # resolvable reference on its own for files/csvpaths too now,
+        # not just results.
         r = Reference3(
             root_major="acme", datatype=datatype, name_one=self._name_one("a")
-        )
-        with pytest.raises(ReferenceException3):
-            r.check_valid()
-
-    def test_check_valid_allows_missing_name_three_for_results(self):
-        r = Reference3(
-            root_major="acme",
-            datatype=Reference3.RESULTS,
-            name_one=self._name_one("a"),
         )
         r.check_valid()  # should not raise
 
@@ -292,26 +288,42 @@ class TestReference3:
         assert a != c
 
 
-class TestResolvesToData:
-    def _name_one(self, *path):
-        return NameOne3(path=list(path))
+class TestResolveKind:
+    def _name_one(self, *path, functions=None):
+        return NameOne3(path=list(path), functions=functions)
 
-    def test_false_when_no_name_three(self):
+    def test_first_party_when_no_name_three_and_no_name_one_functions(self):
         r = Reference3(
             root_major="acme", datatype=Reference3.RESULTS, name_one=self._name_one("a")
         )
-        assert r.resolves_to_data is False
+        assert r.resolve_kind == Reference3.FIRST_PARTY
 
-    def test_false_for_plain_well_known_file_function(self):
+    def test_first_party_for_ordinary_selector_function_with_nested_arg(self):
+        # :from(:index(0)) is still a version/range selector, not a
+        # value extraction -- a nested function arg alone must not
+        # trigger anything beyond FIRST_PARTY.
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.FILES,
+            name_one=self._name_one("a"),
+            name_three=NameThree3(
+                functions=[
+                    FunctionCall3(name="from", arg=FunctionCall3(name="index", arg=0))
+                ]
+            ),
+        )
+        assert r.resolve_kind == Reference3.FIRST_PARTY
+
+    def test_metadata_file_for_plain_well_known_file_function(self):
         r = Reference3(
             root_major="acme",
             datatype=Reference3.RESULTS,
             name_one=self._name_one("a"),
             name_three=NameThree3(functions=[FunctionCall3(name="errors")]),
         )
-        assert r.resolves_to_data is False
+        assert r.resolve_kind == Reference3.METADATA_FILE
 
-    def test_true_when_value_locator_nested_in_terminal_function(self):
+    def test_metadata_field_when_value_locator_nested_in_terminal_function(self):
         r = Reference3(
             root_major="acme",
             datatype=Reference3.RESULTS,
@@ -325,20 +337,15 @@ class TestResolvesToData:
                 ]
             ),
         )
-        assert r.resolves_to_data is True
+        assert r.resolve_kind == Reference3.METADATA_FIELD
 
-    def test_false_for_ordinary_selector_function_with_nested_arg(self):
-        # :from(:index(0)) is still a version/range selector, not a
-        # value extraction -- a nested function arg alone must not
-        # trigger resolves_to_data.
+    def test_uses_name_one_functions_when_name_three_is_absent(self):
+        # name_one alone is now a legal terminus (name_three optional
+        # everywhere), so its own trailing function chain is what
+        # resolve_kind must inspect when there is no name_three.
         r = Reference3(
             root_major="acme",
             datatype=Reference3.FILES,
-            name_one=self._name_one("a"),
-            name_three=NameThree3(
-                functions=[
-                    FunctionCall3(name="from", arg=FunctionCall3(name="index", arg=0))
-                ]
-            ),
+            name_one=self._name_one("a", functions=[FunctionCall3(name="errors")]),
         )
-        assert r.resolves_to_data is False
+        assert r.resolve_kind == Reference3.METADATA_FILE

--- a/tests/references/test_reference_finder_3.py
+++ b/tests/references/test_reference_finder_3.py
@@ -54,27 +54,12 @@ class TestConstruction:
         assert f.csvpaths is CSVPATHS
 
 
-class TestResolveWithoutDataExtraction:
-    # "$acme.results.a.:errors()" -- a plain well-known-file function,
-    # no value-locator nested in it, so resolves_to_data is False.
-    def test_resolve_leaves_data_none(self):
-        f = _DummyFinder(csvpaths=CSVPATHS, ref=_ref("$acme.results.a.:errors()"))
-        results = f.resolve()
-        assert results.files == ["p1", "p2"]
-        assert all(r.data is None for r in results.results)
-
-    def test_resolve_from_list_narrows_without_extracting(self):
-        f = _DummyFinder(csvpaths=CSVPATHS, ref=_ref("$acme.results.a.:errors()"))
-        results = f.resolve_from(["p1"])
-        assert results.files == ["p1"]
-        assert results.results[0].data is None
-        assert f.query_call_count == 1
-
-
-class TestResolveWithDataExtraction:
-    # ":errors(:idchain(...))" -- a value-locator nested in the
-    # well-known-file function's arg, so resolves_to_data is True.
-    REF = '$acme.results.a.:errors(:idchain("add[0]string[2]"))'
+class TestResolve:
+    # resolve_from() always calls _extract_data() for every result now
+    # -- the old resolves_to_data gate is gone from the ABC (it moved
+    # into what each concrete finder's own _extract_data() does with
+    # Reference3.resolve_kind, not whether it gets called at all).
+    REF = "$acme.results.a"
 
     def test_resolve_extracts_data_for_every_result(self):
         f = _DummyFinder(csvpaths=CSVPATHS, ref=_ref(self.REF))
@@ -82,11 +67,11 @@ class TestResolveWithDataExtraction:
         assert results.data_for_uuid("u1") == "data-for-p1"
         assert results.data_for_uuid("u2") == "data-for-p2"
 
-    def test_resolve_from_narrows_then_only_extracts_the_selection(self):
+    def test_resolve_from_list_narrows_then_only_extracts_the_selection(self):
         f = _DummyFinder(csvpaths=CSVPATHS, ref=_ref(self.REF))
-        results = f.resolve_from(["u2"])
-        assert results.files == ["p2"]
-        assert results.results[0].data == "data-for-p2"
+        results = f.resolve_from(["p1"])
+        assert results.files == ["p1"]
+        assert results.results[0].data == "data-for-p1"
         assert f.query_call_count == 1
 
     def test_resolve_from_a_results3_does_not_requery(self):

--- a/tests/references/test_reference_parser_3.py
+++ b/tests/references/test_reference_parser_3.py
@@ -1,7 +1,6 @@
 import pytest
 
 from csvpath.references.reference_3 import Reference3
-from csvpath.references.reference_exceptions_3 import ReferenceException3
 from csvpath.references.reference_parser_3 import ReferenceParser3
 
 #
@@ -127,23 +126,16 @@ class TestProperties:
         assert isinstance(r.parsed, Reference3)
 
 
-class TestNameThreeRequiredness:
-    @pytest.mark.parametrize("datatype", ["files", "csvpaths"])
-    def test_missing_name_three_raises_for_files_and_csvpaths(self, datatype):
-        with pytest.raises(ReferenceException3):
-            ReferenceParser3(string=f"$acme.{datatype}.a", csvpaths=CSVPATHS)
-
-    def test_missing_name_three_is_fine_for_results(self):
-        r = ReferenceParser3(string="$acme.results.a", csvpaths=CSVPATHS)
+class TestNameThreeOptional:
+    # name_three is optional for every datatype (per "creating
+    # references v3.txt"'s STRUCTURE section) -- name_one alone is a
+    # legal, resolvable reference on its own. check_valid() is still
+    # called by parse() after the transform completes, outside
+    # Transformer.transform()'s own call stack, on principle (so that
+    # if a future semantic rule gets added there, it surfaces as
+    # ReferenceException3 itself rather than wrapped in lark's
+    # VisitError) -- there is just nothing that rule currently rejects.
+    @pytest.mark.parametrize("datatype", ["files", "csvpaths", "results"])
+    def test_missing_name_three_is_fine_for_every_datatype(self, datatype):
+        r = ReferenceParser3(string=f"$acme.{datatype}.a", csvpaths=CSVPATHS)
         assert r.name_three is None
-
-    def test_reference_exception_is_not_wrapped_by_lark(self):
-        # regression: check_valid() runs outside Transformer.transform(),
-        # specifically so a violation surfaces as ReferenceException3
-        # itself, not wrapped in lark.exceptions.VisitError.
-        try:
-            ReferenceParser3(string="$acme.files.a", csvpaths=CSVPATHS)
-        except ReferenceException3:
-            pass
-        else:
-            pytest.fail("expected ReferenceException3")

--- a/tests/references/test_reference_results_3.py
+++ b/tests/references/test_reference_results_3.py
@@ -9,10 +9,16 @@ class TestReferenceResult3:
         with pytest.raises(ValueError):
             ReferenceResult3(path=bad_path, uuid="u1")
 
-    @pytest.mark.parametrize("bad_uuid", [None, ""])
-    def test_rejects_none_or_empty_uuid(self, bad_uuid):
+    def test_rejects_empty_uuid(self):
         with pytest.raises(ValueError):
-            ReferenceResult3(path="p1", uuid=bad_uuid)
+            ReferenceResult3(path="p1", uuid="")
+
+    def test_allows_none_uuid(self):
+        # a directory-level, name_three-absent result has no single
+        # version/registration to identify -- None, not empty string,
+        # is the correct "no uuid" value.
+        r = ReferenceResult3(path="p1", uuid=None)
+        assert r.uuid is None
 
     def test_data_defaults_to_none(self):
         r = ReferenceResult3(path="p1", uuid="u1")


### PR DESCRIPTION
## Summary
- `name_three` is now optional for every datatype (files/csvpaths, not just results) — `name_one` alone is a legal, resolvable reference on its own. `Reference3.check_valid()` no longer enforces a datatype-dependent requirement there; it's a no-op hook now, ready for whatever real semantic rule comes next.
- `Reference3.resolves_to_data` (bool) replaced by `resolve_kind` — `FIRST_PARTY` / `METADATA_FILE` / `METADATA_FIELD` — computed from whichever function chain is terminal (`name_three`'s if present, else `name_one`'s own trailing chain). `ReferenceFinder3.resolve_from()` now always calls `_extract_data()`; each finder branches on `resolve_kind` itself instead of a shared gate.
- A bare, unqualified trailing `*` is now illegal (`Reference3.check_valid()`): `*` is a fragment ("any of the data that ___") that needs something after it to complete the sentence — more path, a function, or `name_three`. `:all()` is unaffected (it's already a complete instruction). `$alpha.files.*` now raises; `$alpha.files.*/orders`, `$alpha.files.*:first()`, `$alpha.files.*.:first()`, and `$alpha.files.:all()` are all still fine.
- `FilesReferenceFinder3.query()`, when `name_three` is absent, now returns one result per distinct file-home directory (deduplicated across versions) instead of one per manifest version — matching the spec's "prefix search returns zero or more paths to file home directories." These directory-level results carry `uuid=None` (`ReferenceResult3.uuid` is now nullable — a directory isn't a specific registered version, so it has no uuid of its own). `_extract_data()` correspondingly returns `None` for a name_one-terminal result (the spec's "no default" rule) instead of trying to read a directory as a file.

## Test plan
- [x] `tests/references/` — 295 tests, all passing
- [x] Full suite — 1875 passed, 11 failed (known SFTP/S3/remote-backend baseline, unrelated to this change)
