### PR TITLE
References v3: fix :manifest()/:definition() ROLE, make :manifest() context-aware

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -22,7 +22,12 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
     #    absent (e.g. a bare :all()), every version in the manifest is
     #    returned, unreduced -- this is how "list of versions in the
     #    form: (path-to-group.csvpaths, uuid)" (STRUCTURE table) is
-    #    actually reached. Literal/"*"/path-building content, and the
+    #    actually reached. ":manifest()" may ride alongside the version
+    #    pointer in this same combined chain (e.g. ":last():manifest()")
+    #    -- it never narrows/selects itself (see functions/manifest_3.py),
+    #    it just changes what _extract_data() resolves to: the matched
+    #    version's own manifest entry, instead of its statement text.
+    #    Literal/"*"/path-building content, and the
     #    "#worksheet" marker (name_two, files-only), are not meaningful
     #    for csvpaths and are rejected. :uuid() is not yet a registered
     #    function, so it is "not yet supported" for now like any other
@@ -110,14 +115,29 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
     def _extract_data(self, result: ReferenceResult3):
         reference = self.ref.parsed
         kind = reference.resolve_kind
-        if kind == Reference3.METADATA_FILE and (
-            self._is_bare_pointer_reference(reference, "manifest")
-            or self._is_bare_pointer_reference(reference, "definition")
-        ):
-            # result.path is already the manifest.json/definition.json
-            # path itself (set by query()'s _query_well_known_file()
-            # branch above).
-            return self._read_well_known_file(result.path)
+        if kind == Reference3.METADATA_FILE:
+            if self._is_bare_pointer_reference(
+                reference, "manifest"
+            ) or self._is_bare_pointer_reference(reference, "definition"):
+                # result.path is already the manifest.json/definition.json
+                # path itself (set by query()'s _query_well_known_file()
+                # branch above).
+                return self._read_well_known_file(result.path)
+            name_one = reference.name_one
+            has_manifest = any(
+                seg.contains_function_named("manifest")
+                for seg in (name_one.path[0], *name_one.functions)
+                if isinstance(seg, FunctionCall3)
+            )
+            if has_manifest:
+                # :manifest() riding alongside the real version-selecting
+                # pointer already in name_one's own combined chain (e.g.
+                # ":last():manifest()") -- give the matched version's own
+                # manifest entry, not the whole raw file.
+                manifest = self.csvpaths.paths_manager.get_manifest_for_name(
+                    reference.root_major
+                )
+                return self._find_manifest_entry_by_uuid(manifest, result.uuid)
         if kind != Reference3.FIRST_PARTY:
             raise ReferenceException3(
                 f"CsvpathsReferenceFinder3 does not yet support "
@@ -134,9 +154,7 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         manifest = self.csvpaths.paths_manager.get_manifest_for_name(
             reference.root_major
         )
-        selected = next(
-            (entry for entry in manifest if entry["uuid"] == result.uuid), None
-        )
+        selected = self._find_manifest_entry_by_uuid(manifest, result.uuid)
         if selected is None:
             return None
         identities = selected.get("named_paths_identities") or []

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -2,7 +2,7 @@ from csvpath.util.file_readers import DataFileReader
 
 from .functions.function_3 import Function3
 from .functions.reference_function_factory_3 import ReferenceFunctionFactory
-from .reference_3 import FunctionCall3, Reference3, Star3
+from .reference_3 import Reference3, Star3
 from .reference_exceptions_3 import ReferenceException3
 from .reference_finder_3 import ReferenceFinder3
 from .reference_results_3 import ReferenceResult3, ReferenceResults3
@@ -172,31 +172,6 @@ class FilesReferenceFinder3(ReferenceFinder3):
             "-- only :manifest()/:definition() are wired up as metadata-"
             "file functions so far."
         )
-
-    @staticmethod
-    def _compile_path_pattern(path: list) -> list:
-        """turns name_one.path into a list of str/Star3 to match against
-        real file_home segments. a literal str or Star3 segment passes
-        through unchanged; a :name("...") segment is compiled and
-        unwrapped to its literal string, so matching downstream doesn't
-        need to know the difference. any other function-valued segment
-        is explicitly not yet supported."""
-        pattern = []
-        for segment in path:
-            if isinstance(segment, FunctionCall3):
-                if segment.name != "name":
-                    raise ReferenceException3(
-                        f"FilesReferenceFinder3 does not yet support :{segment.name}() "
-                        "as a name_one path segment -- only :name(\"...\") and "
-                        "literal/'*' segments are supported."
-                    )
-                built = ReferenceFunctionFactory.build(segment)
-                pattern.append(built.arg)
-            elif isinstance(segment, (str, Star3)):
-                pattern.append(segment)
-            else:
-                raise ReferenceException3(f"Unsupported name_one path segment: {segment!r}")
-        return pattern
 
     @staticmethod
     def _matches(entry: dict, home: str, pattern: list) -> bool:

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -22,7 +22,12 @@ class FilesReferenceFinder3(ReferenceFinder3):
     #    function (:first()/:last()/:index(n)) -- matching the
     #    STRUCTURE table: name_one picks *which file*, name_three picks
     #    *which version*. A literal name_three body (bypassing a
-    #    pointer function entirely) is not yet supported. name_three is
+    #    pointer function entirely) is not yet supported. ":manifest()"
+    #    may ride alongside the pointer (e.g. ":last():manifest()" --
+    #    the matched version's own manifest entry) or appear alone with
+    #    no pointer at all (e.g. ":manifest()" alone -- every matching
+    #    version's entry, unreduced) -- it never narrows/selects itself,
+    #    see functions/manifest_3.py. name_three is
     #    optional: when absent, name_one alone is a prefix search that
     #    returns zero or more paths to file-home directories (one per
     #    distinct file matched, deduplicated across versions) -- per
@@ -102,20 +107,33 @@ class FilesReferenceFinder3(ReferenceFinder3):
             )
         built = ReferenceFunctionFactory.build_chain(name_three.functions)
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
-        if len(pointers) != 1:
+        has_manifest = any(f.name == "manifest" for f in built)
+        if not pointers and not has_manifest:
             raise ReferenceException3(
                 "FilesReferenceFinder3 requires name_three to resolve to "
-                "exactly one pointer function (:first()/:last()/:index(n))."
+                "exactly one pointer function (:first()/:last()/:index(n)), "
+                "optionally combined with :manifest()."
             )
-        pointer = pointers[0]
 
-        selected = self._apply_pointer(pointer, candidates)
-        results = []
-        if selected is not None:
-            results.append(
-                ReferenceResult3(path=selected["file"], uuid=selected["uuid"])
-            )
-        return ReferenceResults3(results=results)
+        if pointers:
+            # a pointer (with or without :manifest() riding alongside it)
+            # reduces to one specific version, same as before.
+            selected = self._apply_pointer(pointers[0], candidates)
+            selected_candidates = [selected] if selected is not None else []
+        else:
+            # :manifest() alone, no pointer -- every version matching
+            # name_one's own path narrowing, unreduced. This is how
+            # "$acme.files.orders.:manifest()" (David's own example) is
+            # actually reached: the manifest entries of every
+            # registration under "orders", not just one.
+            selected_candidates = candidates
+
+        return ReferenceResults3(
+            results=[
+                ReferenceResult3(path=c["file"], uuid=c["uuid"])
+                for c in selected_candidates
+            ]
+        )
 
     def _extract_data(self, result: ReferenceResult3):
         reference = self.ref.parsed
@@ -130,14 +148,25 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 return None
             with DataFileReader(path=result.path, mode="rb") as reader:
                 return reader.source.read()
-        if kind == Reference3.METADATA_FILE and (
-            self._is_bare_pointer_reference(reference, "manifest")
-            or self._is_bare_pointer_reference(reference, "definition")
-        ):
-            # result.path is already the manifest.json/definition.json
-            # path itself (set by query()'s _query_well_known_file()
-            # branch above).
-            return self._read_well_known_file(result.path)
+        if kind == Reference3.METADATA_FILE:
+            if self._is_bare_pointer_reference(
+                reference, "manifest"
+            ) or self._is_bare_pointer_reference(reference, "definition"):
+                # result.path is already the manifest.json/definition.json
+                # path itself (set by query()'s _query_well_known_file()
+                # branch above).
+                return self._read_well_known_file(result.path)
+            if reference.name_three is not None and any(
+                f.contains_function_named("manifest")
+                for f in reference.name_three.functions
+            ):
+                # :manifest() riding alongside a real path/version match
+                # (a pointer, or none at all -- see query()) -- give the
+                # matched entry itself, not the whole raw file.
+                manifest = self.csvpaths.file_manager.get_manifest(
+                    reference.root_major
+                )
+                return self._find_manifest_entry_by_uuid(manifest, result.uuid)
         raise ReferenceException3(
             f"FilesReferenceFinder3 does not yet support resolve_kind={kind!r} "
             "-- only :manifest()/:definition() are wired up as metadata-"

--- a/csvpath/references/functions/manifest_3.py
+++ b/csvpath/references/functions/manifest_3.py
@@ -4,31 +4,40 @@ from .function_3 import Function3
 
 class Manifest3(Function3):
     #
-    # the first real metadata-file function -- resolves to the raw
-    # contents of the enclosing named-file/named-paths group's own
-    # manifest.json, the append-only record of every version ever
-    # registered/loaded under that name (see "creating references
-    # v3.txt"'s "Resolve terminating at name_one, with file pointer"
-    # row). ROLE is POINTER, matching the established taxonomy for
-    # well-known-file functions ("In name_three, a pointer resolves to
-    # a well-known metadata file (e.g. :errors())") -- it resolves the
-    # current scope down to exactly one concrete resource, it just
-    # doesn't do it by list-position the way :first()/:last()/:index()
-    # do. Only wired in today as a name_one-terminal, bare/sole-content
-    # reference (e.g. "$acme.files.:manifest()") -- see
-    # FilesReferenceFinder3/CsvpathsReferenceFinder3's own
-    # _is_bare_pointer_reference-gated query() branch. Not yet wired in
-    # for name_three (files' name_three is reserved for version
-    # selection; csvpaths' name_three doesn't support a function chain
-    # at all yet).
+    # the first real metadata-file function -- resolves to the manifest
+    # data of the enclosing named-file/named-paths group, or of whatever
+    # more specific scope has already been identified alongside it (see
+    # "creating references v3.txt"'s "Resolve terminating at name_one,
+    # with file pointer" row).
+    #
+    # ROLE is VALUE, not POINTER -- corrected after realizing the
+    # original POINTER assignment was wrong: :manifest() never narrows
+    # or selects anything itself, in any of its usages. Even bare
+    # ("$acme.files.:manifest()") it isn't resolving scope down from
+    # multiple candidates -- root_major already fully identifies the one
+    # named-file: :manifest() just accesses its manifest. This only
+    # became visible as a problem once :manifest() needed to sit
+    # *beside* a real version-selecting pointer in the same chain (e.g.
+    # "$acme.files.a.:last():manifest()") -- as POINTER it would have
+    # been double-counted by ReferenceFunctionFactory.build_chain()'s
+    # "at most one pointer per chain" rule, even though nothing is
+    # actually being narrowed twice. VALUE is excluded from that count,
+    # same as a computed value like a future :year() would be.
+    #
+    # Wired in for two name_one-terminal shapes: bare/sole-content
+    # (e.g. "$acme.files.:manifest()" -- the whole raw manifest.json) and
+    # combined with real path/version narrowing in name_three, where it
+    # resolves to the matched entry/entries instead (see
+    # FilesReferenceFinder3/CsvpathsReferenceFinder3's own handling).
     #
     NAME = "manifest"
     SUMMARY = (
-        "Points at the whole manifest.json for the enclosing named-file "
-        "or named-paths group -- the append-only record of every version "
-        "ever registered/loaded under that name."
+        "Points at the manifest data for the enclosing named-file or "
+        "named-paths group -- the whole file when nothing else narrows "
+        "scope, or the matched entry/entries when combined with real "
+        "path/version narrowing."
     )
-    ROLE = Function3.POINTER
+    ROLE = Function3.VALUE
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -148,6 +148,15 @@ class ReferenceFinder3(ABC):
             return reader.source.read()
 
     @staticmethod
+    def _find_manifest_entry_by_uuid(manifest: list, uuid: str) -> dict | None:
+        """returns the manifest array entry whose "uuid" matches, or None
+        if absent -- shared by any finder resolving a ":manifest()" call
+        that rides alongside a real pointer (the entry the pointer
+        already selected, per Reference3.resolve_kind's METADATA_FILE
+        classification), rather than the whole raw file."""
+        return next((entry for entry in manifest if entry["uuid"] == uuid), None)
+
+    @staticmethod
     def _find_by_identity(identity: str, identities: list) -> int | None:
         """returns the index of `identity` within `identities` (exact
         string match), or None if absent. shared by any finder whose

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -3,7 +3,8 @@ from abc import ABC, abstractmethod
 from csvpath.util.file_readers import DataFileReader
 from csvpath.util.nos import Nos
 
-from .reference_3 import FunctionCall3, Reference3
+from .functions.reference_function_factory_3 import ReferenceFunctionFactory
+from .reference_3 import FunctionCall3, Reference3, Star3
 from .reference_exceptions_3 import ReferenceException3
 from .reference_parser_3 import ReferenceParser3
 from .reference_results_3 import ReferenceResult3, ReferenceResults3
@@ -155,6 +156,37 @@ class ReferenceFinder3(ABC):
         already selected, per Reference3.resolve_kind's METADATA_FILE
         classification), rather than the whole raw file."""
         return next((entry for entry in manifest if entry["uuid"] == uuid), None)
+
+    @staticmethod
+    def _compile_path_pattern(path: list) -> list:
+        """turns a name_one path into a list of str/Star3 to match
+        against real path segments (a manifest entry's file_home for
+        files, real directory names for results). a literal str or
+        Star3 segment passes through unchanged; a :name("...") segment
+        is compiled and unwrapped to its literal string, so matching
+        downstream doesn't need to know the difference -- built
+        specifically because a literal name containing characters a
+        bare PATH_SEGMENT cannot hold (e.g. a real filename's ".") has
+        no other way to appear. any other function-valued segment is
+        explicitly not yet supported. shared by files and results --
+        both have a real, literal/star/:name(...) path to match; csvpaths
+        does not (its whole name_one is version-selecting functions)."""
+        pattern = []
+        for segment in path:
+            if isinstance(segment, FunctionCall3):
+                if segment.name != "name":
+                    raise ReferenceException3(
+                        f"Does not yet support :{segment.name}() as a "
+                        "name_one path segment -- only :name(\"...\") and "
+                        "literal/'*' segments are supported."
+                    )
+                built = ReferenceFunctionFactory.build(segment)
+                pattern.append(built.arg)
+            elif isinstance(segment, (str, Star3)):
+                pattern.append(segment)
+            else:
+                raise ReferenceException3(f"Unsupported name_one path segment: {segment!r}")
+        return pattern
 
     @staticmethod
     def _find_by_identity(identity: str, identities: list) -> int | None:

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -1,0 +1,266 @@
+import json
+
+from csvpath.util.file_readers import DataFileReader
+from csvpath.util.nos import Nos
+
+from .functions.function_3 import Function3
+from .functions.reference_function_factory_3 import ReferenceFunctionFactory
+from .reference_3 import FunctionCall3, Reference3, Star3
+from .reference_exceptions_3 import ReferenceException3
+from .reference_finder_3 import ReferenceFinder3
+from .reference_results_3 import ReferenceResult3, ReferenceResults3
+
+#
+# first pass, deliberately narrow, mirroring Files/CsvpathsReferenceFinder3's
+# scoping approach -- but results is its own shape, the STRUCTURE table's
+# "deepest hierarchy": name_one is a path-like prefix search AS WELL AS the
+# version (run) selector, both together (unlike files, which splits "which
+# file"/name_one from "which version"/name_three; unlike csvpaths, which has
+# no real path at all). name_three identifies one csvpath statement's own
+# result directory within the selected run(s).
+#
+#  - root_major is a literal named-results name (the same name as the named-
+#    paths group that was run). "*" (every named-results group) is a
+#    different traversal problem, not yet built.
+#  - name_one has TWO legal shapes, matching the spec's own examples
+#    ("$acme.results.:all()"/"$acme.results.:last()" alongside
+#    "$acme.results.customers/2025:first()"):
+#      (a) bare/function-only, no literal path at all (mirrors csvpaths --
+#          the sole path "segment" is itself a version-selecting function,
+#          e.g. :all()/:first()/:last()/:index(n)). Used when there is no
+#          template, or the caller does not care about path narrowing --
+#          the named-results home directory itself is the "prefix".
+#      (b) literal/"*"/:name("...") path segments (same semantics as files
+#          -- see ReferenceFinder3._compile_path_pattern) PLUS its own
+#          trailing function chain.
+#    Either way, the combined chain (whichever function(s) are not path-
+#    building) may contain at most one pointer function (:first()/:last()/
+#    :index(n)): if present, it reduces each matched prefix to that
+#    prefix's one specific run; if absent, every run under each matched
+#    prefix comes back, unreduced. This is how "Name_one used alone == path
+#    to run dir" (STRUCTURE table) is reached, matching how
+#    CsvpathsReferenceFinder3 already handles "zero or one pointer" for its
+#    own combined chain. The "#worksheet" marker (name_two, files-only) is
+#    not meaningful here and is rejected.
+#    KNOWN LIMITATION: this finder does not know how many literal path
+#    segments a given named-results group's template actually has before
+#    reaching the run-directory level (that lives in the group's own
+#    template string, e.g. via PathsManager.get_template_for_paths()) --
+#    it simply treats whatever directories the given pattern matches as
+#    "the runs". Under-specifying the path (fewer segments than the real
+#    template) silently treats an intermediate directory's own children as
+#    if they were runs, rather than raising. Not validated in this pass.
+#  - name_three, if present, is an identity lookup into the selected run's
+#    own instance-directory listing (one subdirectory per csvpath statement,
+#    named by that statement's identity -- same convention as csvpaths'
+#    named_paths_identities) -- matched by identity string, or by :all() for
+#    every instance in the run. Well-known instance-level file functions
+#    (:data()/:vars()/:meta()/:unmatched()/:errors()) are not yet
+#    registered, so resolving a matched instance always gives None for now
+#    (no default) -- query() still finds every matched path+uuid correctly,
+#    resolve() just has nothing further to extract yet.
+#
+# storage facts this relies on (confirmed against ResultsManager/
+# ResultsRegistrar/ResultRegistrar/ResultSerializer, not assumed): there is
+# no per-named-results-group manifest array the way files/csvpaths have --
+# query() has to walk real directories. Run directories are named
+# "%Y-%m-%d_%H-%M-%S[_N]" (RunHomeMaker), lexicographically sortable =
+# chronological (confirmed by direct experiment -- see project memory).
+# Each run directory has its own manifest.json (a single dict, not an
+# array -- "run_uuid" identifies the run itself). Each run directory
+# contains one subdirectory per csvpath statement, named by that
+# statement's own identity (ResultSerializer.get_instance_dir), each with
+# its own manifest.json (a single dict; "uuid" identifies that instance).
+#
+
+
+class ResultsReferenceFinder3(ReferenceFinder3):
+    def query(self) -> ReferenceResults3:
+        reference = self.ref.parsed
+        root_major = reference.root_major
+        if isinstance(root_major, Star3):
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 does not yet support '*' as "
+                "root_major (querying every named-results group) -- use a "
+                "literal group name."
+            )
+
+        name_one = reference.name_one
+        if name_one.name_two is not None:
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 does not support the '#worksheet' "
+                "marker (name_two) -- it is files-only."
+            )
+
+        home = self.csvpaths.results_manager.get_named_results_home(root_major)
+        if self._is_bare_function_only(name_one):
+            # mirrors csvpaths: no literal path at all, e.g.
+            # "$acme.results.:all()"/"$acme.results.:last()" -- the named-
+            # results home directory itself is the "prefix".
+            prefixes = [home]
+            calls = [name_one.path[0], *name_one.functions]
+        else:
+            pattern = self._compile_path_pattern(name_one.path)
+            prefixes = self._matching_prefix_dirs(home, pattern)
+            calls = list(name_one.functions)
+
+        pointer = self._pointer_from_calls(calls)
+        identity, match_all = self._name_three_selector(reference.name_three)
+
+        results = []
+        for prefix in prefixes:
+            run_names = sorted(Nos(prefix).listdir(dirs_only=True))
+            if pointer is not None:
+                selected = self._apply_pointer(pointer, run_names)
+                selected_runs = [selected] if selected is not None else []
+            else:
+                selected_runs = run_names
+
+            for run_name in selected_runs:
+                run_dir = Nos(prefix).join(run_name)
+                results.extend(
+                    self._results_for_run(run_dir, identity, match_all)
+                )
+        return ReferenceResults3(results=results)
+
+    def _extract_data(self, result: ReferenceResult3):
+        reference = self.ref.parsed
+        kind = reference.resolve_kind
+        if kind != Reference3.FIRST_PARTY:
+            raise ReferenceException3(
+                f"ResultsReferenceFinder3 does not yet support "
+                f"resolve_kind={kind!r} -- no metadata-file/metadata-field "
+                "functions are registered for results yet."
+            )
+        # neither a whole run directory nor an instance directory matched
+        # by identity/:all() has a single unambiguous payload without a
+        # well-known-file function -- none registered yet, so "no
+        # default" applies uniformly here, per "creating references
+        # v3.txt"'s resolve table.
+        return None
+
+    def _results_for_run(
+        self, run_dir: str, identity: str | None, match_all: bool
+    ) -> list[ReferenceResult3]:
+        if identity is None and not match_all:
+            uuid = self._read_json_field(
+                Nos(run_dir).join("manifest.json"), "run_uuid"
+            )
+            return [ReferenceResult3(path=run_dir, uuid=uuid)]
+
+        instances = self._list_instance_identities(run_dir)
+        if match_all:
+            matched = instances
+        else:
+            index = self._find_by_identity(identity, instances)
+            matched = [instances[index]] if index is not None else []
+
+        found = []
+        for inst in matched:
+            inst_dir = Nos(run_dir).join(inst)
+            uuid = self._read_json_field(
+                Nos(inst_dir).join("manifest.json"), "uuid"
+            )
+            found.append(ReferenceResult3(path=inst_dir, uuid=uuid))
+        return found
+
+    @staticmethod
+    def _is_bare_function_only(name_one) -> bool:
+        """true for a name_one with no literal path at all -- its sole
+        path "segment" is itself a version-selecting function (e.g.
+        :all()/:first()/:last()/:index(n)), mirroring csvpaths' own
+        "path[0] is a FunctionCall3" shape. :name("...") is excluded --
+        that is path-*building* (a literal name), not a version
+        selector, so it stays in the ordinary literal-path shape even
+        as the sole segment."""
+        return (
+            len(name_one.path) == 1
+            and isinstance(name_one.path[0], FunctionCall3)
+            and name_one.path[0].name != "name"
+        )
+
+    @staticmethod
+    def _pointer_from_calls(calls: list):
+        """at most one pointer function (:first()/:last()/:index(n))
+        among the combined chain selects which run -- build_chain()
+        already enforces the "at most one" rule; absent means every run
+        comes back unreduced."""
+        if not calls:
+            return None
+        built = ReferenceFunctionFactory.build_chain(calls)
+        pointers = [f for f in built if f.ROLE == Function3.POINTER]
+        return pointers[0] if pointers else None
+
+    @staticmethod
+    def _name_three_selector(name_three) -> tuple[str | None, bool]:
+        """returns (identity, match_all) for name_three -- identity is a
+        literal statement-identity string to look up, match_all is True
+        for a bare :all() (every instance in the run, unfiltered). Any
+        other function (well-known instance-level files -- :data()/
+        :vars()/:meta()/:unmatched()/:errors()) is not yet registered
+        and raises via build_chain() itself ("Unknown reference
+        function"); any registered function other than :all() (there is
+        no other one that makes sense here) is explicitly rejected too."""
+        if name_three is None:
+            return None, False
+        if name_three.functions:
+            built = ReferenceFunctionFactory.build_chain(name_three.functions)
+            if not (len(built) == 1 and built[0].name == "all"):
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3 only supports :all() as a "
+                    "name_three function for now -- well-known instance "
+                    "files (:data()/:vars()/:meta()/:unmatched()/"
+                    ":errors()) are not yet registered for results."
+                )
+            return None, True
+        if isinstance(name_three.body, Star3):
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 does not support a bare '*' as "
+                "name_three's body -- use :all() instead."
+            )
+        return name_three.body, False
+
+    @staticmethod
+    def _matching_prefix_dirs(home: str, pattern: list) -> list[str]:
+        """walks real directories under `home`, matching each literal/
+        Star3 pattern segment against one level of subdirectories --
+        the results-side equivalent of FilesReferenceFinder3's manifest-
+        array matching, needed because there is no per-named-results-
+        group manifest array to scan (confirmed by direct experiment --
+        see project memory) -- only real directories on disk."""
+        current = [home]
+        for segment in pattern:
+            next_level = []
+            for base in current:
+                for name in sorted(Nos(base).listdir(dirs_only=True)):
+                    if isinstance(segment, Star3) or name == segment:
+                        next_level.append(Nos(base).join(name))
+            current = next_level
+        return current
+
+    @staticmethod
+    def _list_instance_identities(run_dir: str) -> list[str]:
+        """every csvpath statement's own result subdirectory within a
+        run, named by that statement's identity -- "_extra_data" is the
+        one non-instance directory a run dir can contain (manifest.json
+        is a file, already excluded by dirs_only)."""
+        return [
+            name
+            for name in Nos(run_dir).listdir(dirs_only=True)
+            if name != "_extra_data"
+        ]
+
+    @staticmethod
+    def _read_json_field(path: str, field: str):
+        """reads one field from a small JSON file (a run's or an
+        instance's own manifest.json), tolerating absence -- None if the
+        file does not exist rather than raising or fabricating a
+        default. Deliberately does not reuse ResultFileReader.json_file()
+        here -- that helper writes a fresh empty JSON file when one is
+        missing, a write side effect a read-only reference query must
+        never trigger."""
+        if not Nos(path).exists():
+            return None
+        with DataFileReader(path) as reader:
+            data = json.load(reader.source)
+        return data.get(field)

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -28,28 +28,20 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 #      (a) bare/function-only, no literal path at all (mirrors csvpaths --
 #          the sole path "segment" is itself a version-selecting function,
 #          e.g. :all()/:first()/:last()/:index(n)). Used when there is no
-#          template, or the caller does not care about path narrowing --
-#          the named-results home directory itself is the "prefix".
+#          template, or the caller does not care about path narrowing at
+#          all -- every run discovered for the group is a candidate.
 #      (b) literal/"*"/:name("...") path segments (same semantics as files
 #          -- see ReferenceFinder3._compile_path_pattern) PLUS its own
-#          trailing function chain.
-#    Either way, the combined chain (whichever function(s) are not path-
-#    building) may contain at most one pointer function (:first()/:last()/
-#    :index(n)): if present, it reduces each matched prefix to that
-#    prefix's one specific run; if absent, every run under each matched
-#    prefix comes back, unreduced. This is how "Name_one used alone == path
-#    to run dir" (STRUCTURE table) is reached, matching how
-#    CsvpathsReferenceFinder3 already handles "zero or one pointer" for its
-#    own combined chain. The "#worksheet" marker (name_two, files-only) is
-#    not meaningful here and is rejected.
-#    KNOWN LIMITATION: this finder does not know how many literal path
-#    segments a given named-results group's template actually has before
-#    reaching the run-directory level (that lives in the group's own
-#    template string, e.g. via PathsManager.get_template_for_paths()) --
-#    it simply treats whatever directories the given pattern matches as
-#    "the runs". Under-specifying the path (fewer segments than the real
-#    template) silently treats an intermediate directory's own children as
-#    if they were runs, rather than raising. Not validated in this pass.
+#          trailing function chain -- narrows to runs whose own prefix
+#          (see _discover_run_homes/_matches_prefix below) matches.
+#    Either way, every matching run is pooled into ONE flat list first
+#    (mirroring how a bare "*" already flattens across every match for
+#    files, rather than reducing per matched prefix separately), and the
+#    combined chain's at most one pointer function (:first()/:last()/
+#    :index(n)) reduces that WHOLE pool to one run; absent, every pooled
+#    run comes back unreduced. This is how "Name_one used alone == path to
+#    run dir" (STRUCTURE table) is reached. The "#worksheet" marker
+#    (name_two, files-only) is not meaningful here and is rejected.
 #  - name_three, if present, is an identity lookup into the selected run's
 #    own instance-directory listing (one subdirectory per csvpath statement,
 #    named by that statement's identity -- same convention as csvpaths'
@@ -61,16 +53,32 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 #    resolve() just has nothing further to extract yet.
 #
 # storage facts this relies on (confirmed against ResultsManager/
-# ResultsRegistrar/ResultRegistrar/ResultSerializer, not assumed): there is
-# no per-named-results-group manifest array the way files/csvpaths have --
-# query() has to walk real directories. Run directories are named
+# ResultsRegistrar/ResultRegistrar/ResultSerializer, and a real archive-root
+# manifest.json entry David pasted, not assumed): there is no per-named-
+# results-group manifest array the way files/csvpaths have -- but there IS
+# a single, archive-wide manifest.json (one entry per csvpath-statement
+# execution, across every named-paths group -- the same one the earlier
+# run-ordering experiment found unreliable as an ORDERING source, owing to
+# cross-group interleaving and stale entries for deleted runs). Each entry
+# already carries "run_home", the exact, already-resolved absolute path a
+# specific run's directory landed at, recorded at the moment that run
+# happened -- discovery, not ordering: this sidesteps ever needing to
+# know/guess a group's own template depth (which lives in the group's own
+# template string, e.g. PathsManager.get_template_for_paths(), and can
+# change over time or be overridden per-run -- neither matters here, since
+# run_home already reflects whatever template was actually in effect for
+# that specific run). Confirmed against v1/v2's own working equivalent
+# (csvpath/util/references/results_tools/resolve_possibles.py), which uses
+# this exact same manifest+run_home+existence-check approach rather than
+# directory-walking. Stale entries are handled by an existence check
+# (Nos(run_home).exists()), same as v2 does. Run directories are named
 # "%Y-%m-%d_%H-%M-%S[_N]" (RunHomeMaker), lexicographically sortable =
-# chronological (confirmed by direct experiment -- see project memory).
-# Each run directory has its own manifest.json (a single dict, not an
-# array -- "run_uuid" identifies the run itself). Each run directory
-# contains one subdirectory per csvpath statement, named by that
-# statement's own identity (ResultSerializer.get_instance_dir), each with
-# its own manifest.json (a single dict; "uuid" identifies that instance).
+# chronological (confirmed separately by direct experiment). Each run
+# directory has its own manifest.json (a single dict; "run_uuid" identifies
+# the run itself). Each run directory contains one subdirectory per csvpath
+# statement, named by that statement's own identity
+# (ResultSerializer.get_instance_dir), each with its own manifest.json (a
+# single dict; "uuid" identifies that instance).
 #
 
 
@@ -93,34 +101,34 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             )
 
         home = self.csvpaths.results_manager.get_named_results_home(root_major)
+        run_homes = self._discover_run_homes(root_major)
+
         if self._is_bare_function_only(name_one):
             # mirrors csvpaths: no literal path at all, e.g.
-            # "$acme.results.:all()"/"$acme.results.:last()" -- the named-
-            # results home directory itself is the "prefix".
-            prefixes = [home]
+            # "$acme.results.:all()"/"$acme.results.:last()" -- every run
+            # discovered for the group is a candidate, no prefix narrowing.
+            candidates = run_homes
             calls = [name_one.path[0], *name_one.functions]
         else:
             pattern = self._compile_path_pattern(name_one.path)
-            prefixes = self._matching_prefix_dirs(home, pattern)
+            candidates = [
+                rh for rh in run_homes if self._matches_prefix(rh, home, pattern)
+            ]
             calls = list(name_one.functions)
+        candidates = sorted(candidates)
 
         pointer = self._pointer_from_calls(calls)
         identity, match_all = self._name_three_selector(reference.name_three)
 
-        results = []
-        for prefix in prefixes:
-            run_names = sorted(Nos(prefix).listdir(dirs_only=True))
-            if pointer is not None:
-                selected = self._apply_pointer(pointer, run_names)
-                selected_runs = [selected] if selected is not None else []
-            else:
-                selected_runs = run_names
+        if pointer is not None:
+            selected = self._apply_pointer(pointer, candidates)
+            selected_runs = [selected] if selected is not None else []
+        else:
+            selected_runs = candidates
 
-            for run_name in selected_runs:
-                run_dir = Nos(prefix).join(run_name)
-                results.extend(
-                    self._results_for_run(run_dir, identity, match_all)
-                )
+        results = []
+        for run_dir in selected_runs:
+            results.extend(self._results_for_run(run_dir, identity, match_all))
         return ReferenceResults3(results=results)
 
     def _extract_data(self, result: ReferenceResult3):
@@ -138,6 +146,29 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         # default" applies uniformly here, per "creating references
         # v3.txt"'s resolve table.
         return None
+
+    def _discover_run_homes(self, root_major: str) -> list[str]:
+        """every distinct, still-existing run_home for this group, read
+        from the archive-root manifest.json -- see this module's own
+        docstring for why this replaces directory-walking entirely (no
+        need to know/guess the group's template depth). Many entries can
+        share the same run_home (one entry per csvpath-statement
+        execution, several statements per run), so dedupe; a stale entry
+        (the run since deleted) is dropped via an existence check."""
+        archive = self.csvpaths.config.get(section="results", name="archive")
+        manifest_path = Nos(archive).join("manifest.json")
+        if not Nos(manifest_path).exists():
+            return []
+        with DataFileReader(manifest_path) as reader:
+            entries = json.load(reader.source)
+        homes = []
+        for entry in entries:
+            if entry.get("named_paths_name") != root_major:
+                continue
+            run_home = entry.get("run_home")
+            if run_home and run_home not in homes:
+                homes.append(run_home)
+        return [h for h in homes if Nos(h).exists()]
 
     def _results_for_run(
         self, run_dir: str, identity: str | None, match_all: bool
@@ -221,22 +252,28 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         return name_three.body, False
 
     @staticmethod
-    def _matching_prefix_dirs(home: str, pattern: list) -> list[str]:
-        """walks real directories under `home`, matching each literal/
-        Star3 pattern segment against one level of subdirectories --
-        the results-side equivalent of FilesReferenceFinder3's manifest-
-        array matching, needed because there is no per-named-results-
-        group manifest array to scan (confirmed by direct experiment --
-        see project memory) -- only real directories on disk."""
-        current = [home]
-        for segment in pattern:
-            next_level = []
-            for base in current:
-                for name in sorted(Nos(base).listdir(dirs_only=True)):
-                    if isinstance(segment, Star3) or name == segment:
-                        next_level.append(Nos(base).join(name))
-            current = next_level
-        return current
+    def _matches_prefix(run_home: str, home: str, pattern: list) -> bool:
+        """true if run_home's own prefix -- everything between `home`
+        and the run directory's own name (the last path segment) --
+        matches `pattern` position-by-position (Star3 as wildcard).
+        Similar in spirit to FilesReferenceFinder3._matches, but the run
+        directory's own name is excluded from the comparison first,
+        since (unlike a file's file_home) run_home already includes
+        that final, version-identifying segment itself."""
+        home = home.rstrip("/")
+        if not run_home.startswith(home):
+            return False
+        rel = run_home[len(home) :].lstrip("/")
+        segments = rel.split("/") if rel else []
+        prefix_segments = segments[:-1]
+        if len(prefix_segments) != len(pattern):
+            return False
+        for actual, expected in zip(prefix_segments, pattern):
+            if isinstance(expected, Star3):
+                continue
+            if actual != expected:
+                return False
+        return True
 
     @staticmethod
     def _list_instance_identities(run_dir: str) -> list[str]:

--- a/tests/references/functions/test_manifest_3.py
+++ b/tests/references/functions/test_manifest_3.py
@@ -9,7 +9,10 @@ from csvpath.references.reference_exceptions_3 import ReferenceException3
 def test_metadata():
     f = Manifest3()
     assert f.name == "manifest"
-    assert f.ROLE == Function3.POINTER
+    # VALUE, not POINTER -- :manifest() never narrows/selects anything,
+    # even bare; it just accesses whatever's already in scope. See
+    # manifest_3.py's own comment for why this was originally wrong.
+    assert f.ROLE == Function3.VALUE
     assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
 
 

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -169,15 +169,24 @@ class TestManifestFunction:
         results = finder.resolve()
         assert results.results[0].data == content
 
-    def test_manifest_combined_with_a_version_pointer_is_two_pointers(self):
-        # :manifest() is POINTER-role but is not a list-position lookup
-        # -- combining it with a real version-selecting function is not
-        # the bare/sole shape, so it falls through to the ordinary
-        # version-selection pipeline, which sees two pointers in one
-        # chain and rejects it (same rule as :first():last() already
-        # being illegal).
-        with pytest.raises(ReferenceException3):
-            _finder("$acme.csvpaths.:manifest():first()").query()
+    def test_manifest_beside_a_version_pointer_gives_the_one_matched_entry(self):
+        # :manifest() never narrows/selects itself (VALUE role, not
+        # POINTER -- see functions/manifest_3.py) -- it can ride
+        # alongside :last() in the same combined chain without tripping
+        # "at most one pointer per chain". :last() still reduces to one
+        # version; :manifest() changes what that version resolves to.
+        results = _finder("$acme.csvpaths.:last():manifest()").resolve()
+        assert results.uuids == ["v1-uuid"]
+        assert results.results[0].data == ACME_MANIFEST[1]
+
+    def test_manifest_with_all_and_no_pointer_gives_every_version_entry(self):
+        # :all() (CONTEXT_SETTER) plus :manifest() (VALUE) -- neither is
+        # a pointer, so every version comes back unreduced, each
+        # resolving to its own manifest entry.
+        results = _finder("$acme.csvpaths.:all():manifest()").resolve()
+        assert results.uuids == ["v0-uuid", "v1-uuid"]
+        assert results.data_for_uuid("v0-uuid") == ACME_MANIFEST[0]
+        assert results.data_for_uuid("v1-uuid") == ACME_MANIFEST[1]
 
 
 class TestDefinitionFunction:

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -245,6 +245,46 @@ class TestManifestFunction:
             finder.query()
 
 
+class TestManifestCombinedWithNameThree:
+    # :manifest() never narrows/selects anything itself -- combined with
+    # real name_one path narrowing plus name_three, it either rides
+    # alongside a real version pointer (giving that one matched entry)
+    # or appears alone with no pointer at all (giving every matching
+    # entry, unreduced). Neither shape routes through
+    # _is_bare_pointer_reference -- that is only for the sole-content
+    # "$acme.files.:manifest()" case.
+    def test_manifest_alone_in_name_three_gives_every_matching_entry(self):
+        # "one.csv" has two versions in ALPHA_MANIFEST -- no pointer, so
+        # both come back, each resolving to its own manifest entry dict.
+        finder = _finder(
+            '$alpha.files.:name("one.csv").:manifest()', ALPHA_HOME, ALPHA_MANIFEST
+        )
+        results = finder.resolve()
+        assert results.uuids == ["u-one-1", "u-one-2"]
+        assert results.data_for_uuid("u-one-1") == ALPHA_MANIFEST[1]
+        assert results.data_for_uuid("u-one-2") == ALPHA_MANIFEST[2]
+
+    def test_manifest_beside_a_pointer_gives_the_one_matched_entry(self):
+        finder = _finder(
+            '$alpha.files.:name("one.csv").:last():manifest()',
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+        )
+        results = finder.resolve()
+        assert results.uuids == ["u-one-2"]
+        assert results.results[0].data == ALPHA_MANIFEST[2]
+
+    def test_name_three_with_neither_pointer_nor_manifest_still_raises(self):
+        # a context setter alone (:name(...) is not meaningful in
+        # name_three for files, but exercises the same "requires a
+        # pointer or :manifest()" gate either function would hit).
+        finder = _finder(
+            '$alpha.files.*.:name("x")', ALPHA_HOME, ALPHA_MANIFEST
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+
 class TestDefinitionFunction:
     # ":definition()" mirrors ":manifest()" exactly -- same bare, sole-
     # content shape, same query()/_extract_data() routing -- except

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -1,0 +1,274 @@
+import json
+
+import pytest
+
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+from csvpath.references.reference_parser_3 import ReferenceParser3
+from csvpath.references.results_reference_finder_3 import ResultsReferenceFinder3
+
+#
+# unlike files/csvpaths (which read a fake in-memory manifest list), results
+# has no per-named-results-group manifest array to fake -- query() walks
+# real directories (confirmed by direct experiment: there is no equivalent
+# to files'/csvpaths' manifest.json array at the group level). So these
+# fixtures build real directory trees under tmp_path, mirroring the
+# confirmed real layout: archive/<name>/<template path>/<run dir>/<instance
+# dir>, run/instance directories each with their own small manifest.json
+# ("run_uuid"/"uuid" respectively).
+#
+
+
+class _FakeResultsManager:
+    def __init__(self, home: str):
+        self._home = home
+
+    def get_named_results_home(self, name):
+        return self._home
+
+
+class _FakeCsvPaths:
+    def __init__(self, results_manager):
+        self.results_manager = results_manager
+
+
+def _write_json(path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def _make_run(base, run_name: str, run_uuid: str, instances: dict) -> None:
+    """instances: {identity: instance_uuid}"""
+    run_dir = base / run_name
+    _write_json(run_dir / "manifest.json", {"run_uuid": run_uuid})
+    for identity, inst_uuid in instances.items():
+        _write_json(run_dir / identity / "manifest.json", {"uuid": inst_uuid})
+
+
+def _finder(reference: str, home: str) -> ResultsReferenceFinder3:
+    csvpaths = _FakeCsvPaths(_FakeResultsManager(home))
+    ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
+    return ResultsReferenceFinder3(csvpaths=csvpaths, ref=ref)
+
+
+@pytest.fixture
+def acme_home(tmp_path):
+    base = tmp_path / "acme" / "customers" / "2025"
+    _make_run(
+        base,
+        "2026-01-01_00-00-00",
+        "run1-uuid",
+        {"company_names": "inst1-uuid", "1": "inst2-uuid"},
+    )
+    _make_run(
+        base,
+        "2026-01-02_00-00-00",
+        "run2-uuid",
+        {"0": "inst3-uuid"},
+    )
+    return str(tmp_path / "acme")
+
+
+class TestVersionPointer:
+    def test_last(self, acme_home):
+        results = _finder(
+            "$acme.results.customers/2025:last()", acme_home
+        ).query()
+        assert results.uuids == ["run2-uuid"]
+
+    def test_first(self, acme_home):
+        results = _finder(
+            "$acme.results.customers/2025:first()", acme_home
+        ).query()
+        assert results.uuids == ["run1-uuid"]
+
+    def test_index(self, acme_home):
+        results = _finder(
+            "$acme.results.customers/2025:index(1)", acme_home
+        ).query()
+        assert results.uuids == ["run2-uuid"]
+
+    def test_index_out_of_range_returns_empty_not_an_error(self, acme_home):
+        results = _finder(
+            "$acme.results.customers/2025:index(99)", acme_home
+        ).query()
+        assert results.files == []
+
+    def test_result_path_is_the_run_directory(self, acme_home):
+        results = _finder(
+            "$acme.results.customers/2025:first()", acme_home
+        ).query()
+        assert results.files == [
+            f"{acme_home}/customers/2025/2026-01-01_00-00-00"
+        ]
+
+
+class TestNoPointerReturnsEveryRun:
+    def test_no_pointer_returns_every_run_unreduced(self, acme_home):
+        results = _finder("$acme.results.customers/2025", acme_home).query()
+        assert results.uuids == ["run1-uuid", "run2-uuid"]
+
+    def test_no_pointer_no_matching_prefix_returns_empty(self, acme_home):
+        results = _finder("$acme.results.orders/2025", acme_home).query()
+        assert results.files == []
+
+
+class TestPathMatching:
+    def test_star_segment_matches_any_prefix(self, acme_home):
+        results = _finder("$acme.results.*/2025:last()", acme_home).query()
+        assert results.uuids == ["run2-uuid"]
+
+    def test_name_function_as_path_segment(self, acme_home):
+        results = _finder(
+            '$acme.results.:name("customers")/2025:last()', acme_home
+        ).query()
+        assert results.uuids == ["run2-uuid"]
+
+    def test_under_specified_path_is_a_known_limitation_not_validated(
+        self, acme_home
+    ):
+        # "customers" alone does not reach the real run-directory level
+        # (that is one level short of "customers/2025") -- this finder
+        # has no way to know the group's own template depth, so it
+        # treats whatever it finds ("2025", a directory) as if it were a
+        # run. Documented as a known limitation, not a silent-failure
+        # regression: this locks in the actual (if unhelpful) behavior.
+        results = _finder("$acme.results.customers:last()", acme_home).query()
+        assert results.files == [f"{acme_home}/customers/2025"]
+        assert results.results[0].uuid is None
+
+
+class TestBareFunctionOnlyNameOne:
+    # mirrors csvpaths: no literal path at all -- the sole path
+    # "segment" is itself a version-selecting function. Used when the
+    # caller does not care about path narrowing (or there is no
+    # template) -- the named-results home directory itself is the
+    # "prefix". Exercised against a flat, no-template layout (unlike
+    # acme_home's own templated "customers/2025" structure).
+    @pytest.fixture
+    def flat_home(self, tmp_path):
+        base = tmp_path / "flat"
+        _make_run(base, "2026-01-01_00-00-00", "run1-uuid", {})
+        _make_run(base, "2026-01-02_00-00-00", "run2-uuid", {})
+        return str(base)
+
+    def test_bare_last(self, flat_home):
+        results = _finder("$flat.results.:last()", flat_home).query()
+        assert results.uuids == ["run2-uuid"]
+
+    def test_bare_first(self, flat_home):
+        results = _finder("$flat.results.:first()", flat_home).query()
+        assert results.uuids == ["run1-uuid"]
+
+    def test_bare_all_returns_every_run(self, flat_home):
+        results = _finder("$flat.results.:all()", flat_home).query()
+        assert set(results.uuids) == {"run1-uuid", "run2-uuid"}
+
+
+class TestIdentityLookupOnNameThree:
+    def test_matches_named_identity(self, acme_home):
+        results = _finder(
+            "$acme.results.customers/2025:first().company_names", acme_home
+        ).query()
+        assert results.uuids == ["inst1-uuid"]
+
+    def test_matches_stringified_index_identity(self, acme_home):
+        results = _finder(
+            "$acme.results.customers/2025:first().1", acme_home
+        ).query()
+        assert results.uuids == ["inst2-uuid"]
+
+    def test_no_matching_identity_returns_empty(self, acme_home):
+        results = _finder(
+            "$acme.results.customers/2025:first().nope", acme_home
+        ).query()
+        assert results.files == []
+
+    def test_result_path_is_the_instance_directory(self, acme_home):
+        results = _finder(
+            "$acme.results.customers/2025:first().company_names", acme_home
+        ).query()
+        assert results.files == [
+            f"{acme_home}/customers/2025/2026-01-01_00-00-00/company_names"
+        ]
+
+
+class TestAllFunctionOnNameThree:
+    def test_all_returns_every_instance_in_the_run(self, acme_home):
+        results = _finder(
+            "$acme.results.customers/2025:first().:all()", acme_home
+        ).query()
+        assert set(results.uuids) == {"inst1-uuid", "inst2-uuid"}
+
+    def test_all_with_no_run_pointer_covers_every_matched_run(self, acme_home):
+        results = _finder(
+            "$acme.results.customers/2025.:all()", acme_home
+        ).query()
+        assert set(results.uuids) == {"inst1-uuid", "inst2-uuid", "inst3-uuid"}
+
+
+class TestResolve:
+    def test_resolving_a_run_gives_none(self, acme_home):
+        results = _finder(
+            "$acme.results.customers/2025:first()", acme_home
+        ).resolve()
+        assert results.results[0].data is None
+
+    def test_resolving_a_named_identity_gives_none(self, acme_home):
+        # no well-known instance-level file function is registered yet
+        # (:data()/:vars()/:meta()/:unmatched()/:errors()) -- "no
+        # default" applies uniformly until one exists.
+        results = _finder(
+            "$acme.results.customers/2025:first().company_names", acme_home
+        ).resolve()
+        assert results.results[0].data is None
+
+
+class TestScopeLimits:
+    def test_star_root_major_not_yet_supported(self, acme_home):
+        finder = _finder("$*.results.customers/2025:last()", acme_home)
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_name_two_worksheet_marker_not_supported(self, acme_home):
+        finder = _finder(
+            "$acme.results.customers/2025#sheet1:last()", acme_home
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_two_pointers_in_name_one_raises(self, acme_home):
+        finder = _finder(
+            "$acme.results.customers/2025:first():last()", acme_home
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_star_body_on_name_three_not_supported(self, acme_home):
+        finder = _finder("$acme.results.customers/2025:first().*", acme_home)
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_unregistered_function_on_name_three_not_yet_supported(
+        self, acme_home
+    ):
+        finder = _finder(
+            "$acme.results.customers/2025:first().:data()", acme_home
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_manifest_function_on_name_three_not_yet_supported(self, acme_home):
+        # :manifest() is registered, but not meaningful as a name_three
+        # function for results in this pass -- only :all() is accepted.
+        finder = _finder(
+            "$acme.results.customers/2025:first().:manifest()", acme_home
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_unsupported_function_valued_path_segment(self, acme_home):
+        finder = _finder(
+            "$acme.results.:quarter()/2025:last()", acme_home
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import pytest
 
@@ -8,27 +9,38 @@ from csvpath.references.results_reference_finder_3 import ResultsReferenceFinder
 
 #
 # unlike files/csvpaths (which read a fake in-memory manifest list), results
-# has no per-named-results-group manifest array to fake -- query() walks
-# real directories (confirmed by direct experiment: there is no equivalent
-# to files'/csvpaths' manifest.json array at the group level). So these
-# fixtures build real directory trees under tmp_path, mirroring the
-# confirmed real layout: archive/<name>/<template path>/<run dir>/<instance
-# dir>, run/instance directories each with their own small manifest.json
-# ("run_uuid"/"uuid" respectively).
+# discovery reads a fake archive-root manifest.json (one entry per csvpath-
+# statement execution, across every named-paths group -- confirmed against a
+# real entry David pasted, and against v1/v2's own working equivalent,
+# results_tools/resolve_possibles.py). Each entry's "run_home" is the exact,
+# already-resolved path a run landed at -- this is how the finder discovers
+# real run directories without ever needing to know/guess a group's
+# template depth. Per-run/per-instance manifest.json files (for "run_uuid"/
+# "uuid") still need real directories on disk, same as before.
 #
 
 
+class _FakeConfig:
+    def __init__(self, archive: str):
+        self._archive = archive
+
+    def get(self, *, section, name):
+        assert (section, name) == ("results", "archive")
+        return self._archive
+
+
 class _FakeResultsManager:
-    def __init__(self, home: str):
-        self._home = home
+    def __init__(self, archive: str):
+        self._archive = archive
 
     def get_named_results_home(self, name):
-        return self._home
+        return os.path.join(self._archive, name)
 
 
 class _FakeCsvPaths:
-    def __init__(self, results_manager):
-        self.results_manager = results_manager
+    def __init__(self, archive: str):
+        self.results_manager = _FakeResultsManager(archive)
+        self.config = _FakeConfig(archive)
 
 
 def _write_json(path, data) -> None:
@@ -36,239 +48,287 @@ def _write_json(path, data) -> None:
     path.write_text(json.dumps(data))
 
 
-def _make_run(base, run_name: str, run_uuid: str, instances: dict) -> None:
-    """instances: {identity: instance_uuid}"""
+def _make_run(base, run_name: str, run_uuid: str, instances: dict) -> str:
+    """instances: {identity: instance_uuid}. Returns the run's own full
+    path (for use as a "run_home" entry in the fake archive manifest)."""
     run_dir = base / run_name
     _write_json(run_dir / "manifest.json", {"run_uuid": run_uuid})
     for identity, inst_uuid in instances.items():
         _write_json(run_dir / identity / "manifest.json", {"uuid": inst_uuid})
+    return str(run_dir)
 
 
-def _finder(reference: str, home: str) -> ResultsReferenceFinder3:
-    csvpaths = _FakeCsvPaths(_FakeResultsManager(home))
+def _write_archive_manifest(archive, group: str, run_homes: list[str]) -> None:
+    entries = [{"named_paths_name": group, "run_home": rh} for rh in run_homes]
+    _write_json(archive / "manifest.json", entries)
+
+
+def _finder(reference: str, archive: str) -> ResultsReferenceFinder3:
+    csvpaths = _FakeCsvPaths(archive)
     ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
     return ResultsReferenceFinder3(csvpaths=csvpaths, ref=ref)
 
 
 @pytest.fixture
-def acme_home(tmp_path):
+def acme_archive(tmp_path):
     base = tmp_path / "acme" / "customers" / "2025"
-    _make_run(
+    run1 = _make_run(
         base,
         "2026-01-01_00-00-00",
         "run1-uuid",
         {"company_names": "inst1-uuid", "1": "inst2-uuid"},
     )
-    _make_run(
-        base,
-        "2026-01-02_00-00-00",
-        "run2-uuid",
-        {"0": "inst3-uuid"},
-    )
-    return str(tmp_path / "acme")
+    run2 = _make_run(base, "2026-01-02_00-00-00", "run2-uuid", {"0": "inst3-uuid"})
+    _write_archive_manifest(tmp_path, "acme", [run1, run2])
+    return str(tmp_path)
 
 
 class TestVersionPointer:
-    def test_last(self, acme_home):
+    def test_last(self, acme_archive):
         results = _finder(
-            "$acme.results.customers/2025:last()", acme_home
+            "$acme.results.customers/2025:last()", acme_archive
         ).query()
         assert results.uuids == ["run2-uuid"]
 
-    def test_first(self, acme_home):
+    def test_first(self, acme_archive):
         results = _finder(
-            "$acme.results.customers/2025:first()", acme_home
+            "$acme.results.customers/2025:first()", acme_archive
         ).query()
         assert results.uuids == ["run1-uuid"]
 
-    def test_index(self, acme_home):
+    def test_index(self, acme_archive):
         results = _finder(
-            "$acme.results.customers/2025:index(1)", acme_home
+            "$acme.results.customers/2025:index(1)", acme_archive
         ).query()
         assert results.uuids == ["run2-uuid"]
 
-    def test_index_out_of_range_returns_empty_not_an_error(self, acme_home):
+    def test_index_out_of_range_returns_empty_not_an_error(self, acme_archive):
         results = _finder(
-            "$acme.results.customers/2025:index(99)", acme_home
+            "$acme.results.customers/2025:index(99)", acme_archive
         ).query()
         assert results.files == []
 
-    def test_result_path_is_the_run_directory(self, acme_home):
+    def test_result_path_is_the_run_directory(self, acme_archive):
         results = _finder(
-            "$acme.results.customers/2025:first()", acme_home
+            "$acme.results.customers/2025:first()", acme_archive
         ).query()
         assert results.files == [
-            f"{acme_home}/customers/2025/2026-01-01_00-00-00"
+            f"{acme_archive}/acme/customers/2025/2026-01-01_00-00-00"
         ]
 
 
 class TestNoPointerReturnsEveryRun:
-    def test_no_pointer_returns_every_run_unreduced(self, acme_home):
-        results = _finder("$acme.results.customers/2025", acme_home).query()
+    def test_no_pointer_returns_every_run_unreduced(self, acme_archive):
+        results = _finder("$acme.results.customers/2025", acme_archive).query()
         assert results.uuids == ["run1-uuid", "run2-uuid"]
 
-    def test_no_pointer_no_matching_prefix_returns_empty(self, acme_home):
-        results = _finder("$acme.results.orders/2025", acme_home).query()
+    def test_no_pointer_no_matching_prefix_returns_empty(self, acme_archive):
+        results = _finder("$acme.results.orders/2025", acme_archive).query()
         assert results.files == []
 
 
 class TestPathMatching:
-    def test_star_segment_matches_any_prefix(self, acme_home):
-        results = _finder("$acme.results.*/2025:last()", acme_home).query()
+    def test_star_segment_matches_any_prefix(self, acme_archive):
+        results = _finder("$acme.results.*/2025:last()", acme_archive).query()
         assert results.uuids == ["run2-uuid"]
 
-    def test_name_function_as_path_segment(self, acme_home):
+    def test_name_function_as_path_segment(self, acme_archive):
         results = _finder(
-            '$acme.results.:name("customers")/2025:last()', acme_home
+            '$acme.results.:name("customers")/2025:last()', acme_archive
         ).query()
         assert results.uuids == ["run2-uuid"]
 
-    def test_under_specified_path_is_a_known_limitation_not_validated(
-        self, acme_home
-    ):
-        # "customers" alone does not reach the real run-directory level
-        # (that is one level short of "customers/2025") -- this finder
-        # has no way to know the group's own template depth, so it
-        # treats whatever it finds ("2025", a directory) as if it were a
-        # run. Documented as a known limitation, not a silent-failure
-        # regression: this locks in the actual (if unhelpful) behavior.
-        results = _finder("$acme.results.customers:last()", acme_home).query()
-        assert results.files == [f"{acme_home}/customers/2025"]
-        assert results.results[0].uuid is None
+    def test_under_specified_path_now_correctly_matches_nothing(self, acme_archive):
+        # "customers" alone is one segment short of the real template
+        # depth ("customers/2025") -- with manifest-driven discovery this
+        # correctly matches nothing (the discovered run_homes' own
+        # prefixes are 2 segments long, not 1), rather than the old
+        # directory-walking design's silent misfire (treating "2025" as
+        # if it were itself a run).
+        results = _finder("$acme.results.customers:last()", acme_archive).query()
+        assert results.files == []
 
 
 class TestBareFunctionOnlyNameOne:
     # mirrors csvpaths: no literal path at all -- the sole path
-    # "segment" is itself a version-selecting function. Used when the
-    # caller does not care about path narrowing (or there is no
-    # template) -- the named-results home directory itself is the
-    # "prefix". Exercised against a flat, no-template layout (unlike
-    # acme_home's own templated "customers/2025" structure).
+    # "segment" is itself a version-selecting function. Every run
+    # discovered for the group is a candidate, regardless of how deep
+    # its own prefix happens to be (unlike the literal-path shape, which
+    # requires an exact segment-count match).
     @pytest.fixture
-    def flat_home(self, tmp_path):
+    def flat_archive(self, tmp_path):
         base = tmp_path / "flat"
-        _make_run(base, "2026-01-01_00-00-00", "run1-uuid", {})
-        _make_run(base, "2026-01-02_00-00-00", "run2-uuid", {})
-        return str(base)
+        run1 = _make_run(base, "2026-01-01_00-00-00", "run1-uuid", {})
+        run2 = _make_run(base, "2026-01-02_00-00-00", "run2-uuid", {})
+        _write_archive_manifest(tmp_path, "flat", [run1, run2])
+        return str(tmp_path)
 
-    def test_bare_last(self, flat_home):
-        results = _finder("$flat.results.:last()", flat_home).query()
+    def test_bare_last(self, flat_archive):
+        results = _finder("$flat.results.:last()", flat_archive).query()
         assert results.uuids == ["run2-uuid"]
 
-    def test_bare_first(self, flat_home):
-        results = _finder("$flat.results.:first()", flat_home).query()
+    def test_bare_first(self, flat_archive):
+        results = _finder("$flat.results.:first()", flat_archive).query()
         assert results.uuids == ["run1-uuid"]
 
-    def test_bare_all_returns_every_run(self, flat_home):
-        results = _finder("$flat.results.:all()", flat_home).query()
+    def test_bare_all_returns_every_run(self, flat_archive):
+        results = _finder("$flat.results.:all()", flat_archive).query()
         assert set(results.uuids) == {"run1-uuid", "run2-uuid"}
+
+    def test_bare_pointer_still_finds_a_run_under_a_deep_template(
+        self, acme_archive
+    ):
+        # bare :last() ignores prefix depth entirely -- it still finds
+        # the group's runs even though they sit under "customers/2025".
+        results = _finder("$acme.results.:last()", acme_archive).query()
+        assert results.uuids == ["run2-uuid"]
+
+
+class TestDiscoveryFromArchiveManifest:
+    def test_dedupes_multiple_entries_sharing_one_run_home(self, tmp_path):
+        # a real run_home is written once per csvpath-statement
+        # execution -- several entries in the archive manifest can share
+        # the same run_home for one run with multiple statements.
+        base = tmp_path / "acme"
+        run1 = _make_run(base, "2026-01-01_00-00-00", "run1-uuid", {})
+        _write_archive_manifest(tmp_path, "acme", [run1, run1, run1])
+        results = _finder("$acme.results.:all()", str(tmp_path)).query()
+        assert results.uuids == ["run1-uuid"]
+
+    def test_stale_entry_for_a_deleted_run_is_dropped(self, tmp_path):
+        base = tmp_path / "acme"
+        run1 = _make_run(base, "2026-01-01_00-00-00", "run1-uuid", {})
+        deleted_run_home = str(base / "2025-06-06_00-00-00")
+        _write_archive_manifest(tmp_path, "acme", [run1, deleted_run_home])
+        results = _finder("$acme.results.:all()", str(tmp_path)).query()
+        assert results.uuids == ["run1-uuid"]
+
+    def test_other_groups_entries_are_ignored(self, tmp_path):
+        acme_base = tmp_path / "acme"
+        other_base = tmp_path / "other"
+        acme_run = _make_run(acme_base, "2026-01-01_00-00-00", "acme-run-uuid", {})
+        other_run = _make_run(
+            other_base, "2026-01-01_00-00-00", "other-run-uuid", {}
+        )
+        _write_json(
+            tmp_path / "manifest.json",
+            [
+                {"named_paths_name": "acme", "run_home": acme_run},
+                {"named_paths_name": "other", "run_home": other_run},
+            ],
+        )
+        results = _finder("$acme.results.:all()", str(tmp_path)).query()
+        assert results.uuids == ["acme-run-uuid"]
+
+    def test_no_archive_manifest_yet_returns_empty_not_an_error(self, tmp_path):
+        (tmp_path / "acme").mkdir()
+        results = _finder("$acme.results.:all()", str(tmp_path)).query()
+        assert results.files == []
 
 
 class TestIdentityLookupOnNameThree:
-    def test_matches_named_identity(self, acme_home):
+    def test_matches_named_identity(self, acme_archive):
         results = _finder(
-            "$acme.results.customers/2025:first().company_names", acme_home
+            "$acme.results.customers/2025:first().company_names", acme_archive
         ).query()
         assert results.uuids == ["inst1-uuid"]
 
-    def test_matches_stringified_index_identity(self, acme_home):
+    def test_matches_stringified_index_identity(self, acme_archive):
         results = _finder(
-            "$acme.results.customers/2025:first().1", acme_home
+            "$acme.results.customers/2025:first().1", acme_archive
         ).query()
         assert results.uuids == ["inst2-uuid"]
 
-    def test_no_matching_identity_returns_empty(self, acme_home):
+    def test_no_matching_identity_returns_empty(self, acme_archive):
         results = _finder(
-            "$acme.results.customers/2025:first().nope", acme_home
+            "$acme.results.customers/2025:first().nope", acme_archive
         ).query()
         assert results.files == []
 
-    def test_result_path_is_the_instance_directory(self, acme_home):
+    def test_result_path_is_the_instance_directory(self, acme_archive):
         results = _finder(
-            "$acme.results.customers/2025:first().company_names", acme_home
+            "$acme.results.customers/2025:first().company_names", acme_archive
         ).query()
         assert results.files == [
-            f"{acme_home}/customers/2025/2026-01-01_00-00-00/company_names"
+            f"{acme_archive}/acme/customers/2025/2026-01-01_00-00-00/company_names"
         ]
 
 
 class TestAllFunctionOnNameThree:
-    def test_all_returns_every_instance_in_the_run(self, acme_home):
+    def test_all_returns_every_instance_in_the_run(self, acme_archive):
         results = _finder(
-            "$acme.results.customers/2025:first().:all()", acme_home
+            "$acme.results.customers/2025:first().:all()", acme_archive
         ).query()
         assert set(results.uuids) == {"inst1-uuid", "inst2-uuid"}
 
-    def test_all_with_no_run_pointer_covers_every_matched_run(self, acme_home):
+    def test_all_with_no_run_pointer_covers_every_matched_run(self, acme_archive):
         results = _finder(
-            "$acme.results.customers/2025.:all()", acme_home
+            "$acme.results.customers/2025.:all()", acme_archive
         ).query()
         assert set(results.uuids) == {"inst1-uuid", "inst2-uuid", "inst3-uuid"}
 
 
 class TestResolve:
-    def test_resolving_a_run_gives_none(self, acme_home):
+    def test_resolving_a_run_gives_none(self, acme_archive):
         results = _finder(
-            "$acme.results.customers/2025:first()", acme_home
+            "$acme.results.customers/2025:first()", acme_archive
         ).resolve()
         assert results.results[0].data is None
 
-    def test_resolving_a_named_identity_gives_none(self, acme_home):
+    def test_resolving_a_named_identity_gives_none(self, acme_archive):
         # no well-known instance-level file function is registered yet
         # (:data()/:vars()/:meta()/:unmatched()/:errors()) -- "no
         # default" applies uniformly until one exists.
         results = _finder(
-            "$acme.results.customers/2025:first().company_names", acme_home
+            "$acme.results.customers/2025:first().company_names", acme_archive
         ).resolve()
         assert results.results[0].data is None
 
 
 class TestScopeLimits:
-    def test_star_root_major_not_yet_supported(self, acme_home):
-        finder = _finder("$*.results.customers/2025:last()", acme_home)
+    def test_star_root_major_not_yet_supported(self, acme_archive):
+        finder = _finder("$*.results.customers/2025:last()", acme_archive)
         with pytest.raises(ReferenceException3):
             finder.query()
 
-    def test_name_two_worksheet_marker_not_supported(self, acme_home):
+    def test_name_two_worksheet_marker_not_supported(self, acme_archive):
         finder = _finder(
-            "$acme.results.customers/2025#sheet1:last()", acme_home
+            "$acme.results.customers/2025#sheet1:last()", acme_archive
         )
         with pytest.raises(ReferenceException3):
             finder.query()
 
-    def test_two_pointers_in_name_one_raises(self, acme_home):
+    def test_two_pointers_in_name_one_raises(self, acme_archive):
         finder = _finder(
-            "$acme.results.customers/2025:first():last()", acme_home
+            "$acme.results.customers/2025:first():last()", acme_archive
         )
         with pytest.raises(ReferenceException3):
             finder.query()
 
-    def test_star_body_on_name_three_not_supported(self, acme_home):
-        finder = _finder("$acme.results.customers/2025:first().*", acme_home)
+    def test_star_body_on_name_three_not_supported(self, acme_archive):
+        finder = _finder("$acme.results.customers/2025:first().*", acme_archive)
         with pytest.raises(ReferenceException3):
             finder.query()
 
     def test_unregistered_function_on_name_three_not_yet_supported(
-        self, acme_home
+        self, acme_archive
     ):
         finder = _finder(
-            "$acme.results.customers/2025:first().:data()", acme_home
+            "$acme.results.customers/2025:first().:data()", acme_archive
         )
         with pytest.raises(ReferenceException3):
             finder.query()
 
-    def test_manifest_function_on_name_three_not_yet_supported(self, acme_home):
+    def test_manifest_function_on_name_three_not_yet_supported(self, acme_archive):
         # :manifest() is registered, but not meaningful as a name_three
         # function for results in this pass -- only :all() is accepted.
         finder = _finder(
-            "$acme.results.customers/2025:first().:manifest()", acme_home
+            "$acme.results.customers/2025:first().:manifest()", acme_archive
         )
         with pytest.raises(ReferenceException3):
             finder.query()
 
-    def test_unsupported_function_valued_path_segment(self, acme_home):
-        finder = _finder(
-            "$acme.results.:quarter()/2025:last()", acme_home
-        )
+    def test_unsupported_function_valued_path_segment(self, acme_archive):
+        finder = _finder("$acme.results.:quarter()/2025:last()", acme_archive)
         with pytest.raises(ReferenceException3):
             finder.query()


### PR DESCRIPTION
## Summary
- Fix Manifest3/Definition3 ROLE from POINTER to VALUE. Neither function narrows or selects anything, even bare (root_major already fully identifies the one named-file/group) -- POINTER was wrong from the start, it just never surfaced since the bare shape never competed with a real pointer for build_chain()'s "at most one pointer per chain" slot. Confirmed non-breaking: ROLE was never actually consulted by the bare-shape code paths.
- That fix unblocks :manifest() combined with real narrowing and/or a version pointer, which now resolves to the manifest data for whatever's currently in scope rather than unconditionally the whole raw file: bare gives the whole file; real path narrowing with no pointer gives every matching entry unreduced; path narrowing plus a pointer gives the single matched entry.
- FilesReferenceFinder3.query() relaxed name_three's pointer requirement from "exactly one" to "one, or zero if :manifest() is present". Both finders' _extract_data() recognize :manifest() in the relevant chain and return the matched entry via a new shared ReferenceFinder3._find_manifest_entry_by_uuid(), instead of raw bytes/statement text.
- :definition() needed none of this -- definition.json is a single dict, no "filtered subset"/"matched entry" concept applies.

This is preliminary/preparatory work found while confirming :manifest() semantics before starting ResultsReferenceFinder3 -- results will reuse this same context-aware pattern once its own :manifest() wiring is built (still deferred).

## Test plan
- [x] `pytest tests/references/ -q` - 398 passed
- [x] `pytest -q` (full suite) - 1978 passed, 11 failed (pre-existing SFTP/S3/Nos baseline, unrelated)
- [x] Verified end to end against real fake-manager data for both the single-entry-via-pointer and filtered-list-via-path-narrowing cases