### PR TITLE
References v3: add :manifest(), the first metadata-file function

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -1,3 +1,6 @@
+from csvpath.util.file_readers import DataFileReader
+from csvpath.util.nos import Nos
+
 from .functions.function_3 import Function3
 from .functions.reference_function_factory_3 import ReferenceFunctionFactory
 from .reference_3 import FunctionCall3, Reference3, Star3
@@ -66,6 +69,9 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 "marker (name_two) -- it is files-only."
             )
 
+        if self._is_bare_pointer_reference(reference, "manifest"):
+            return self._query_manifest(root_major)
+
         manifest = self.csvpaths.paths_manager.get_manifest_for_name(root_major)
         selected_versions = self._resolve_versions(name_one, manifest)
 
@@ -99,11 +105,18 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
     def _extract_data(self, result: ReferenceResult3):
         reference = self.ref.parsed
         kind = reference.resolve_kind
+        if kind == Reference3.METADATA_FILE and self._is_bare_pointer_reference(
+            reference, "manifest"
+        ):
+            # result.path is already the manifest.json path itself (set
+            # by _query_manifest()).
+            with DataFileReader(path=result.path, mode="rb") as reader:
+                return reader.source.read()
         if kind != Reference3.FIRST_PARTY:
             raise ReferenceException3(
                 f"CsvpathsReferenceFinder3 does not yet support "
-                f"resolve_kind={kind!r} -- no metadata-access functions are "
-                "registered for csvpaths yet."
+                f"resolve_kind={kind!r} -- only :manifest() is wired up as "
+                "a metadata-file function so far."
             )
         name_three = reference.name_three
         if name_three is None:
@@ -126,6 +139,22 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
             return None
         statements = selected.get("named_paths") or []
         return statements[index]
+
+    def _query_manifest(self, root_major: str) -> ReferenceResults3:
+        """the ":manifest()" query() branch -- manifest.json is one
+        fixed resource per named-paths group (root_major), covering
+        every loaded/reloaded version, not scoped to any particular
+        version -- so this bypasses _resolve_versions()'s version-
+        selection logic entirely rather than trying to route :manifest()
+        through it (it is POINTER-role, like :first()/:last()/:index(),
+        but is not a list-position lookup -- _apply_pointer() would not
+        know what to do with it). uuid=None: a manifest file is not
+        itself a registered version."""
+        home = self.csvpaths.paths_manager.named_paths_home(root_major)
+        manifest_path = Nos(home).join("manifest.json")
+        return ReferenceResults3(
+            results=[ReferenceResult3(path=manifest_path, uuid=None)]
+        )
 
     def _resolve_versions(self, name_one, manifest: list) -> list:
         """name_one's sole job for csvpaths is selecting which

--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -1,6 +1,3 @@
-from csvpath.util.file_readers import DataFileReader
-from csvpath.util.nos import Nos
-
 from .functions.function_3 import Function3
 from .functions.reference_function_factory_3 import ReferenceFunctionFactory
 from .reference_3 import FunctionCall3, Reference3, Star3
@@ -69,8 +66,16 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 "marker (name_two) -- it is files-only."
             )
 
-        if self._is_bare_pointer_reference(reference, "manifest"):
-            return self._query_manifest(root_major)
+        if self._is_bare_pointer_reference(
+            reference, "manifest"
+        ) or self._is_bare_pointer_reference(reference, "definition"):
+            # both ":manifest()" and ":definition()" are a bare, sole-
+            # content name_one whose function name IS the JSON file's
+            # own name (manifest.json/definition.json) -- see
+            # _query_well_known_file() on the ABC.
+            home = self.csvpaths.paths_manager.named_paths_home(root_major)
+            filename = f"{name_one.path[0].name}.json"
+            return self._query_well_known_file(home, filename)
 
         manifest = self.csvpaths.paths_manager.get_manifest_for_name(root_major)
         selected_versions = self._resolve_versions(name_one, manifest)
@@ -105,18 +110,19 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
     def _extract_data(self, result: ReferenceResult3):
         reference = self.ref.parsed
         kind = reference.resolve_kind
-        if kind == Reference3.METADATA_FILE and self._is_bare_pointer_reference(
-            reference, "manifest"
+        if kind == Reference3.METADATA_FILE and (
+            self._is_bare_pointer_reference(reference, "manifest")
+            or self._is_bare_pointer_reference(reference, "definition")
         ):
-            # result.path is already the manifest.json path itself (set
-            # by _query_manifest()).
-            with DataFileReader(path=result.path, mode="rb") as reader:
-                return reader.source.read()
+            # result.path is already the manifest.json/definition.json
+            # path itself (set by query()'s _query_well_known_file()
+            # branch above).
+            return self._read_well_known_file(result.path)
         if kind != Reference3.FIRST_PARTY:
             raise ReferenceException3(
                 f"CsvpathsReferenceFinder3 does not yet support "
-                f"resolve_kind={kind!r} -- only :manifest() is wired up as "
-                "a metadata-file function so far."
+                f"resolve_kind={kind!r} -- only :manifest()/:definition() "
+                "are wired up as metadata-file functions so far."
             )
         name_three = reference.name_three
         if name_three is None:
@@ -139,22 +145,6 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
             return None
         statements = selected.get("named_paths") or []
         return statements[index]
-
-    def _query_manifest(self, root_major: str) -> ReferenceResults3:
-        """the ":manifest()" query() branch -- manifest.json is one
-        fixed resource per named-paths group (root_major), covering
-        every loaded/reloaded version, not scoped to any particular
-        version -- so this bypasses _resolve_versions()'s version-
-        selection logic entirely rather than trying to route :manifest()
-        through it (it is POINTER-role, like :first()/:last()/:index(),
-        but is not a list-position lookup -- _apply_pointer() would not
-        know what to do with it). uuid=None: a manifest file is not
-        itself a registered version."""
-        home = self.csvpaths.paths_manager.named_paths_home(root_major)
-        manifest_path = Nos(home).join("manifest.json")
-        return ReferenceResults3(
-            results=[ReferenceResult3(path=manifest_path, uuid=None)]
-        )
 
     def _resolve_versions(self, name_one, manifest: list) -> list:
         """name_one's sole job for csvpaths is selecting which

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -1,4 +1,5 @@
 from csvpath.util.file_readers import DataFileReader
+from csvpath.util.nos import Nos
 
 from .functions.function_3 import Function3
 from .functions.reference_function_factory_3 import ReferenceFunctionFactory
@@ -55,6 +56,10 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "FilesReferenceFinder3 does not yet support the '#worksheet' "
                 "marker (name_two)."
             )
+
+        if self._is_bare_pointer_reference(reference, "manifest"):
+            return self._query_manifest(root_major)
+
         if name_one.functions:
             raise ReferenceException3(
                 "FilesReferenceFinder3 does not yet support functions attached "
@@ -118,10 +123,31 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 return None
             with DataFileReader(path=result.path, mode="rb") as reader:
                 return reader.source.read()
+        if kind == Reference3.METADATA_FILE and self._is_bare_pointer_reference(
+            reference, "manifest"
+        ):
+            # result.path is already the manifest.json path itself (set
+            # by _query_manifest()) -- same raw-bytes read as the
+            # FIRST_PARTY case above, just a different resource.
+            with DataFileReader(path=result.path, mode="rb") as reader:
+                return reader.source.read()
         raise ReferenceException3(
             f"FilesReferenceFinder3 does not yet support resolve_kind={kind!r} "
-            "-- no metadata-file/metadata-field functions are registered for "
-            "files yet."
+            "-- only :manifest() is wired up as a metadata-file function "
+            "so far."
+        )
+
+    def _query_manifest(self, root_major: str) -> ReferenceResults3:
+        """the ":manifest()" query() branch -- manifest.json is one
+        fixed resource per named-file (root_major), not scoped to any
+        particular file/version, so this bypasses the "which file"
+        pattern-matching pipeline entirely rather than trying to fit it
+        through _compile_path_pattern/_matches. uuid=None: a manifest
+        file is not itself a registered version."""
+        home = self.csvpaths.file_manager.named_file_home(root_major)
+        manifest_path = Nos(home).join("manifest.json")
+        return ReferenceResults3(
+            results=[ReferenceResult3(path=manifest_path, uuid=None)]
         )
 
     @staticmethod

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -1,5 +1,4 @@
 from csvpath.util.file_readers import DataFileReader
-from csvpath.util.nos import Nos
 
 from .functions.function_3 import Function3
 from .functions.reference_function_factory_3 import ReferenceFunctionFactory
@@ -57,8 +56,16 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "marker (name_two)."
             )
 
-        if self._is_bare_pointer_reference(reference, "manifest"):
-            return self._query_manifest(root_major)
+        if self._is_bare_pointer_reference(
+            reference, "manifest"
+        ) or self._is_bare_pointer_reference(reference, "definition"):
+            # both ":manifest()" and ":definition()" are a bare, sole-
+            # content name_one whose function name IS the JSON file's
+            # own name (manifest.json/definition.json) -- see
+            # _query_well_known_file() on the ABC.
+            home = self.csvpaths.file_manager.named_file_home(root_major)
+            filename = f"{name_one.path[0].name}.json"
+            return self._query_well_known_file(home, filename)
 
         if name_one.functions:
             raise ReferenceException3(
@@ -123,31 +130,18 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 return None
             with DataFileReader(path=result.path, mode="rb") as reader:
                 return reader.source.read()
-        if kind == Reference3.METADATA_FILE and self._is_bare_pointer_reference(
-            reference, "manifest"
+        if kind == Reference3.METADATA_FILE and (
+            self._is_bare_pointer_reference(reference, "manifest")
+            or self._is_bare_pointer_reference(reference, "definition")
         ):
-            # result.path is already the manifest.json path itself (set
-            # by _query_manifest()) -- same raw-bytes read as the
-            # FIRST_PARTY case above, just a different resource.
-            with DataFileReader(path=result.path, mode="rb") as reader:
-                return reader.source.read()
+            # result.path is already the manifest.json/definition.json
+            # path itself (set by query()'s _query_well_known_file()
+            # branch above).
+            return self._read_well_known_file(result.path)
         raise ReferenceException3(
             f"FilesReferenceFinder3 does not yet support resolve_kind={kind!r} "
-            "-- only :manifest() is wired up as a metadata-file function "
-            "so far."
-        )
-
-    def _query_manifest(self, root_major: str) -> ReferenceResults3:
-        """the ":manifest()" query() branch -- manifest.json is one
-        fixed resource per named-file (root_major), not scoped to any
-        particular file/version, so this bypasses the "which file"
-        pattern-matching pipeline entirely rather than trying to fit it
-        through _compile_path_pattern/_matches. uuid=None: a manifest
-        file is not itself a registered version."""
-        home = self.csvpaths.file_manager.named_file_home(root_major)
-        manifest_path = Nos(home).join("manifest.json")
-        return ReferenceResults3(
-            results=[ReferenceResult3(path=manifest_path, uuid=None)]
+            "-- only :manifest()/:definition() are wired up as metadata-"
+            "file functions so far."
         )
 
     @staticmethod

--- a/csvpath/references/functions/definition_3.py
+++ b/csvpath/references/functions/definition_3.py
@@ -1,0 +1,32 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class Definition3(Function3):
+    #
+    # the second metadata-file function, mirroring Manifest3 exactly --
+    # points at the enclosing named-file/named-paths group's own
+    # definition.json (its stored configuration: sources, on_arrival
+    # behavior, scripts, webhooks, etc -- see NamedFileDescriber/
+    # NamedPathsDescriber, both JSON_FILE = "definition.json", stored at
+    # the same home directory as manifest.json). Unlike manifest.json,
+    # definition.json is genuinely optional -- a named-file/group that
+    # was never explicitly configured has no definition.json on disk at
+    # all, and it is not currently versioned (always the single current
+    # definition, regardless of which version of the file/group you are
+    # looking at -- versioning description files is a real future need,
+    # just not yet prioritized). Named-results has no definition.json
+    # equivalent, so this is FILES/CSVPATHS only, unlike Manifest3.
+    #
+    NAME = "definition"
+    SUMMARY = (
+        "Points at the whole definition.json for the enclosing named-file "
+        "or named-paths group -- its stored configuration (sources, "
+        "on_arrival behavior, scripts, webhooks, etc). Not currently "
+        "versioned; resolves to None if the group/file was never "
+        "explicitly configured (no definition.json written yet)."
+    )
+    ROLE = Function3.POINTER
+    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False

--- a/csvpath/references/functions/manifest_3.py
+++ b/csvpath/references/functions/manifest_3.py
@@ -1,0 +1,34 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class Manifest3(Function3):
+    #
+    # the first real metadata-file function -- resolves to the raw
+    # contents of the enclosing named-file/named-paths group's own
+    # manifest.json, the append-only record of every version ever
+    # registered/loaded under that name (see "creating references
+    # v3.txt"'s "Resolve terminating at name_one, with file pointer"
+    # row). ROLE is POINTER, matching the established taxonomy for
+    # well-known-file functions ("In name_three, a pointer resolves to
+    # a well-known metadata file (e.g. :errors())") -- it resolves the
+    # current scope down to exactly one concrete resource, it just
+    # doesn't do it by list-position the way :first()/:last()/:index()
+    # do. Only wired in today as a name_one-terminal, bare/sole-content
+    # reference (e.g. "$acme.files.:manifest()") -- see
+    # FilesReferenceFinder3/CsvpathsReferenceFinder3's own
+    # _is_bare_pointer_reference-gated query() branch. Not yet wired in
+    # for name_three (files' name_three is reserved for version
+    # selection; csvpaths' name_three doesn't support a function chain
+    # at all yet).
+    #
+    NAME = "manifest"
+    SUMMARY = (
+        "Points at the whole manifest.json for the enclosing named-file "
+        "or named-paths group -- the append-only record of every version "
+        "ever registered/loaded under that name."
+    )
+    ROLE = Function3.POINTER
+    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -20,6 +20,7 @@ class ReferenceFunctionFactory:
         from .first_3 import First3
         from .index_3 import Index3
         from .last_3 import Last3
+        from .manifest_3 import Manifest3
         from .name_3 import Name3
 
         cls._FUNCTIONS = {
@@ -28,6 +29,7 @@ class ReferenceFunctionFactory:
             Index3.NAME: Index3,
             Name3.NAME: Name3,
             All3.NAME: All3,
+            Manifest3.NAME: Manifest3,
         }
 
     @classmethod

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -17,6 +17,7 @@ class ReferenceFunctionFactory:
     @classmethod
     def _load(cls) -> None:
         from .all_3 import All3
+        from .definition_3 import Definition3
         from .first_3 import First3
         from .index_3 import Index3
         from .last_3 import Last3
@@ -30,6 +31,7 @@ class ReferenceFunctionFactory:
             Name3.NAME: Name3,
             All3.NAME: All3,
             Manifest3.NAME: Manifest3,
+            Definition3.NAME: Definition3,
         }
 
     @classmethod

--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -458,15 +458,32 @@ class Reference3:
         METADATA_FILE (a whole well-known/named file), or
         METADATA_FIELD (one value drilled out of such a file). computed
         from whichever function chain is terminal: name_three's if
-        name_three is present, else name_one's own trailing chain (a
-        legal terminus now that name_three is optional everywhere).
-        see the _METADATA_FILE_FUNCTIONS/_METADATA_FIELD_FUNCTIONS
-        placeholder comment above -- both lists are stand-ins for traits
-        the future function registry will own."""
+        name_three is present, else name_one's own complete function
+        chain (a legal terminus now that name_three is optional
+        everywhere) -- which includes any function-valued name_one path
+        segment (e.g. a "path-less, function-only" name_one like
+        ":all()"/":manifest()" occupying the sole segment), not just its
+        trailing chain: a metadata-file function can be the whole of
+        name_one with nothing following it (":manifest()" needs
+        exactly this shape to be recognized at all). Safe to widen this
+        way -- an ordinary path-matching function like :name("...")
+        never appears in _METADATA_FILE_FUNCTIONS/_METADATA_FIELD_
+        FUNCTIONS, so including path segments here only lets the real
+        metadata functions be seen, it does not change what gets
+        flagged. see the _METADATA_FILE_FUNCTIONS/_METADATA_FIELD_
+        FUNCTIONS placeholder comment above -- both lists are stand-ins
+        for traits the future function registry will own."""
         terminal_functions = (
             self._name_three.functions
             if self._name_three is not None
-            else self._name_one.functions
+            else [
+                *(
+                    segment
+                    for segment in self._name_one.path
+                    if isinstance(segment, FunctionCall3)
+                ),
+                *self._name_one.functions,
+            ]
         )
         for f in terminal_functions:
             if any(

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from .reference_3 import FunctionCall3, Reference3
 from .reference_exceptions_3 import ReferenceException3
 from .reference_parser_3 import ReferenceParser3
 from .reference_results_3 import ReferenceResult3, ReferenceResults3
@@ -90,6 +91,27 @@ class ReferenceFinder3(ABC):
             except IndexError:
                 return None
         raise ReferenceException3(f"Unsupported pointer function: {pointer.name}")
+
+    @staticmethod
+    def _is_bare_pointer_reference(reference: Reference3, name: str) -> bool:
+        """true when name_one's entire content is a single, argument-
+        less ":name()" call -- no other path segments, no trailing
+        chain, and no name_three. Detects a reference like
+        "$acme.files.:manifest()", which needs its own query() branch
+        entirely separate from ordinary "which file"/"which version"
+        narrowing, since a metadata-file function like :manifest()
+        points at one fixed resource regardless of any path/version
+        selection. Shared here because both files and csvpaths need the
+        identical check for :manifest()."""
+        name_one = reference.name_one
+        return (
+            reference.name_three is None
+            and not name_one.functions
+            and len(name_one.path) == 1
+            and isinstance(name_one.path[0], FunctionCall3)
+            and name_one.path[0].name == name
+            and name_one.path[0].arg is None
+        )
 
     @staticmethod
     def _find_by_identity(identity: str, identities: list) -> int | None:

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -1,5 +1,8 @@
 from abc import ABC, abstractmethod
 
+from csvpath.util.file_readers import DataFileReader
+from csvpath.util.nos import Nos
+
 from .reference_3 import FunctionCall3, Reference3
 from .reference_exceptions_3 import ReferenceException3
 from .reference_parser_3 import ReferenceParser3
@@ -112,6 +115,37 @@ class ReferenceFinder3(ABC):
             and name_one.path[0].name == name
             and name_one.path[0].arg is None
         )
+
+    @staticmethod
+    def _query_well_known_file(home: str, filename: str) -> ReferenceResults3:
+        """query() branch for a fixed, home-directory-scoped JSON
+        resource (manifest.json, definition.json) -- one result,
+        uuid=None (not a registered version), bypassing whatever
+        "which file"/"which version" narrowing the concrete finder
+        would otherwise do for an ordinary reference. Shared by files
+        and csvpaths for both :manifest() and :definition() -- both
+        live at exactly the same named-file/named-paths home directory
+        in either datatype."""
+        path = Nos(home).join(filename)
+        return ReferenceResults3(results=[ReferenceResult3(path=path, uuid=None)])
+
+    @staticmethod
+    def _read_well_known_file(path: str):
+        """reads a well-known, home-directory-scoped JSON resource
+        (manifest.json, definition.json) as raw bytes -- None if it
+        does not exist yet. manifest.json is always created once
+        anything is registered/loaded, but definition.json is genuinely
+        optional -- a named-file/named-paths group that was never
+        explicitly configured has no definition.json on disk at all.
+        The describer classes elsewhere in the codebase (NamedFile
+        Describer/NamedPathsDescriber) already treat that absence as
+        normal, not an error (their own get_json() returns {} rather
+        than raising) -- same treatment here, rather than fabricating
+        an empty-JSON default nobody actually wrote."""
+        if not Nos(path).exists():
+            return None
+        with DataFileReader(path=path, mode="rb") as reader:
+            return reader.source.read()
 
     @staticmethod
     def _find_by_identity(identity: str, identities: list) -> int | None:

--- a/tests/references/functions/test_definition_3.py
+++ b/tests/references/functions/test_definition_3.py
@@ -1,0 +1,23 @@
+import pytest
+
+from csvpath.references.functions.definition_3 import Definition3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Definition3()
+    assert f.name == "definition"
+    assert f.ROLE == Function3.POINTER
+    # unlike Manifest3, results has no definition.json equivalent.
+    assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS)
+
+
+def test_no_arg_is_valid():
+    Definition3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Definition3(arg="x").check_valid()

--- a/tests/references/functions/test_manifest_3.py
+++ b/tests/references/functions/test_manifest_3.py
@@ -1,0 +1,22 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.manifest_3 import Manifest3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Manifest3()
+    assert f.name == "manifest"
+    assert f.ROLE == Function3.POINTER
+    assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+
+
+def test_no_arg_is_valid():
+    Manifest3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Manifest3(arg="x").check_valid()

--- a/tests/references/functions/test_reference_function_factory_3.py
+++ b/tests/references/functions/test_reference_function_factory_3.py
@@ -1,6 +1,7 @@
 import pytest
 
 from csvpath.references.functions.all_3 import All3
+from csvpath.references.functions.definition_3 import Definition3
 from csvpath.references.functions.first_3 import First3
 from csvpath.references.functions.function_3 import Function3
 from csvpath.references.functions.index_3 import Index3
@@ -44,6 +45,10 @@ class TestBuild:
     def test_builds_manifest(self):
         f = ReferenceFunctionFactory.build(FunctionCall3(name="manifest"))
         assert isinstance(f, Manifest3)
+
+    def test_builds_definition(self):
+        f = ReferenceFunctionFactory.build(FunctionCall3(name="definition"))
+        assert isinstance(f, Definition3)
 
     def test_unknown_function_raises(self):
         with pytest.raises(ReferenceException3):

--- a/tests/references/functions/test_reference_function_factory_3.py
+++ b/tests/references/functions/test_reference_function_factory_3.py
@@ -5,6 +5,7 @@ from csvpath.references.functions.first_3 import First3
 from csvpath.references.functions.function_3 import Function3
 from csvpath.references.functions.index_3 import Index3
 from csvpath.references.functions.last_3 import Last3
+from csvpath.references.functions.manifest_3 import Manifest3
 from csvpath.references.functions.name_3 import Name3
 from csvpath.references.functions.reference_function_factory_3 import (
     ReferenceFunctionFactory,
@@ -39,6 +40,10 @@ class TestBuild:
     def test_builds_all(self):
         f = ReferenceFunctionFactory.build(FunctionCall3(name="all"))
         assert isinstance(f, All3)
+
+    def test_builds_manifest(self):
+        f = ReferenceFunctionFactory.build(FunctionCall3(name="manifest"))
+        assert isinstance(f, Manifest3)
 
     def test_unknown_function_raises(self):
         with pytest.raises(ReferenceException3):

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -33,12 +33,19 @@ ACME_MANIFEST = [
 ]
 
 
+GROUP_HOME = "named_paths/acme"
+
+
 class _FakePathsManager:
-    def __init__(self, manifest):
+    def __init__(self, manifest, home=GROUP_HOME):
         self._manifest = manifest
+        self._home = home
 
     def get_manifest_for_name(self, name):
         return self._manifest
+
+    def named_paths_home(self, name):
+        return self._home
 
 
 class _FakeCsvPaths:
@@ -139,6 +146,38 @@ class TestResolve:
         # a whole group version has no single unambiguous payload.
         results = _finder("$acme.csvpaths.:last()").resolve()
         assert results.results[0].data is None
+
+
+class TestManifestFunction:
+    # ":manifest()" is a name_one-terminal, bare/sole-content shape --
+    # it bypasses _resolve_versions()'s version-selection pipeline
+    # entirely and points at the named-paths group's own manifest.json
+    # instead (one fixed resource per group, covering every version).
+    def test_query_returns_the_manifest_path_with_no_uuid(self):
+        results = _finder("$acme.csvpaths.:manifest()").query()
+        assert results.files == [f"{GROUP_HOME}/manifest.json"]
+        assert results.results[0].uuid is None
+
+    def test_resolve_reads_the_manifest_files_raw_bytes(self, tmp_path):
+        content = b"[]"
+        home = tmp_path / "acme"
+        home.mkdir()
+        (home / "manifest.json").write_bytes(content)
+        csvpaths = _FakeCsvPaths(_FakePathsManager(ACME_MANIFEST, home=str(home)))
+        ref = ReferenceParser3(string="$acme.csvpaths.:manifest()", csvpaths=csvpaths)
+        finder = CsvpathsReferenceFinder3(csvpaths=csvpaths, ref=ref)
+        results = finder.resolve()
+        assert results.results[0].data == content
+
+    def test_manifest_combined_with_a_version_pointer_is_two_pointers(self):
+        # :manifest() is POINTER-role but is not a list-position lookup
+        # -- combining it with a real version-selecting function is not
+        # the bare/sole shape, so it falls through to the ordinary
+        # version-selection pipeline, which sees two pointers in one
+        # chain and rejects it (same rule as :first():last() already
+        # being illegal).
+        with pytest.raises(ReferenceException3):
+            _finder("$acme.csvpaths.:manifest():first()").query()
 
 
 class TestScopeLimits:

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -180,6 +180,41 @@ class TestManifestFunction:
             _finder("$acme.csvpaths.:manifest():first()").query()
 
 
+class TestDefinitionFunction:
+    # ":definition()" mirrors ":manifest()" exactly -- same bare, sole-
+    # content shape, same query()/_extract_data() routing -- except
+    # definition.json is genuinely optional, so resolving one that was
+    # never written gives None rather than raising.
+    def test_query_returns_the_definition_path_with_no_uuid(self):
+        results = _finder("$acme.csvpaths.:definition()").query()
+        assert results.files == [f"{GROUP_HOME}/definition.json"]
+        assert results.results[0].uuid is None
+
+    def test_resolve_reads_the_definition_files_raw_bytes(self, tmp_path):
+        content = b'{"_config": {}}'
+        home = tmp_path / "acme"
+        home.mkdir()
+        (home / "definition.json").write_bytes(content)
+        csvpaths = _FakeCsvPaths(_FakePathsManager(ACME_MANIFEST, home=str(home)))
+        ref = ReferenceParser3(
+            string="$acme.csvpaths.:definition()", csvpaths=csvpaths
+        )
+        finder = CsvpathsReferenceFinder3(csvpaths=csvpaths, ref=ref)
+        results = finder.resolve()
+        assert results.results[0].data == content
+
+    def test_resolve_gives_none_when_never_configured(self, tmp_path):
+        home = tmp_path / "acme"
+        home.mkdir()
+        csvpaths = _FakeCsvPaths(_FakePathsManager(ACME_MANIFEST, home=str(home)))
+        ref = ReferenceParser3(
+            string="$acme.csvpaths.:definition()", csvpaths=csvpaths
+        )
+        finder = CsvpathsReferenceFinder3(csvpaths=csvpaths, ref=ref)
+        results = finder.resolve()
+        assert results.results[0].data is None
+
+
 class TestScopeLimits:
     def test_star_root_major_not_yet_supported(self):
         finder = _finder("$*.csvpaths.:last().x")

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -245,6 +245,38 @@ class TestManifestFunction:
             finder.query()
 
 
+class TestDefinitionFunction:
+    # ":definition()" mirrors ":manifest()" exactly -- same bare, sole-
+    # content shape, same query()/_extract_data() routing -- except
+    # definition.json is genuinely optional, so resolving one that was
+    # never written gives None rather than raising.
+    def test_query_returns_the_definition_path_with_no_uuid(self):
+        finder = _finder("$alpha.files.:definition()", ALPHA_HOME, ALPHA_MANIFEST)
+        results = finder.query()
+        assert results.files == [f"{ALPHA_HOME}/definition.json"]
+        assert results.results[0].uuid is None
+
+    def test_resolve_reads_the_definition_files_raw_bytes(self, tmp_path):
+        content = b'{"sources": {}}'
+        home = tmp_path / "alpha"
+        home.mkdir()
+        (home / "definition.json").write_bytes(content)
+        finder = _finder("$alpha.files.:definition()", str(home), ALPHA_MANIFEST)
+        results = finder.resolve()
+        assert results.results[0].data == content
+
+    def test_resolve_gives_none_when_never_configured(self, tmp_path):
+        # a named-file that was never explicitly configured has no
+        # definition.json on disk at all -- this is a normal, expected
+        # absence (matching NamedFileDescriber.get_json()'s own
+        # "return {} if missing" treatment), not an error.
+        home = tmp_path / "alpha"
+        home.mkdir()
+        finder = _finder("$alpha.files.:definition()", str(home), ALPHA_MANIFEST)
+        results = finder.resolve()
+        assert results.results[0].data is None
+
+
 class TestExtractData:
     def test_first_party_returns_raw_file_bytes(self, tmp_path):
         # resolve_kind is FIRST_PARTY by default (no metadata-file/

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -214,6 +214,37 @@ class TestScopeLimits:
             finder.query()
 
 
+class TestManifestFunction:
+    # ":manifest()" is a name_one-terminal, bare/sole-content shape --
+    # it bypasses the "which file" pattern-matching pipeline entirely
+    # and points at the named-file's own manifest.json instead (one
+    # fixed resource per named-file, not scoped to any particular file/
+    # version).
+    def test_query_returns_the_manifest_path_with_no_uuid(self):
+        finder = _finder("$alpha.files.:manifest()", ALPHA_HOME, ALPHA_MANIFEST)
+        results = finder.query()
+        assert results.files == [f"{ALPHA_HOME}/manifest.json"]
+        assert results.results[0].uuid is None
+
+    def test_resolve_reads_the_manifest_files_raw_bytes(self, tmp_path):
+        content = b'[{"file_home": "zero.csv"}]'
+        home = tmp_path / "alpha"
+        home.mkdir()
+        (home / "manifest.json").write_bytes(content)
+        finder = _finder("$alpha.files.:manifest()", str(home), ALPHA_MANIFEST)
+        results = finder.resolve()
+        assert results.results[0].data == content
+
+    def test_manifest_with_extra_path_narrowing_is_not_yet_supported(self):
+        # :manifest() must be name_one's entire content -- combining it
+        # with real path narrowing falls through to the ordinary
+        # "which file" pipeline, which does not recognize it as a
+        # function-valued path segment.
+        finder = _finder("$alpha.files.a/:manifest()", ALPHA_HOME, ALPHA_MANIFEST)
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+
 class TestExtractData:
     def test_first_party_returns_raw_file_bytes(self, tmp_path):
         # resolve_kind is FIRST_PARTY by default (no metadata-file/

--- a/tests/references/test_reference_3.py
+++ b/tests/references/test_reference_3.py
@@ -508,3 +508,16 @@ class TestResolveKind:
             name_one=self._name_one("a", functions=[FunctionCall3(name="errors")]),
         )
         assert r.resolve_kind == Reference3.METADATA_FILE
+
+    def test_uses_name_one_path_segment_function_when_it_is_the_sole_content(self):
+        # a "path-less, function-only" name_one (e.g. ":manifest()" or
+        # ":all()" occupying the sole path segment) has its function in
+        # .path, not .functions -- resolve_kind must look there too, not
+        # just at the trailing chain, or a bare "$acme.files.:manifest()"
+        # would be misclassified as FIRST_PARTY.
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.FILES,
+            name_one=self._name_one(FunctionCall3(name="manifest")),
+        )
+        assert r.resolve_kind == Reference3.METADATA_FILE

--- a/tests/references/test_reference_finder_3.py
+++ b/tests/references/test_reference_finder_3.py
@@ -144,6 +144,28 @@ class TestIsBarePointerReference:
         assert not ReferenceFinder3._is_bare_pointer_reference(r, "manifest")
 
 
+class TestQueryWellKnownFile:
+    # shared query() branch for a fixed, home-directory-scoped JSON
+    # resource (manifest.json, definition.json) -- both files and
+    # csvpaths route :manifest()/:definition() through this.
+    def test_returns_one_result_with_no_uuid(self):
+        results = ReferenceFinder3._query_well_known_file("some/home", "manifest.json")
+        assert results.files == ["some/home/manifest.json"]
+        assert results.results[0].uuid is None
+
+
+class TestReadWellKnownFile:
+    def test_reads_raw_bytes_when_the_file_exists(self, tmp_path):
+        content = b'{"a": 1}'
+        path = tmp_path / "definition.json"
+        path.write_bytes(content)
+        assert ReferenceFinder3._read_well_known_file(str(path)) == content
+
+    def test_returns_none_when_the_file_does_not_exist(self, tmp_path):
+        missing = tmp_path / "definition.json"
+        assert ReferenceFinder3._read_well_known_file(str(missing)) is None
+
+
 class TestFindByIdentity:
     # shared by every finder whose name_three does an identity lookup
     # (csvpaths' named_paths_identities, results' per-statement

--- a/tests/references/test_reference_finder_3.py
+++ b/tests/references/test_reference_finder_3.py
@@ -1,5 +1,6 @@
 import pytest
 
+from csvpath.references.reference_3 import FunctionCall3, NameOne3, NameThree3, Reference3
 from csvpath.references.reference_finder_3 import ReferenceFinder3
 from csvpath.references.reference_parser_3 import ReferenceParser3
 from csvpath.references.reference_results_3 import ReferenceResult3, ReferenceResults3
@@ -90,6 +91,57 @@ class TestApplyPointer:
             ReferenceFinder3._apply_pointer(
                 type("P", (), {"name": "bogus"})(), ["a"]
             )
+
+
+class TestIsBarePointerReference:
+    # shared by every finder that needs to detect a ":manifest()"-style,
+    # sole-content name_one shape (files, csvpaths) -- see :manifest()'s
+    # own query() branch in each finder, which must bypass ordinary
+    # "which file"/"which version" narrowing entirely for this shape.
+    @staticmethod
+    def _ref(name_one, name_three=None) -> Reference3:
+        return Reference3(
+            root_major="acme",
+            datatype=Reference3.FILES,
+            name_one=name_one,
+            name_three=name_three,
+        )
+
+    def test_true_for_bare_sole_function(self):
+        r = self._ref(NameOne3(path=[FunctionCall3(name="manifest")]))
+        assert ReferenceFinder3._is_bare_pointer_reference(r, "manifest")
+
+    def test_false_for_different_function_name(self):
+        r = self._ref(NameOne3(path=[FunctionCall3(name="all")]))
+        assert not ReferenceFinder3._is_bare_pointer_reference(r, "manifest")
+
+    def test_false_when_function_has_an_arg(self):
+        r = self._ref(NameOne3(path=[FunctionCall3(name="manifest", arg="x")]))
+        assert not ReferenceFinder3._is_bare_pointer_reference(r, "manifest")
+
+    def test_false_with_extra_path_segment(self):
+        r = self._ref(NameOne3(path=["a", FunctionCall3(name="manifest")]))
+        assert not ReferenceFinder3._is_bare_pointer_reference(r, "manifest")
+
+    def test_false_with_trailing_functions(self):
+        r = self._ref(
+            NameOne3(
+                path=[FunctionCall3(name="manifest")],
+                functions=[FunctionCall3(name="first")],
+            )
+        )
+        assert not ReferenceFinder3._is_bare_pointer_reference(r, "manifest")
+
+    def test_false_when_name_three_present(self):
+        r = self._ref(
+            NameOne3(path=[FunctionCall3(name="manifest")]),
+            name_three=NameThree3(body="v1"),
+        )
+        assert not ReferenceFinder3._is_bare_pointer_reference(r, "manifest")
+
+    def test_false_for_literal_path_segment(self):
+        r = self._ref(NameOne3(path=["manifest"]))
+        assert not ReferenceFinder3._is_bare_pointer_reference(r, "manifest")
 
 
 class TestFindByIdentity:


### PR DESCRIPTION
## Summary
- Add Manifest3 (POINTER role, no arg) - the first real metadata-file function, resolving to the raw contents of a named-file or named-paths group own manifest.json.
- Add ReferenceFinder3._is_bare_pointer_reference(reference, name), shared on the ABC: detects a name_one-terminal reference whose entire content is a single, argument-less function (e.g. "$acme.files.:manifest()"). Both FilesReferenceFinder3 and CsvpathsReferenceFinder3 check this first in query() and route to a new _query_manifest() when it matches, bypassing ordinary path/version selection entirely.
- Fix a latent bug in Reference3.resolve_kind: it only inspected name_one.functions (the trailing chain) when name_three was absent, missing a function occupying the sole path segment of name_one (the same shape :all() already uses) - so a bare ":manifest()" reference was silently misclassified as FIRST_PARTY. Safe fix - an ordinary path-matching function like :name(...) never matches the metadata-function name lists, so this only widens what gets seen, not what gets flagged.

This closes one of two intermediate steps identified before building ResultsReferenceFinder3 (proving out a metadata-file function against a simpler finder first). The other, resolving how run ordering works for named-results, was already settled by direct experiment.

## Test plan
- [x] `pytest tests/references/ -q` - 381 passed
- [x] `pytest -q` (full suite) - 1961 passed, 11 failed (pre-existing SFTP/S3/Nos baseline, unrelated)
- [x] Verified end to end against a real manifest.json on disk, not just fakes