### PR TITLE
References v3: CsvpathsReferenceFinder3, :all(), string interpolation

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -13,15 +13,20 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
     # REVERSED from files here:
     #  - root_major is a literal named-paths group name. "*" (every
     #    group) is a different traversal problem, not yet built.
-    #  - name_one IS the version pointer for csvpaths (STRUCTURE table:
+    #  - name_one IS the version selector for csvpaths (STRUCTURE table:
     #    "name_one is always one or more versions of a named-paths
-    #    group's group.csvpaths file"). It must resolve, via
-    #    build_chain(), to exactly one pointer function
-    #    (:first()/:last()/:index(n)). Literal/"*"/path-building
-    #    content, and the "#worksheet" marker (name_two, files-only),
-    #    are not meaningful for csvpaths and are rejected. :uuid() is
-    #    not yet a registered function, so it is "not yet supported"
-    #    for now like any other unbuilt function.
+    #    group's group.csvpaths file"). Its combined function chain
+    #    (the sole path-segment function plus any trailing chain) may
+    #    contain at most one pointer function (:first()/:last()/
+    #    :index(n)): if present, it reduces to that one version; if
+    #    absent (e.g. a bare :all()), every version in the manifest is
+    #    returned, unreduced -- this is how "list of versions in the
+    #    form: (path-to-group.csvpaths, uuid)" (STRUCTURE table) is
+    #    actually reached. Literal/"*"/path-building content, and the
+    #    "#worksheet" marker (name_two, files-only), are not meaningful
+    #    for csvpaths and are rejected. :uuid() is not yet a registered
+    #    function, so it is "not yet supported" for now like any other
+    #    unbuilt function.
     #  - name_three, if present, is an identity lookup into that
     #    version's named_paths_identities list -- matched by identity
     #    string, or by the stringified index an unnamed statement is
@@ -60,36 +65,36 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 "CsvpathsReferenceFinder3 does not support the '#worksheet' "
                 "marker (name_two) -- it is files-only."
             )
-        pointer = self._resolve_version_pointer(name_one)
 
         manifest = self.csvpaths.paths_manager.get_manifest_for_name(root_major)
-        selected = self._apply_pointer(pointer, manifest)
-        if selected is None:
-            return ReferenceResults3(results=[])
-
-        result = ReferenceResult3(
-            path=selected["group_file_path"], uuid=selected["uuid"]
-        )
+        selected_versions = self._resolve_versions(name_one, manifest)
 
         name_three = reference.name_three
-        if name_three is None:
-            return ReferenceResults3(results=[result])
+        if name_three is not None:
+            if name_three.functions:
+                raise ReferenceException3(
+                    "CsvpathsReferenceFinder3 does not yet support functions "
+                    "on name_three -- no metadata-access functions are "
+                    "registered for csvpaths yet."
+                )
+            if name_three.body is None or isinstance(name_three.body, Star3):
+                raise ReferenceException3(
+                    "CsvpathsReferenceFinder3 requires name_three to be a "
+                    "literal statement identity or index."
+                )
 
-        if name_three.functions:
-            raise ReferenceException3(
-                "CsvpathsReferenceFinder3 does not yet support functions on "
-                "name_three -- no metadata-access functions are registered "
-                "for csvpaths yet."
+        results = []
+        for selected in selected_versions:
+            if name_three is not None:
+                identities = selected.get("named_paths_identities") or []
+                if self._find_by_identity(name_three.body, identities) is None:
+                    continue
+            results.append(
+                ReferenceResult3(
+                    path=selected["group_file_path"], uuid=selected["uuid"]
+                )
             )
-        if name_three.body is None or isinstance(name_three.body, Star3):
-            raise ReferenceException3(
-                "CsvpathsReferenceFinder3 requires name_three to be a "
-                "literal statement identity or index."
-            )
-        identities = selected.get("named_paths_identities") or []
-        if self._find_by_identity(name_three.body, identities) is None:
-            return ReferenceResults3(results=[])
-        return ReferenceResults3(results=[result])
+        return ReferenceResults3(results=results)
 
     def _extract_data(self, result: ReferenceResult3):
         reference = self.ref.parsed
@@ -122,26 +127,26 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         statements = selected.get("named_paths") or []
         return statements[index]
 
-    @staticmethod
-    def _resolve_version_pointer(name_one) -> Function3:
-        """name_one's sole job for csvpaths is being the version
-        pointer, so its path_prefix must reduce to exactly one
-        function-segment (no literal/"*" path-building, no worksheet
-        marker) -- combined with its own trailing function chain, if
-        any, and required to resolve to exactly one pointer function
-        overall (e.g. :before(:yesterday()):after(...):index(3))."""
+    def _resolve_versions(self, name_one, manifest: list) -> list:
+        """name_one's sole job for csvpaths is selecting which
+        version(s) to work with, so its path_prefix must reduce to
+        exactly one function-segment (no literal/"*" path-building, no
+        worksheet marker) -- combined with its own trailing function
+        chain, if any. At most one pointer function is allowed among
+        the combined chain (build_chain() enforces this): if present,
+        it reduces `manifest` to that one version; if absent (e.g. a
+        bare :all()), every version in `manifest` is returned,
+        unreduced."""
         if len(name_one.path) != 1 or not isinstance(name_one.path[0], FunctionCall3):
             raise ReferenceException3(
                 "CsvpathsReferenceFinder3 requires name_one to be a version-"
-                "selecting function chain (e.g. :last(), :index(3)) -- "
+                "selecting function chain (e.g. :last(), :all()) -- "
                 "literal/'*' path-building is not meaningful for csvpaths."
             )
         calls = [name_one.path[0], *name_one.functions]
         built = ReferenceFunctionFactory.build_chain(calls)
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
-        if len(pointers) != 1:
-            raise ReferenceException3(
-                "CsvpathsReferenceFinder3 requires name_one to resolve to "
-                "exactly one pointer function (:first()/:last()/:index(n))."
-            )
-        return pointers[0]
+        if not pointers:
+            return manifest
+        selected = self._apply_pointer(pointers[0], manifest)
+        return [selected] if selected is not None else []

--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -1,0 +1,147 @@
+from .functions.function_3 import Function3
+from .functions.reference_function_factory_3 import ReferenceFunctionFactory
+from .reference_3 import FunctionCall3, Reference3, Star3
+from .reference_exceptions_3 import ReferenceException3
+from .reference_finder_3 import ReferenceFinder3
+from .reference_results_3 import ReferenceResult3, ReferenceResults3
+
+
+class CsvpathsReferenceFinder3(ReferenceFinder3):
+    #
+    # first pass, deliberately narrow, mirroring FilesReferenceFinder3's
+    # scoping approach -- but note the roles of name_one/name_three are
+    # REVERSED from files here:
+    #  - root_major is a literal named-paths group name. "*" (every
+    #    group) is a different traversal problem, not yet built.
+    #  - name_one IS the version pointer for csvpaths (STRUCTURE table:
+    #    "name_one is always one or more versions of a named-paths
+    #    group's group.csvpaths file"). It must resolve, via
+    #    build_chain(), to exactly one pointer function
+    #    (:first()/:last()/:index(n)). Literal/"*"/path-building
+    #    content, and the "#worksheet" marker (name_two, files-only),
+    #    are not meaningful for csvpaths and are rejected. :uuid() is
+    #    not yet a registered function, so it is "not yet supported"
+    #    for now like any other unbuilt function.
+    #  - name_three, if present, is an identity lookup into that
+    #    version's named_paths_identities list -- matched by identity
+    #    string, or by the stringified index an unnamed statement is
+    #    given at load time (both already live in
+    #    named_paths_identities, so a single exact-match lookup covers
+    #    both cases). A function chain on name_three is not yet
+    #    supported -- no metadata-access functions exist yet for
+    #    csvpaths (see "creating references v3.txt"'s † footnote on
+    #    this).
+    #
+    # storage facts this relies on (confirmed against PathsManager/
+    # PathsRegistrar and the real per-group manifest schema, not
+    # assumed): a named-paths group's manifest.json is one flat,
+    # append-only JSON array, one entry per loaded/reloaded version of
+    # the WHOLE group -- there is only one group.csvpath file, always
+    # the same path, regardless of version. Each entry's "named_paths"
+    # is a list of that version's individual csvpath statement source
+    # strings, and "named_paths_identities" is a parallel list of each
+    # statement's name/id (or its stringified load-time index, if
+    # unnamed). Arrival order is simply array order.
+    #
+
+    def query(self) -> ReferenceResults3:
+        reference = self.ref.parsed
+        root_major = reference.root_major
+        if isinstance(root_major, Star3):
+            raise ReferenceException3(
+                "CsvpathsReferenceFinder3 does not yet support '*' as "
+                "root_major (querying every named-paths group) -- use a "
+                "literal group name."
+            )
+
+        name_one = reference.name_one
+        if name_one.name_two is not None:
+            raise ReferenceException3(
+                "CsvpathsReferenceFinder3 does not support the '#worksheet' "
+                "marker (name_two) -- it is files-only."
+            )
+        pointer = self._resolve_version_pointer(name_one)
+
+        manifest = self.csvpaths.paths_manager.get_manifest_for_name(root_major)
+        selected = self._apply_pointer(pointer, manifest)
+        if selected is None:
+            return ReferenceResults3(results=[])
+
+        result = ReferenceResult3(
+            path=selected["group_file_path"], uuid=selected["uuid"]
+        )
+
+        name_three = reference.name_three
+        if name_three is None:
+            return ReferenceResults3(results=[result])
+
+        if name_three.functions:
+            raise ReferenceException3(
+                "CsvpathsReferenceFinder3 does not yet support functions on "
+                "name_three -- no metadata-access functions are registered "
+                "for csvpaths yet."
+            )
+        if name_three.body is None or isinstance(name_three.body, Star3):
+            raise ReferenceException3(
+                "CsvpathsReferenceFinder3 requires name_three to be a "
+                "literal statement identity or index."
+            )
+        identities = selected.get("named_paths_identities") or []
+        if self._find_by_identity(name_three.body, identities) is None:
+            return ReferenceResults3(results=[])
+        return ReferenceResults3(results=[result])
+
+    def _extract_data(self, result: ReferenceResult3):
+        reference = self.ref.parsed
+        kind = reference.resolve_kind
+        if kind != Reference3.FIRST_PARTY:
+            raise ReferenceException3(
+                f"CsvpathsReferenceFinder3 does not yet support "
+                f"resolve_kind={kind!r} -- no metadata-access functions are "
+                "registered for csvpaths yet."
+            )
+        name_three = reference.name_three
+        if name_three is None:
+            # a whole group version has no single unambiguous payload --
+            # the same "no default" rule as a directory-level, name_one-
+            # terminal result in FilesReferenceFinder3.
+            return None
+
+        manifest = self.csvpaths.paths_manager.get_manifest_for_name(
+            reference.root_major
+        )
+        selected = next(
+            (entry for entry in manifest if entry["uuid"] == result.uuid), None
+        )
+        if selected is None:
+            return None
+        identities = selected.get("named_paths_identities") or []
+        index = self._find_by_identity(name_three.body, identities)
+        if index is None:
+            return None
+        statements = selected.get("named_paths") or []
+        return statements[index]
+
+    @staticmethod
+    def _resolve_version_pointer(name_one) -> Function3:
+        """name_one's sole job for csvpaths is being the version
+        pointer, so its path_prefix must reduce to exactly one
+        function-segment (no literal/"*" path-building, no worksheet
+        marker) -- combined with its own trailing function chain, if
+        any, and required to resolve to exactly one pointer function
+        overall (e.g. :before(:yesterday()):after(...):index(3))."""
+        if len(name_one.path) != 1 or not isinstance(name_one.path[0], FunctionCall3):
+            raise ReferenceException3(
+                "CsvpathsReferenceFinder3 requires name_one to be a version-"
+                "selecting function chain (e.g. :last(), :index(3)) -- "
+                "literal/'*' path-building is not meaningful for csvpaths."
+            )
+        calls = [name_one.path[0], *name_one.functions]
+        built = ReferenceFunctionFactory.build_chain(calls)
+        pointers = [f for f in built if f.ROLE == Function3.POINTER]
+        if len(pointers) != 1:
+            raise ReferenceException3(
+                "CsvpathsReferenceFinder3 requires name_one to resolve to "
+                "exactly one pointer function (:first()/:last()/:index(n))."
+            )
+        return pointers[0]

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -164,18 +164,3 @@ class FilesReferenceFinder3(ReferenceFinder3):
             if actual != expected:
                 return False
         return True
-
-    @staticmethod
-    def _apply_pointer(pointer, candidates: list) -> dict | None:
-        if not candidates:
-            return None
-        if pointer.name == "first":
-            return candidates[0]
-        if pointer.name == "last":
-            return candidates[-1]
-        if pointer.name == "index":
-            try:
-                return candidates[pointer.arg]
-            except IndexError:
-                return None
-        raise ReferenceException3(f"Unsupported pointer function: {pointer.name}")

--- a/csvpath/references/functions/all_3.py
+++ b/csvpath/references/functions/all_3.py
@@ -1,0 +1,30 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class All3(Function3):
+    #
+    # :all() is NOT equivalent to "*" (see reference_grammar_3.py's
+    # module docstring and "creating references v3.txt"'s NOTES): "*"
+    # flattens a wildcard position into a pooled search space that a
+    # pointer then reduces to one answer; ":all()" switches into
+    # grouped/unreduced mode instead. For csvpaths specifically (no
+    # path dimension to group by), that collapses to a simpler case:
+    # ":all()" just means "do not reduce -- return every version," the
+    # same outcome as writing no pointer at all. Its role is
+    # CONTEXT_SETTER (it narrows the current scope without resolving to
+    # a specific item) even though the narrowing is a no-op here -- it
+    # exists so a reference can explicitly ask for "everything" using a
+    # real function, since the grammar requires name_one to contain one
+    # for csvpaths (literal/"*" path-building is not meaningful there).
+    #
+    NAME = "all"
+    SUMMARY = (
+        "Explicitly asks for every match, unreduced -- the complete-"
+        "instruction counterpart to a bare '*', which is a dangling "
+        "fragment on its own."
+    )
+    ROLE = Function3.CONTEXT_SETTER
+    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False

--- a/csvpath/references/functions/function_3.py
+++ b/csvpath/references/functions/function_3.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from ..reference_3 import InterpolatedString3
 from ..reference_exceptions_3 import ReferenceException3
 
 
@@ -15,14 +16,18 @@ from ..reference_exceptions_3 import ReferenceException3
 # validated at runtime (not baked into the grammar), self validating,
 # self describing/inspectable, take at most 1 arg, and self-report
 # their role -- CONTEXT_SETTER (narrows/sets scope without resolving to
-# an item, e.g. :yesterday(), :all()) or POINTER (resolves scope to
-# exactly 0 or 1 item, e.g. :last(), :first(), :index(n)). There is
-# deliberately no code shared with csvpath.matching.functions -- this
-# class does not subclass or import anything from there.
+# an item, e.g. :before()/:after()), POINTER (resolves scope to exactly
+# 0 or 1 item, e.g. :last(), :first(), :index(n)), or VALUE (computes a
+# value -- usually clock/calendar-derived, e.g. :year() -- that behaves
+# like a computed literal wherever it is used; it does not operate on
+# scope at all, unlike the other two roles). There is deliberately no
+# code shared with csvpath.matching.functions -- this class does not
+# subclass or import anything from there.
 #
 class Function3:
     CONTEXT_SETTER = "context_setter"
     POINTER = "pointer"
+    VALUE = "value"
 
     #
     # subclasses override all of these.
@@ -55,16 +60,20 @@ class Function3:
             raise ReferenceException3(f":{self.NAME}() requires an argument")
         if not self.ARG_TYPES and self._arg is not None:
             raise ReferenceException3(f":{self.NAME}() does not take an argument")
-        if (
-            self.ARG_TYPES
-            and self._arg is not None
-            and not isinstance(self._arg, self.ARG_TYPES)
-        ):
-            raise ReferenceException3(
-                f":{self.NAME}() argument must be one of {self.ARG_TYPES}, "
-                f"got {type(self._arg)}"
-            )
-        if isinstance(self._arg, Function3):
+        if self.ARG_TYPES and self._arg is not None:
+            # any function that accepts a plain str also accepts an
+            # interpolated one -- callers should never need to remember
+            # to list InterpolatedString3 separately just to support
+            # "{...}" interpolation in a string arg.
+            allowed = self.ARG_TYPES
+            if str in allowed and InterpolatedString3 not in allowed:
+                allowed = (*allowed, InterpolatedString3)
+            if not isinstance(self._arg, allowed):
+                raise ReferenceException3(
+                    f":{self.NAME}() argument must be one of {self.ARG_TYPES}, "
+                    f"got {type(self._arg)}"
+                )
+        if isinstance(self._arg, (Function3, InterpolatedString3)):
             self._arg.check_valid()
 
     def describe(self) -> dict:

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -16,6 +16,7 @@ class ReferenceFunctionFactory:
 
     @classmethod
     def _load(cls) -> None:
+        from .all_3 import All3
         from .first_3 import First3
         from .index_3 import Index3
         from .last_3 import Last3
@@ -26,6 +27,7 @@ class ReferenceFunctionFactory:
             Last3.NAME: Last3,
             Index3.NAME: Index3,
             Name3.NAME: Name3,
+            All3.NAME: All3,
         }
 
     @classmethod

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -42,6 +42,18 @@ class ReferenceFunctionFactory:
         cls._FUNCTIONS[function_cls.NAME] = function_cls
 
     @classmethod
+    def get_registered_class(cls, name: str) -> type | None:
+        """the registered Function3 CLASS for `name`, or None if
+        unknown -- for checking class-level metadata (e.g. ROLE)
+        without constructing/validating an instance. Used by
+        InterpolatedString3.check_valid() to reject non-VALUE
+        functions inside a "{...}" interpolation without needing to
+        evaluate them."""
+        if not cls._FUNCTIONS:
+            cls._load()
+        return cls._FUNCTIONS.get(name)
+
+    @classmethod
     def build(cls, call: FunctionCall3) -> Function3:
         """compiles one FunctionCall3 into a real, validated Function3.
         recurses first if call.arg is itself a FunctionCall3, so a

--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -71,9 +71,91 @@ class Regex3:
 
 def _arg_to_string(value) -> str:
     if isinstance(value, str):
+        # a bare "{" or "}" can only reach here having survived
+        # unescaping from an original "{{"/"}}" -- a single unescaped
+        # brace is a parse error (see _split_interpolated_parts in
+        # reference_transformer_3.py) and never produces a plain str.
+        # re-escape both back so this round-trips.
         escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        escaped = escaped.replace("{", "{{").replace("}", "}}")
         return f'"{escaped}"'
+    if isinstance(value, InterpolatedString3):
+        return f'"{value}"'
     return str(value)
+
+
+class InterpolatedString3:
+    """a string argument containing one or more "{...}" interpolation
+    spans (each a bare @variable or a call to a VALUE-role function)
+    plus the literal text between them. Built by Reference3Transformer's
+    STRING handling only when the raw content actually has an
+    unescaped "{" -- a string with none stays a plain str, unaffected.
+    "{{"/"}}" escape a literal brace (same convention already used by
+    csvpath/util/var_utility.py's substitute()).
+
+    Parsing/validation only for now: turning this into an actual
+    resolved string (looking up @variables, computing value functions)
+    needs a runtime CsvPaths context this object graph deliberately
+    has none of -- that is deferred until variable resolution and a
+    real VALUE function exist. See check_valid()."""
+
+    def __init__(self, *, parts: list) -> None:
+        if not parts:
+            raise ValueError("InterpolatedString3 parts cannot be None or empty")
+        self._parts = parts
+
+    @property
+    def parts(self) -> list:
+        return self._parts
+
+    def check_valid(self) -> None:
+        """rejects anything other than a bare @variable or a call to a
+        VALUE-role function inside a "{...}" span -- context setters
+        and pointers act on scope, which is not meaningful to
+        interpolate into a string. Checked by looking up each
+        function's registered CLASS (a class-level ROLE attribute),
+        not by building/evaluating it -- evaluation is out of scope
+        for this pass."""
+        # local import: the function registry lives in functions/,
+        # which already depends on this module (e.g. Reference3's
+        # datatype constants) -- importing it back at module level
+        # here would be circular. deferred import breaks the cycle at
+        # exactly this one, narrow, unavoidable point.
+        from .functions.function_3 import Function3
+        from .functions.reference_function_factory_3 import (
+            ReferenceFunctionFactory,
+        )
+
+        for part in self._parts:
+            if not isinstance(part, FunctionCall3):
+                continue
+            function_cls = ReferenceFunctionFactory.get_registered_class(part.name)
+            if function_cls is None:
+                raise ReferenceException3(f"Unknown reference function: {part.name}")
+            if function_cls.ROLE != Function3.VALUE:
+                raise ReferenceException3(
+                    f":{part.name}() cannot be used inside a {{...}} "
+                    "interpolation -- only @variables and VALUE-role "
+                    "functions are allowed there, not context setters or "
+                    "pointers."
+                )
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, InterpolatedString3) and other.parts == self._parts
+
+    def __repr__(self) -> str:
+        return f"InterpolatedString3(parts={self._parts!r})"
+
+    def __str__(self) -> str:
+        out = []
+        for part in self._parts:
+            if isinstance(part, str):
+                escaped = part.replace("\\", "\\\\").replace('"', '\\"')
+                escaped = escaped.replace("{", "{{").replace("}", "}}")
+                out.append(escaped)
+            else:
+                out.append(f"{{{part}}}")
+        return "".join(out)
 
 
 class FunctionCall3:
@@ -122,6 +204,16 @@ class FunctionCall3:
         if isinstance(self._arg, FunctionCall3):
             return self._arg.contains_function_named(name)
         return False
+
+    def check_valid(self) -> None:
+        """recursively validates any InterpolatedString3 nested
+        anywhere in this function's own argument chain (see
+        InterpolatedString3.check_valid() for what that actually
+        checks) -- functions have no other structural rule to check
+        here themselves (their own arg-type/arity rules are Function3's
+        job, once built by the registry, not FunctionCall3's)."""
+        if isinstance(self._arg, (InterpolatedString3, FunctionCall3)):
+            self._arg.check_valid()
 
 
 class NameOne3:
@@ -330,6 +422,18 @@ class Reference3:
                 "not '*' alone."
             )
             raise ReferenceException3(msg)
+
+        # validates any "{...}" interpolation nested anywhere in this
+        # reference's functions -- see FunctionCall3.check_valid()/
+        # InterpolatedString3.check_valid().
+        for segment in self._name_one.path:
+            if isinstance(segment, FunctionCall3):
+                segment.check_valid()
+        for f in self._name_one.functions:
+            f.check_valid()
+        if self._name_three is not None:
+            for f in self._name_three.functions:
+                f.check_valid()
 
     @property
     def root_major(self):

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from .reference_exceptions_3 import ReferenceException3
 from .reference_parser_3 import ReferenceParser3
 from .reference_results_3 import ReferenceResult3, ReferenceResults3
 
@@ -68,3 +69,40 @@ class ReferenceFinder3(ABC):
         given already-queried result. datatype-specific -- reading raw
         file bytes vs errors.json vs vars.json differs enough there is
         no generic implementation."""
+
+    @staticmethod
+    def _apply_pointer(pointer, candidates: list) -> dict | None:
+        """reduces a list of manifest-entry dicts to the one a pointer
+        function selects -- :first()/:last()/:index(n) are plain list-
+        position lookups (arrival/registration order is array order,
+        confirmed against real manifests for both files and csvpaths),
+        so this is identical across every datatype that reads a flat
+        manifest array. shared here rather than duplicated per finder."""
+        if not candidates:
+            return None
+        if pointer.name == "first":
+            return candidates[0]
+        if pointer.name == "last":
+            return candidates[-1]
+        if pointer.name == "index":
+            try:
+                return candidates[pointer.arg]
+            except IndexError:
+                return None
+        raise ReferenceException3(f"Unsupported pointer function: {pointer.name}")
+
+    @staticmethod
+    def _find_by_identity(identity: str, identities: list) -> int | None:
+        """returns the index of `identity` within `identities` (exact
+        string match), or None if absent. shared by any finder whose
+        name_three does an identity lookup -- csvpaths'
+        named_paths_identities and results' per-statement directory
+        names both name individual csvpath statements the same way: an
+        explicit id/name comment, or the stringified run index if the
+        statement is unnamed -- so a plain list membership check
+        handles both without needing a separate "or try as an int"
+        fallback."""
+        try:
+            return identities.index(identity)
+        except ValueError:
+            return None

--- a/csvpath/references/reference_parser_3.py
+++ b/csvpath/references/reference_parser_3.py
@@ -1,5 +1,7 @@
 import logging
 
+from lark.exceptions import VisitError
+
 from .reference_3 import Reference3
 from .reference_grammar_3 import QueryParser3
 from .reference_transformer_3 import Reference3Transformer
@@ -93,6 +95,17 @@ class ReferenceParser3:
             tree = self._get_query_parser().parse(string)
             self._parsed = Reference3Transformer().transform(tree)
             self._parsed.check_valid()
+        except VisitError as e:
+            # any exception raised from inside a Transformer rule
+            # method (e.g. STRING's interpolation parsing rejecting an
+            # unescaped brace) arrives here wrapped in lark's own
+            # VisitError -- unwrap it so callers see the real
+            # exception (typically ReferenceException3) rather than a
+            # lark-internal type. Same reasoning as why
+            # Reference3.check_valid() is called outside transform()'s
+            # own call stack in the first place.
+            logger.error("Failed to parse reference '%s': %s", string, e.orig_exc)
+            raise e.orig_exc from e
         except Exception as e:
             logger.error("Failed to parse reference '%s': %s", string, e)
             raise

--- a/csvpath/references/reference_transformer_3.py
+++ b/csvpath/references/reference_transformer_3.py
@@ -1,9 +1,11 @@
 import re
 
-from lark import Transformer, v_args
+from lark import Lark, Transformer, v_args
+from lark.exceptions import UnexpectedInput
 
 from .reference_3 import (
     FunctionCall3,
+    InterpolatedString3,
     NameOne3,
     NameThree3,
     Reference3,
@@ -11,6 +13,7 @@ from .reference_3 import (
     Star3,
     Variable3,
 )
+from .reference_exceptions_3 import ReferenceException3
 
 #
 # turns a references-v3 Lark parse tree (see reference_grammar_3.py) into
@@ -32,6 +35,117 @@ from .reference_3 import (
 # defaults handle safely (fewer children always means the rightmost
 # param(s) are missing, never a reshuffle).
 #
+
+
+#
+# String interpolation: a STRING argument may contain one or more
+# "{...}" spans -- each a bare @variable or a call to a function whose
+# role is VALUE (context setters/pointers are rejected -- see
+# InterpolatedString3.check_valid()). "{{"/"}}" escape a literal brace,
+# matching the convention already used by csvpath/util/var_utility.py's
+# substitute().
+#
+# kept as a separate, small grammar rather than a REFERENCE_GRAMMAR_3
+# change, so the main, LALR-clean reference grammar stays untouched --
+# this one only ever parses the *content* of one already-found
+# "{...}" span, reusing the exact same AT_VAR/FNAME/function/arg
+# terminal definitions (kept textually identical to
+# reference_grammar_3.py's on purpose, to avoid behavioral drift
+# between the two).
+#
+_INTERPOLATION_GRAMMAR_3 = r"""
+    ?start: AT_VAR
+          | function
+
+    function: ":" FNAME "(" arg? ")"
+
+    arg: STRING
+       | SIGNED_INT
+       | AT_VAR
+       | function
+       | REGEX
+       | STAR
+
+    STAR: "*"
+    AT_VAR: "@" IDENTIFIER
+    FNAME: /[a-zA-Z_][a-zA-Z0-9_]*/
+    IDENTIFIER: /[a-zA-Z_][a-zA-Z0-9_\-]*/
+    STRING: /"(?:[^"\\]|\\.)*"/
+    SIGNED_INT: /-?\d+/
+    REGEX: "/" REGEX_INNER "/"
+    REGEX_INNER: /([^\/\\]|\\.)*/
+
+    %import common.WS
+    %ignore WS
+"""
+
+_interpolation_parser = None
+
+
+def _get_interpolation_parser() -> Lark:
+    global _interpolation_parser
+    if _interpolation_parser is None:
+        _interpolation_parser = Lark(_INTERPOLATION_GRAMMAR_3, parser="lalr")
+    return _interpolation_parser
+
+
+def _parse_interpolation_span(inner: str):
+    try:
+        tree = _get_interpolation_parser().parse(inner)
+    except UnexpectedInput as e:
+        raise ReferenceException3(
+            f"Invalid {{...}} interpolation content {inner!r}: {e}"
+        ) from e
+    return Reference3Transformer().transform(tree)
+
+
+def _split_interpolated_parts(text: str) -> list:
+    """splits `text` into literal string chunks and parsed @variable/
+    function parts, honoring "{{"/"}}" as escapes for a literal brace.
+    a plain string with no unescaped "{" comes back as a single-element
+    list holding the original string, untouched -- callers use that to
+    skip wrapping in InterpolatedString3 for the (overwhelmingly
+    common) no-interpolation case.
+
+    deliberately simple: finds each span by the next unescaped "}"
+    after an unescaped "{", not by brace-depth/quote-aware balancing --
+    sufficient for the interpolation shapes actually in use (a bare
+    @variable or one function call), not a general nested-brace parser."""
+    parts = []
+    buf = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "{" and i + 1 < n and text[i + 1] == "{":
+            buf.append("{")
+            i += 2
+            continue
+        if ch == "}" and i + 1 < n and text[i + 1] == "}":
+            buf.append("}")
+            i += 2
+            continue
+        if ch == "{":
+            end = text.find("}", i + 1)
+            if end == -1:
+                raise ReferenceException3(
+                    f"Unescaped '{{' with no matching '}}' in string: {text!r}"
+                )
+            if buf:
+                parts.append("".join(buf))
+                buf = []
+            parts.append(_parse_interpolation_span(text[i + 1 : end]))
+            i = end + 1
+            continue
+        if ch == "}":
+            raise ReferenceException3(
+                f"Unescaped '}}' with no matching '{{' in string: {text!r}"
+            )
+        buf.append(ch)
+        i += 1
+    if buf or not parts:
+        parts.append("".join(buf))
+    return parts
 
 
 class _PathPrefixResult:
@@ -132,12 +246,16 @@ class Reference3Transformer(Transformer):
     def IDENTIFIER(self, token) -> str:  # noqa: N802
         return str(token)
 
-    def STRING(self, token) -> str:  # noqa: N802
+    def STRING(self, token) -> str | InterpolatedString3:  # noqa: N802
         # grammar's STRING allows "\." to escape any character (not just
         # quote/backslash) -- undo that generically rather than special
         # casing \" and \\.
         raw = str(token)[1:-1]
-        return re.sub(r"\\(.)", r"\1", raw)
+        unescaped = re.sub(r"\\(.)", r"\1", raw)
+        parts = _split_interpolated_parts(unescaped)
+        if len(parts) == 1 and isinstance(parts[0], str):
+            return parts[0]
+        return InterpolatedString3(parts=parts)
 
     def SIGNED_INT(self, token) -> int:  # noqa: N802
         return int(token)

--- a/tests/references/functions/test_all_3.py
+++ b/tests/references/functions/test_all_3.py
@@ -1,0 +1,22 @@
+import pytest
+
+from csvpath.references.functions.all_3 import All3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = All3()
+    assert f.name == "all"
+    assert f.ROLE == Function3.CONTEXT_SETTER
+    assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+
+
+def test_no_arg_is_valid():
+    All3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        All3(arg="x").check_valid()

--- a/tests/references/functions/test_function_3.py
+++ b/tests/references/functions/test_function_3.py
@@ -1,6 +1,7 @@
 import pytest
 
 from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import FunctionCall3, InterpolatedString3, Variable3
 from csvpath.references.reference_exceptions_3 import ReferenceException3
 
 
@@ -68,6 +69,23 @@ class TestCheckValid:
         bad_nested = _RequiredIntArgFunction()  # missing its own required arg
         with pytest.raises(ReferenceException3):
             _AcceptsFunctionArg(arg=bad_nested).check_valid()
+
+    def test_str_typed_arg_accepts_interpolated_string(self):
+        # ARG_TYPES = (str,) is auto-widened to also accept
+        # InterpolatedString3 -- a function that takes a plain string
+        # must also accept one containing {...} interpolation.
+        good = InterpolatedString3(parts=["x-", Variable3(name="company")])
+        _OptionalStrArgFunction(arg=good).check_valid()  # should not raise
+
+    def test_nested_interpolated_string_arg_is_recursively_checked(self):
+        # the nested InterpolatedString3 contains a POINTER-role
+        # function call, which is illegal inside {...} -- check_valid()
+        # must recurse into it, not just check the outer arg's type.
+        bad = InterpolatedString3(
+            parts=["x-", FunctionCall3(name="first")]
+        )
+        with pytest.raises(ReferenceException3):
+            _OptionalStrArgFunction(arg=bad).check_valid()
 
 
 class TestProperties:

--- a/tests/references/functions/test_reference_function_factory_3.py
+++ b/tests/references/functions/test_reference_function_factory_3.py
@@ -1,5 +1,6 @@
 import pytest
 
+from csvpath.references.functions.all_3 import All3
 from csvpath.references.functions.first_3 import First3
 from csvpath.references.functions.function_3 import Function3
 from csvpath.references.functions.index_3 import Index3
@@ -34,6 +35,10 @@ class TestBuild:
         f = ReferenceFunctionFactory.build(FunctionCall3(name="name", arg="zero.csv"))
         assert isinstance(f, Name3)
         assert f.arg == "zero.csv"
+
+    def test_builds_all(self):
+        f = ReferenceFunctionFactory.build(FunctionCall3(name="all"))
+        assert isinstance(f, All3)
 
     def test_unknown_function_raises(self):
         with pytest.raises(ReferenceException3):

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -80,6 +80,28 @@ class TestVersionPointer:
             _finder("$acme.csvpaths.:last():index(0)").query()
 
 
+class TestNoPointerReturnsEveryVersion:
+    # a chain with no pointer at all (e.g. a bare :all()) does not
+    # narrow to one version -- every version in the manifest comes
+    # back, unreduced. This is how "Name_one used alone == list of
+    # versions in the form: (path-to-group.csvpaths, uuid)" (STRUCTURE
+    # table) is actually reached.
+    def test_bare_all_returns_every_version(self):
+        results = _finder("$acme.csvpaths.:all()").query()
+        assert results.files == [GROUP_FILE_PATH, GROUP_FILE_PATH]
+        assert results.uuids == ["v0-uuid", "v1-uuid"]
+
+    def test_all_combined_with_name_three_filters_each_version(self):
+        # only versions containing the matching identity come back --
+        # "company_names" only exists in v0's identities.
+        results = _finder("$acme.csvpaths.:all().company_names").query()
+        assert results.uuids == ["v0-uuid"]
+
+    def test_all_with_no_matches_at_all_returns_empty(self):
+        results = _finder("$acme.csvpaths.:all().nope").query()
+        assert results.files == []
+
+
 class TestIdentityLookupOnNameThree:
     def test_matches_named_identity(self):
         results = _finder("$acme.csvpaths.:first().company_names").query()
@@ -142,16 +164,6 @@ class TestScopeLimits:
 
     def test_two_pointers_in_name_one_raises(self):
         finder = _finder("$acme.csvpaths.:first():last()")
-        with pytest.raises(ReferenceException3):
-            finder.query()
-
-    def test_name_one_with_no_pointer_at_all_raises(self):
-        # a context-setter alone (no pointer) does not resolve to
-        # exactly one version -- not yet supported (no context-setter
-        # functions are registered yet anyway, so this always surfaces
-        # as an unknown-function error today, but the "exactly one
-        # pointer" requirement stands regardless).
-        finder = _finder("$acme.csvpaths.:before(:yesterday())")
         with pytest.raises(ReferenceException3):
             finder.query()
 

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -1,0 +1,179 @@
+import pytest
+
+from csvpath.references.csvpaths_reference_finder_3 import CsvpathsReferenceFinder3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+from csvpath.references.reference_parser_3 import ReferenceParser3
+from csvpath.references.reference_results_3 import ReferenceResult3
+
+
+#
+# fixture: named-paths group "acme" with two loaded versions. version 0
+# has two statements (one identified as "company_names", one unnamed --
+# unnamed statements get the stringified load-time index as their
+# identity, per PathsManager.add_named_paths); version 1 has one
+# unnamed statement. group_file_path is identical across every version
+# -- there is only one group.csvpath file, ever, regardless of version
+# (confirmed against PathsRegistrar.metadata_update's real manifest
+# schema).
+#
+GROUP_FILE_PATH = "named_paths/acme/group.csvpath"
+ACME_MANIFEST = [
+    {
+        "group_file_path": GROUP_FILE_PATH,
+        "uuid": "v0-uuid",
+        "named_paths": ["stmt text A", "stmt text B"],
+        "named_paths_identities": ["company_names", "1"],
+    },
+    {
+        "group_file_path": GROUP_FILE_PATH,
+        "uuid": "v1-uuid",
+        "named_paths": ["stmt text C"],
+        "named_paths_identities": ["0"],
+    },
+]
+
+
+class _FakePathsManager:
+    def __init__(self, manifest):
+        self._manifest = manifest
+
+    def get_manifest_for_name(self, name):
+        return self._manifest
+
+
+class _FakeCsvPaths:
+    def __init__(self, paths_manager):
+        self.paths_manager = paths_manager
+
+
+def _finder(reference: str, manifest: list = ACME_MANIFEST) -> CsvpathsReferenceFinder3:
+    csvpaths = _FakeCsvPaths(_FakePathsManager(manifest))
+    ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
+    return CsvpathsReferenceFinder3(csvpaths=csvpaths, ref=ref)
+
+
+class TestVersionPointer:
+    def test_last(self):
+        results = _finder("$acme.csvpaths.:last()").query()
+        assert results.files == [GROUP_FILE_PATH]
+        assert results.uuids == ["v1-uuid"]
+
+    def test_first(self):
+        results = _finder("$acme.csvpaths.:first()").query()
+        assert results.uuids == ["v0-uuid"]
+
+    def test_index(self):
+        results = _finder("$acme.csvpaths.:index(0)").query()
+        assert results.uuids == ["v0-uuid"]
+
+    def test_index_out_of_range_returns_empty_not_an_error(self):
+        results = _finder("$acme.csvpaths.:index(99)").query()
+        assert results.files == []
+
+    def test_chained_functions_combine_with_name_ones_own_chain(self):
+        # :last() occupies the sole path-segment, :index(0) is name_one's
+        # own trailing function chain -- both get combined into one
+        # chain; index(0) is the only pointer among the two once
+        # combined... except :last() is ALSO a pointer, so this should
+        # raise (two pointers, same chain).
+        with pytest.raises(ReferenceException3):
+            _finder("$acme.csvpaths.:last():index(0)").query()
+
+
+class TestIdentityLookupOnNameThree:
+    def test_matches_named_identity(self):
+        results = _finder("$acme.csvpaths.:first().company_names").query()
+        assert results.uuids == ["v0-uuid"]
+
+    def test_matches_stringified_index_identity(self):
+        results = _finder("$acme.csvpaths.:last().0").query()
+        assert results.uuids == ["v1-uuid"]
+
+    def test_no_matching_identity_returns_empty(self):
+        results = _finder("$acme.csvpaths.:first().nope").query()
+        assert results.files == []
+
+    def test_name_three_does_not_change_path_or_uuid(self):
+        # per the STRUCTURE table: querying at name_three gives the same
+        # (path, uuid) as name_one alone for csvpaths -- name_three only
+        # adds an existence constraint, it does not select a different
+        # physical thing (there isn't one -- one file, one uuid per
+        # version, regardless of which statement within it).
+        with_three = _finder("$acme.csvpaths.:first().company_names").query()
+        without_three = _finder("$acme.csvpaths.:first()").query()
+        assert with_three.results == without_three.results
+
+
+class TestResolve:
+    def test_resolving_a_named_identity_gives_its_statement_text(self):
+        results = _finder("$acme.csvpaths.:first().company_names").resolve()
+        assert results.results[0].data == "stmt text A"
+
+    def test_resolving_a_stringified_index_identity_gives_its_statement_text(self):
+        results = _finder("$acme.csvpaths.:last().0").resolve()
+        assert results.results[0].data == "stmt text C"
+
+    def test_resolving_with_no_name_three_gives_none(self):
+        # a whole group version has no single unambiguous payload.
+        results = _finder("$acme.csvpaths.:last()").resolve()
+        assert results.results[0].data is None
+
+
+class TestScopeLimits:
+    def test_star_root_major_not_yet_supported(self):
+        finder = _finder("$*.csvpaths.:last().x")
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_name_two_worksheet_marker_not_yet_supported(self):
+        finder = _finder("$acme.csvpaths.:last()#sheet1.x")
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_literal_path_in_name_one_not_supported(self):
+        finder = _finder("$acme.csvpaths.somefile.x")
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_star_in_name_one_not_supported(self):
+        finder = _finder("$acme.csvpaths.*.x")
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_two_pointers_in_name_one_raises(self):
+        finder = _finder("$acme.csvpaths.:first():last()")
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_name_one_with_no_pointer_at_all_raises(self):
+        # a context-setter alone (no pointer) does not resolve to
+        # exactly one version -- not yet supported (no context-setter
+        # functions are registered yet anyway, so this always surfaces
+        # as an unknown-function error today, but the "exactly one
+        # pointer" requirement stands regardless).
+        finder = _finder("$acme.csvpaths.:before(:yesterday())")
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_function_chain_on_name_three_not_yet_supported(self):
+        finder = _finder("$acme.csvpaths.:last().company_names:data()")
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_star_body_on_name_three_not_supported(self):
+        finder = _finder("$acme.csvpaths.:last().*")
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_metadata_kind_not_yet_supported(self):
+        # :meta() matches resolve_kind's METADATA_FILE placeholder list
+        # (Reference3._METADATA_FILE_FUNCTIONS) even though it is not
+        # an actual registered function -- query() would already reject
+        # this reference for a different reason first (functions on
+        # name_three are rejected outright), so _extract_data() is
+        # called directly to test its own resolve_kind branching in
+        # isolation, ahead of any real metadata-access function
+        # existing for csvpaths.
+        finder = _finder("$acme.csvpaths.:first().:meta()")
+        with pytest.raises(ReferenceException3):
+            finder._extract_data(ReferenceResult3(path="p", uuid="v0-uuid"))

--- a/tests/references/test_reference_3.py
+++ b/tests/references/test_reference_3.py
@@ -2,6 +2,7 @@ import pytest
 
 from csvpath.references.reference_3 import (
     FunctionCall3,
+    InterpolatedString3,
     NameOne3,
     NameThree3,
     Reference3,
@@ -131,6 +132,101 @@ class TestFunctionCall3:
 
     def test_contains_function_named_false_with_no_arg(self):
         assert not FunctionCall3(name="all").contains_function_named("idchain")
+
+    def test_check_valid_passes_with_no_arg(self):
+        FunctionCall3(name="all").check_valid()  # should not raise
+
+    def test_check_valid_passes_with_a_plain_string_arg(self):
+        FunctionCall3(name="name", arg="Acme").check_valid()  # should not raise
+
+    def test_check_valid_recurses_into_a_nested_function_arg(self):
+        bad_interpolation = InterpolatedString3(
+            parts=["x-", FunctionCall3(name="first")]
+        )
+        outer = FunctionCall3(
+            name="from", arg=FunctionCall3(name="name", arg=bad_interpolation)
+        )
+        with pytest.raises(ReferenceException3):
+            outer.check_valid()
+
+    def test_check_valid_recurses_into_an_interpolated_string_arg(self):
+        bad_interpolation = InterpolatedString3(
+            parts=["x-", FunctionCall3(name="first")]
+        )
+        f = FunctionCall3(name="name", arg=bad_interpolation)
+        with pytest.raises(ReferenceException3):
+            f.check_valid()
+
+
+class TestInterpolatedString3:
+    def test_rejects_none_or_empty_parts(self):
+        with pytest.raises(ValueError):
+            InterpolatedString3(parts=None)
+        with pytest.raises(ValueError):
+            InterpolatedString3(parts=[])
+
+    def test_check_valid_accepts_a_bare_variable(self):
+        s = InterpolatedString3(parts=["x-", Variable3(name="company")])
+        s.check_valid()  # should not raise
+
+    def test_check_valid_rejects_a_pointer_role_function(self):
+        # :first() is POINTER -- pointers act on scope, not on
+        # producing a plain value to interpolate.
+        s = InterpolatedString3(parts=["x-", FunctionCall3(name="first")])
+        with pytest.raises(ReferenceException3):
+            s.check_valid()
+
+    def test_check_valid_rejects_a_context_setter_role_function(self):
+        # :all() is CONTEXT_SETTER -- same reasoning as pointers.
+        s = InterpolatedString3(parts=["x-", FunctionCall3(name="all")])
+        with pytest.raises(ReferenceException3):
+            s.check_valid()
+
+    def test_check_valid_rejects_an_unknown_function(self):
+        s = InterpolatedString3(
+            parts=["x-", FunctionCall3(name="not_a_real_function")]
+        )
+        with pytest.raises(ReferenceException3):
+            s.check_valid()
+
+    def test_check_valid_accepts_a_value_role_function(self):
+        from csvpath.references.functions.function_3 import Function3
+        from csvpath.references.functions.reference_function_factory_3 import (
+            ReferenceFunctionFactory,
+        )
+
+        class _Year3ForTest(Function3):
+            NAME = "year_for_test"
+            SUMMARY = "test-only value function"
+            ROLE = Function3.VALUE
+            DATATYPES = ()
+            ARG_TYPES = ()
+            ARG_REQUIRED = False
+
+        ReferenceFunctionFactory.add_function(_Year3ForTest)
+        try:
+            s = InterpolatedString3(
+                parts=["x-", FunctionCall3(name="year_for_test")]
+            )
+            s.check_valid()  # should not raise
+        finally:
+            del ReferenceFunctionFactory._FUNCTIONS["year_for_test"]
+
+    def test_equality(self):
+        assert InterpolatedString3(parts=["a"]) == InterpolatedString3(parts=["a"])
+        assert InterpolatedString3(parts=["a"]) != InterpolatedString3(parts=["b"])
+
+    def test_str_renders_variable_in_braces(self):
+        s = InterpolatedString3(parts=["partner-", Variable3(name="company")])
+        assert str(s) == "partner-{@company}"
+
+    def test_str_escapes_literal_braces(self):
+        s = InterpolatedString3(parts=["a{b}c"])
+        assert str(s) == "a{{b}}c"
+
+    def test_str_renders_function_in_braces(self):
+        s = InterpolatedString3(parts=["x-", FunctionCall3(name="first")])
+        assert str(s) == "x-{:first()}"
 
 
 class TestNameOne3:

--- a/tests/references/test_reference_finder_3.py
+++ b/tests/references/test_reference_finder_3.py
@@ -54,6 +54,58 @@ class TestConstruction:
         assert f.csvpaths is CSVPATHS
 
 
+class TestApplyPointer:
+    # shared by every finder that reads a flat manifest array (files,
+    # csvpaths) -- moved onto the ABC once there were two real
+    # consumers, not just one.
+    def test_first(self):
+        assert ReferenceFinder3._apply_pointer(
+            type("P", (), {"name": "first"})(), ["a", "b", "c"]
+        ) == "a"
+
+    def test_last(self):
+        assert ReferenceFinder3._apply_pointer(
+            type("P", (), {"name": "last"})(), ["a", "b", "c"]
+        ) == "c"
+
+    def test_index(self):
+        assert ReferenceFinder3._apply_pointer(
+            type("P", (), {"name": "index", "arg": 1})(), ["a", "b", "c"]
+        ) == "b"
+
+    def test_index_out_of_range_returns_none(self):
+        assert ReferenceFinder3._apply_pointer(
+            type("P", (), {"name": "index", "arg": 99})(), ["a", "b", "c"]
+        ) is None
+
+    def test_empty_candidates_returns_none(self):
+        assert ReferenceFinder3._apply_pointer(
+            type("P", (), {"name": "first"})(), []
+        ) is None
+
+    def test_unsupported_pointer_name_raises(self):
+        from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+        with pytest.raises(ReferenceException3):
+            ReferenceFinder3._apply_pointer(
+                type("P", (), {"name": "bogus"})(), ["a"]
+            )
+
+
+class TestFindByIdentity:
+    # shared by every finder whose name_three does an identity lookup
+    # (csvpaths' named_paths_identities, results' per-statement
+    # directory names).
+    def test_matches_named_identity(self):
+        assert ReferenceFinder3._find_by_identity("b", ["a", "b", "c"]) == 1
+
+    def test_matches_stringified_index_identity(self):
+        assert ReferenceFinder3._find_by_identity("0", ["0", "named"]) == 0
+
+    def test_no_match_returns_none(self):
+        assert ReferenceFinder3._find_by_identity("nope", ["a", "b"]) is None
+
+
 class TestResolve:
     # resolve_from() always calls _extract_data() for every result now
     # -- the old resolves_to_data gate is gone from the ABC (it moved

--- a/tests/references/test_reference_parser_3.py
+++ b/tests/references/test_reference_parser_3.py
@@ -1,6 +1,7 @@
 import pytest
 
 from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
 from csvpath.references.reference_parser_3 import ReferenceParser3
 
 #
@@ -139,3 +140,91 @@ class TestNameThreeOptional:
     def test_missing_name_three_is_fine_for_every_datatype(self, datatype):
         r = ReferenceParser3(string=f"$acme.{datatype}.a", csvpaths=CSVPATHS)
         assert r.name_three is None
+
+
+class TestStringInterpolationThroughParser:
+    #
+    # exercises the full pipeline (string -> Lark parse -> transform ->
+    # check_valid()) for {...} interpolation, including the error paths
+    # that only surface at this level: lark wraps exceptions raised
+    # inside the STRING terminal transform (unbalanced braces) and
+    # Reference3.check_valid() (non-VALUE function inside {...}) in its
+    # own VisitError -- ReferenceParser3.parse() must unwrap both back
+    # to a plain ReferenceException3. see reference_parser_3.py's
+    # VisitError handling.
+    #
+    def test_bare_variable_interpolation_round_trips(self):
+        original = '$acme.files.a.:name("partner-{@company}-orders")'
+        r = ReferenceParser3(string=original, csvpaths=CSVPATHS)
+        assert r.ref_string == original
+
+    def test_function_interpolation_round_trips(self):
+        # no real VALUE-role function exists yet (evaluation is
+        # deliberately deferred -- see project memory/compendium), so a
+        # test-only one stands in to exercise check_valid()'s acceptance
+        # path plus str() round-tripping through the full pipeline.
+        from csvpath.references.functions.function_3 import Function3
+        from csvpath.references.functions.reference_function_factory_3 import (
+            ReferenceFunctionFactory,
+        )
+
+        class _Year3ForTest(Function3):
+            NAME = "year_for_test"
+            SUMMARY = "test-only value function"
+            ROLE = Function3.VALUE
+            DATATYPES = ()
+            ARG_TYPES = ()
+            ARG_REQUIRED = False
+
+        ReferenceFunctionFactory.add_function(_Year3ForTest)
+        try:
+            original = '$acme.files.a.:name("partner-{:year_for_test()}-{@company}")'
+            r = ReferenceParser3(string=original, csvpaths=CSVPATHS)
+            assert r.ref_string == original
+        finally:
+            del ReferenceFunctionFactory._FUNCTIONS["year_for_test"]
+
+    def test_escaped_braces_round_trip(self):
+        original = '$acme.files.a.:name("literal {{brace}} text")'
+        r = ReferenceParser3(string=original, csvpaths=CSVPATHS)
+        assert r.ref_string == original
+
+    def test_unescaped_open_brace_raises_reference_exception(self):
+        with pytest.raises(ReferenceException3):
+            ReferenceParser3(
+                string='$acme.files.a.:name("oops { unbalanced")',
+                csvpaths=CSVPATHS,
+            )
+
+    def test_unescaped_close_brace_raises_reference_exception(self):
+        with pytest.raises(ReferenceException3):
+            ReferenceParser3(
+                string='$acme.files.a.:name("oops } unbalanced")',
+                csvpaths=CSVPATHS,
+            )
+
+    def test_malformed_interpolation_content_raises_reference_exception(self):
+        with pytest.raises(ReferenceException3):
+            ReferenceParser3(
+                string='$acme.files.a.:name("{not valid syntax!}")',
+                csvpaths=CSVPATHS,
+            )
+
+    def test_pointer_role_function_inside_interpolation_is_rejected(self):
+        # :first() is POINTER -- illegal inside {...}, and this is only
+        # detectable once check_valid() runs against the real function
+        # registry, i.e. at the full-parser level, not the transformer
+        # level (which is structural-only, see
+        # TestStringInterpolation.test_function_interpolation).
+        with pytest.raises(ReferenceException3):
+            ReferenceParser3(
+                string='$acme.files.a.:name("partner-{:first()}-orders")',
+                csvpaths=CSVPATHS,
+            )
+
+    def test_unknown_function_inside_interpolation_is_rejected(self):
+        with pytest.raises(ReferenceException3):
+            ReferenceParser3(
+                string='$acme.files.a.:name("partner-{:not_a_real_function()}")',
+                csvpaths=CSVPATHS,
+            )

--- a/tests/references/test_reference_transformer_3.py
+++ b/tests/references/test_reference_transformer_3.py
@@ -2,6 +2,7 @@ import pytest
 
 from csvpath.references.reference_3 import (
     FunctionCall3,
+    InterpolatedString3,
     Regex3,
     Star3,
     Variable3,
@@ -178,3 +179,58 @@ class TestFunctionArgs:
     def test_string_with_escaped_quote_and_backslash(self, parser):
         r = build(parser, '$acme.files.a.:name("say \\"hi\\"")')
         assert r.name_three.functions[0].arg == 'say "hi"'
+
+
+class TestStringInterpolation:
+    def test_plain_string_with_no_braces_is_unaffected(self, parser):
+        # no InterpolatedString3 wrapper for the overwhelmingly common
+        # no-interpolation case -- stays a plain str.
+        r = build(parser, '$acme.files.a.:name("Acme")')
+        assert r.name_three.functions[0].arg == "Acme"
+
+    def test_bare_variable_interpolation(self, parser):
+        r = build(parser, '$acme.files.a.:name("partner-{@company}-orders")')
+        arg = r.name_three.functions[0].arg
+        assert arg == InterpolatedString3(
+            parts=["partner-", Variable3(name="company"), "-orders"]
+        )
+
+    def test_function_interpolation(self, parser):
+        # structural only -- the transformer does not know or care that
+        # "year" is not a real/registered function yet, it just parses
+        # the {...} span's shape.
+        r = build(parser, '$acme.files.a.:name("partner-{:year()}-orders")')
+        arg = r.name_three.functions[0].arg
+        assert arg == InterpolatedString3(
+            parts=["partner-", FunctionCall3(name="year"), "-orders"]
+        )
+
+    def test_multiple_interpolations(self, parser):
+        r = build(parser, '$acme.files.a.:name("partner-{:year()}-{@company}")')
+        arg = r.name_three.functions[0].arg
+        assert arg == InterpolatedString3(
+            parts=["partner-", FunctionCall3(name="year"), "-", Variable3(name="company")]
+        )
+
+    def test_escaped_braces_yield_a_plain_string(self, parser):
+        r = build(parser, '$acme.files.a.:name("literal {{brace}} text")')
+        assert r.name_three.functions[0].arg == "literal {brace} text"
+
+    def test_escaped_braces_alongside_a_real_interpolation(self, parser):
+        r = build(parser, '$acme.files.a.:name("{{tag}} {@company}")')
+        arg = r.name_three.functions[0].arg
+        assert arg == InterpolatedString3(parts=["{tag} ", Variable3(name="company")])
+
+    def test_interpolation_with_a_nested_function_arg(self, parser):
+        r = build(
+            parser, '$acme.files.a.:name("id-{:idchain(@x)}")'
+        )
+        arg = r.name_three.functions[0].arg
+        assert arg == InterpolatedString3(
+            parts=["id-", FunctionCall3(name="idchain", arg=Variable3(name="x"))]
+        )
+
+    def test_round_trips_through_str(self, parser):
+        original = '$acme.files.a.:name("partner-{:year()}-{@company}")'
+        r = build(parser, original)
+        assert str(r) == original


### PR DESCRIPTION
## Summary
- Add CsvpathsReferenceFinder3, and extract _apply_pointer/_find_by_identity onto the ReferenceFinder3 ABC now that files and csvpaths both need them.
- Add All3 (CONTEXT_SETTER, no arg) and let a csvpaths name_one chain resolve with zero pointers, so a group's every version can actually be listed (Name_one used alone == list of versions, per the STRUCTURE table).
- Add structural parsing/validation for {...} string interpolation in function string args (e.g. :name("partner-{@company}-orders")), since functions take at most one argument so there is no :concat(). Only a bare @variable or a call to a VALUE-role function is legal inside {...}; {{ / }} escapes a literal brace. Evaluation (actually resolving a variable/value against a runtime context) is deliberately deferred - this pass is parsing/validation only.
- Along the way: fixed a round-trip bug where a plain string containing only escaped braces was not being re-escaped on render, and unwrapped lark's VisitError in ReferenceParser3.parse() so errors raised inside the STRING terminal transform surface as ReferenceException3.

## Test plan
- [x] `pytest tests/references/ -q` - 363 passed
- [x] `pytest -q` (full suite) - 1943 passed, 11 failed (pre-existing SFTP/S3/Nos baseline, unrelated)