### PR TITLE
References v3: well-known-file functions for results (errors/vars/meta/data/unmatched/file)

### DIFF
--- a/csvpath/references/functions/data_3.py
+++ b/csvpath/references/functions/data_3.py
@@ -1,0 +1,23 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class Data3(Function3):
+    #
+    # resolves to the raw bytes of data.csv -- the matched-line output a
+    # csvpath statement's own run instance wrote
+    # (ResultSerializer._save -- only written if there is at least one
+    # matched line; genuinely optional, same as definition.json,
+    # resolves to None rather than raising when absent). See Errors3 for
+    # the shared name_three shape this rides alongside.
+    #
+    NAME = "data"
+    SUMMARY = (
+        "The raw bytes of a run instance's data.csv -- the matched-line "
+        "output that csvpath statement's execution wrote. None if no "
+        "lines matched (the file was never written)."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False

--- a/csvpath/references/functions/definition_3.py
+++ b/csvpath/references/functions/definition_3.py
@@ -18,6 +18,15 @@ class Definition3(Function3):
     # just not yet prioritized). Named-results has no definition.json
     # equivalent, so this is FILES/CSVPATHS only, unlike Manifest3.
     #
+    # ROLE is VALUE, not POINTER, for the same reason Manifest3's own
+    # ROLE was corrected: :definition() never narrows or selects
+    # anything, even bare -- it only ever accesses what root_major
+    # already fully identifies. This one was missed in that earlier fix
+    # (only Manifest3 got corrected) -- caught while re-checking every
+    # existing "accessor" function's role for consistency ahead of
+    # adding the well-known-file functions below, which share the
+    # exact same trait.
+    #
     NAME = "definition"
     SUMMARY = (
         "Points at the whole definition.json for the enclosing named-file "
@@ -26,7 +35,7 @@ class Definition3(Function3):
         "versioned; resolves to None if the group/file was never "
         "explicitly configured (no definition.json written yet)."
     )
-    ROLE = Function3.POINTER
+    ROLE = Function3.VALUE
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS)
     ARG_TYPES = ()
     ARG_REQUIRED = False

--- a/csvpath/references/functions/errors_3.py
+++ b/csvpath/references/functions/errors_3.py
@@ -1,0 +1,24 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class Errors3(Function3):
+    #
+    # the first of the results-only well-known instance-level file
+    # functions -- resolves to the parsed JSON contents of errors.json,
+    # the list of error dicts a csvpath statement's own run instance
+    # wrote (ResultSerializer._save -- always written, even if empty).
+    # Rides alongside the identity/:all() selector already occupying
+    # name_three (e.g. "$acme.results.customers/2025:first().invoices
+    # :errors()"), it does not select the instance itself -- see
+    # ResultsReferenceFinder3._name_three_selector.
+    #
+    NAME = "errors"
+    SUMMARY = (
+        "The parsed contents of a run instance's errors.json -- the list "
+        "of errors that csvpath statement's execution recorded."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False

--- a/csvpath/references/functions/file_3.py
+++ b/csvpath/references/functions/file_3.py
@@ -1,0 +1,40 @@
+from ..reference_3 import Reference3
+from ..reference_exceptions_3 import ReferenceException3
+from .function_3 import Function3
+
+
+class File3(Function3):
+    #
+    # the arbitrary-named counterpart to the other well-known-file
+    # functions -- resolves to the raw bytes of a user-named output file
+    # (e.g. a custom parquet/jinja/text output) sitting in the same run
+    # instance directory as errors.json/vars.json/etc, per "creating
+    # references v3.txt"'s resolve table ("...or a user-named parquet,
+    # jinja, or text output file... using a function like
+    # :file('orders.parquet')"). Genuinely optional, same as Data3/
+    # Unmatched3 -- resolves to None rather than raising when absent.
+    #
+    NAME = "file"
+    SUMMARY = (
+        "The raw bytes of a user-named output file (e.g. a custom "
+        "parquet/jinja/text output) in a run instance's own directory. "
+        "None if no such file was written."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = (str,)
+    ARG_REQUIRED = True
+
+    def check_valid(self) -> None:
+        super().check_valid()
+        # bare filename only -- no path traversal outside the run
+        # instance's own directory. Skips an InterpolatedString3 arg
+        # (its actual text is not known until evaluation, which is
+        # deferred -- see InterpolatedString3's own docstring).
+        if isinstance(self._arg, str) and (
+            "/" in self._arg or "\\" in self._arg or ".." in self._arg
+        ):
+            raise ReferenceException3(
+                f":{self.NAME}() argument must be a bare filename, not a "
+                f"path: {self._arg!r}"
+            )

--- a/csvpath/references/functions/meta_3.py
+++ b/csvpath/references/functions/meta_3.py
@@ -1,0 +1,22 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class Meta3(Function3):
+    #
+    # resolves to the parsed JSON contents of meta.json -- the run
+    # instance's own metadata (paths_name, file_name, run_time,
+    # run_index, identity, the csvpath statement's own metadata comment,
+    # and its runtime_data -- ResultSerializer._save, always written).
+    # See Errors3 for the shared name_three shape this rides alongside.
+    #
+    NAME = "meta"
+    SUMMARY = (
+        "The parsed contents of a run instance's meta.json -- run/"
+        "identity metadata plus the csvpath statement's own metadata "
+        "and runtime data."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -17,12 +17,18 @@ class ReferenceFunctionFactory:
     @classmethod
     def _load(cls) -> None:
         from .all_3 import All3
+        from .data_3 import Data3
         from .definition_3 import Definition3
+        from .errors_3 import Errors3
+        from .file_3 import File3
         from .first_3 import First3
         from .index_3 import Index3
         from .last_3 import Last3
         from .manifest_3 import Manifest3
+        from .meta_3 import Meta3
         from .name_3 import Name3
+        from .unmatched_3 import Unmatched3
+        from .vars_3 import Vars3
 
         cls._FUNCTIONS = {
             First3.NAME: First3,
@@ -32,6 +38,12 @@ class ReferenceFunctionFactory:
             All3.NAME: All3,
             Manifest3.NAME: Manifest3,
             Definition3.NAME: Definition3,
+            Errors3.NAME: Errors3,
+            Vars3.NAME: Vars3,
+            Meta3.NAME: Meta3,
+            Data3.NAME: Data3,
+            Unmatched3.NAME: Unmatched3,
+            File3.NAME: File3,
         }
 
     @classmethod

--- a/csvpath/references/functions/unmatched_3.py
+++ b/csvpath/references/functions/unmatched_3.py
@@ -1,0 +1,24 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class Unmatched3(Function3):
+    #
+    # resolves to the raw bytes of unmatched.csv -- the unmatched-line
+    # output a csvpath statement's own run instance wrote
+    # (ResultSerializer._save -- only written if there is at least one
+    # unmatched line; genuinely optional, resolves to None rather than
+    # raising when absent). See Errors3 for the shared name_three shape
+    # this rides alongside.
+    #
+    NAME = "unmatched"
+    SUMMARY = (
+        "The raw bytes of a run instance's unmatched.csv -- the "
+        "unmatched-line output that csvpath statement's execution "
+        "wrote. None if nothing was unmatched (the file was never "
+        "written)."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False

--- a/csvpath/references/functions/vars_3.py
+++ b/csvpath/references/functions/vars_3.py
@@ -1,0 +1,22 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class Vars3(Function3):
+    #
+    # resolves to the parsed JSON contents of vars.json, the variables a
+    # csvpath statement's own run instance captured
+    # (ResultSerializer._save_vars -- written via jsonpickle with
+    # unpicklable=False, so plain JSON, parseable the same as any other
+    # well-known JSON file here). See Errors3 for the shared name_three
+    # shape this rides alongside.
+    #
+    NAME = "vars"
+    SUMMARY = (
+        "The parsed contents of a run instance's vars.json -- the "
+        "variables that csvpath statement's execution captured."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -1,3 +1,4 @@
+import json
 from abc import ABC, abstractmethod
 
 from csvpath.util.file_readers import DataFileReader
@@ -147,6 +148,20 @@ class ReferenceFinder3(ABC):
             return None
         with DataFileReader(path=path, mode="rb") as reader:
             return reader.source.read()
+
+    @staticmethod
+    def _read_well_known_json(path: str):
+        """reads a well-known, JSON-shaped resource (results' errors.json/
+        vars.json/meta.json) as a parsed Python structure -- None if it
+        does not exist yet, same tolerant treatment as
+        _read_well_known_file, just parsed rather than raw bytes (per
+        the spec's own "Following a reference" section: resolving a
+        reference gives bytes, if binary, or a string or JSON
+        structure -- these are the JSON-structure case)."""
+        if not Nos(path).exists():
+            return None
+        with DataFileReader(path) as reader:
+            return json.load(reader.source)
 
     @staticmethod
     def _find_manifest_entry_by_uuid(manifest: list, uuid: str) -> dict | None:

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -46,11 +46,16 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 #    own instance-directory listing (one subdirectory per csvpath statement,
 #    named by that statement's identity -- same convention as csvpaths'
 #    named_paths_identities) -- matched by identity string, or by :all() for
-#    every instance in the run. Well-known instance-level file functions
-#    (:data()/:vars()/:meta()/:unmatched()/:errors()) are not yet
-#    registered, so resolving a matched instance always gives None for now
-#    (no default) -- query() still finds every matched path+uuid correctly,
-#    resolve() just has nothing further to extract yet.
+#    every instance in the run. A well-known instance-level file function
+#    (:errors()/:vars()/:meta()/:data()/:unmatched(), or the arbitrary-named
+#    :file("...")) may ride alongside the identity/:all() selector in the
+#    same chain (e.g. "$acme.results.customers/2025:first().invoices:data()")
+#    -- these functions never narrow/select anything themselves (ROLE is
+#    VALUE, matching :manifest()/:definition()'s own corrected role), they
+#    just say what to resolve to once an instance is already identified.
+#    Resolving a matched instance with NO accessor present still gives None
+#    (no default) -- only the identity/:all() selection was made, nothing
+#    further was asked for.
 #
 # storage facts this relies on (confirmed against ResultsManager/
 # ResultsRegistrar/ResultRegistrar/ResultSerializer, and a real archive-root
@@ -118,7 +123,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         candidates = sorted(candidates)
 
         pointer = self._pointer_from_calls(calls)
-        identity, match_all = self._name_three_selector(reference.name_three)
+        identity, match_all, _ = self._name_three_selector(reference.name_three)
 
         if pointer is not None:
             selected = self._apply_pointer(pointer, candidates)
@@ -131,21 +136,50 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             results.extend(self._results_for_run(run_dir, identity, match_all))
         return ReferenceResults3(results=results)
 
+    _JSON_ACCESSOR_FILES = {
+        "errors": "errors.json",
+        "vars": "vars.json",
+        "meta": "meta.json",
+    }
+    _BYTES_ACCESSOR_FILES = {
+        "data": "data.csv",
+        "unmatched": "unmatched.csv",
+    }
+
     def _extract_data(self, result: ReferenceResult3):
         reference = self.ref.parsed
         kind = reference.resolve_kind
+        if kind == Reference3.METADATA_FILE:
+            _, _, accessor = self._name_three_selector(reference.name_three)
+            if accessor is not None:
+                return self._read_accessor(result.path, accessor)
         if kind != Reference3.FIRST_PARTY:
             raise ReferenceException3(
                 f"ResultsReferenceFinder3 does not yet support "
-                f"resolve_kind={kind!r} -- no metadata-file/metadata-field "
-                "functions are registered for results yet."
+                f"resolve_kind={kind!r} -- only :errors()/:vars()/:meta()/"
+                ":data()/:unmatched()/:file() are wired up as metadata-"
+                "file functions so far."
             )
-        # neither a whole run directory nor an instance directory matched
-        # by identity/:all() has a single unambiguous payload without a
-        # well-known-file function -- none registered yet, so "no
-        # default" applies uniformly here, per "creating references
-        # v3.txt"'s resolve table.
+        # a run directory (no name_three) or an instance directory matched
+        # by identity/:all() with no accessor riding alongside has no
+        # single unambiguous payload -- "no default", per "creating
+        # references v3.txt"'s resolve table.
         return None
+
+    @classmethod
+    def _read_accessor(cls, instance_dir: str, accessor):
+        """resolves a well-known instance-level file accessor (errors/
+        vars/meta -> parsed JSON; data/unmatched -> raw bytes, both
+        genuinely optional, None if never written; file("...") -> raw
+        bytes of the user-named file, also optional)."""
+        if accessor.name in cls._JSON_ACCESSOR_FILES:
+            path = Nos(instance_dir).join(cls._JSON_ACCESSOR_FILES[accessor.name])
+            return cls._read_well_known_json(path)
+        if accessor.name in cls._BYTES_ACCESSOR_FILES:
+            path = Nos(instance_dir).join(cls._BYTES_ACCESSOR_FILES[accessor.name])
+            return cls._read_well_known_file(path)
+        path = Nos(instance_dir).join(accessor.arg)
+        return cls._read_well_known_file(path)
 
     def _discover_run_homes(self, root_major: str) -> list[str]:
         """every distinct, still-existing run_home for this group, read
@@ -222,34 +256,58 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
         return pointers[0] if pointers else None
 
+    _ACCESSOR_NAMES = ("errors", "vars", "meta", "data", "unmatched", "file")
+
     @staticmethod
-    def _name_three_selector(name_three) -> tuple[str | None, bool]:
-        """returns (identity, match_all) for name_three -- identity is a
-        literal statement-identity string to look up, match_all is True
-        for a bare :all() (every instance in the run, unfiltered). Any
-        other function (well-known instance-level files -- :data()/
-        :vars()/:meta()/:unmatched()/:errors()) is not yet registered
-        and raises via build_chain() itself ("Unknown reference
-        function"); any registered function other than :all() (there is
-        no other one that makes sense here) is explicitly rejected too."""
+    def _name_three_selector(name_three) -> tuple[str | None, bool, object]:
+        """returns (identity, match_all, accessor) for name_three --
+        identity is a literal statement-identity string to look up (None
+        if match_all, or if no identity/:all() selector is present at
+        all); match_all is True for :all() (every instance in the run);
+        accessor is the built well-known-file Function3 riding alongside
+        the identity/:all() selector, or None if none was requested
+        (resolving then gives None -- "no default"). An unrecognized
+        function raises via build_chain() itself ("Unknown reference
+        function") if it is not registered at all, or is rejected here
+        directly if it is registered but not meaningful as a name_three
+        function (e.g. :manifest())."""
         if name_three is None:
-            return None, False
+            return None, False, None
+
+        match_all = False
+        accessor = None
         if name_three.functions:
             built = ReferenceFunctionFactory.build_chain(name_three.functions)
-            if not (len(built) == 1 and built[0].name == "all"):
-                raise ReferenceException3(
-                    "ResultsReferenceFinder3 only supports :all() as a "
-                    "name_three function for now -- well-known instance "
-                    "files (:data()/:vars()/:meta()/:unmatched()/"
-                    ":errors()) are not yet registered for results."
-                )
-            return None, True
-        if isinstance(name_three.body, Star3):
+            for f in built:
+                if f.name == "all":
+                    match_all = True
+                elif f.name in ResultsReferenceFinder3._ACCESSOR_NAMES:
+                    accessor = f
+                else:
+                    raise ReferenceException3(
+                        f"ResultsReferenceFinder3 does not yet support "
+                        f":{f.name}() as a name_three function."
+                    )
+
+        body = name_three.body
+        if isinstance(body, Star3):
             raise ReferenceException3(
                 "ResultsReferenceFinder3 does not support a bare '*' as "
                 "name_three's body -- use :all() instead."
             )
-        return name_three.body, False
+        if body is not None and match_all:
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 cannot combine a literal "
+                "identity with :all() -- they select instances two "
+                "different, contradictory ways."
+            )
+        if body is None and not match_all:
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 requires name_three to be a "
+                "literal statement identity or :all() to select which "
+                "instance(s) a well-known-file function applies to."
+            )
+        return body, match_all, accessor
 
     @staticmethod
     def _matches_prefix(run_home: str, home: str, pattern: list) -> bool:
@@ -287,17 +345,14 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             if name != "_extra_data"
         ]
 
-    @staticmethod
-    def _read_json_field(path: str, field: str):
+    @classmethod
+    def _read_json_field(cls, path: str, field: str):
         """reads one field from a small JSON file (a run's or an
         instance's own manifest.json), tolerating absence -- None if the
         file does not exist rather than raising or fabricating a
-        default. Deliberately does not reuse ResultFileReader.json_file()
-        here -- that helper writes a fresh empty JSON file when one is
-        missing, a write side effect a read-only reference query must
-        never trigger."""
-        if not Nos(path).exists():
-            return None
-        with DataFileReader(path) as reader:
-            data = json.load(reader.source)
-        return data.get(field)
+        default. Built on the shared _read_well_known_json rather than
+        reusing ResultFileReader.json_file() -- that helper writes a
+        fresh empty JSON file when one is missing, a write side effect a
+        read-only reference query must never trigger."""
+        data = cls._read_well_known_json(path)
+        return data.get(field) if data else None

--- a/tests/references/functions/test_data_3.py
+++ b/tests/references/functions/test_data_3.py
@@ -1,0 +1,22 @@
+import pytest
+
+from csvpath.references.functions.data_3 import Data3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Data3()
+    assert f.name == "data"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+
+
+def test_no_arg_is_valid():
+    Data3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Data3(arg="x").check_valid()

--- a/tests/references/functions/test_definition_3.py
+++ b/tests/references/functions/test_definition_3.py
@@ -9,7 +9,10 @@ from csvpath.references.reference_exceptions_3 import ReferenceException3
 def test_metadata():
     f = Definition3()
     assert f.name == "definition"
-    assert f.ROLE == Function3.POINTER
+    # VALUE, not POINTER -- :definition() never narrows/selects
+    # anything, even bare; same reasoning as Manifest3's own role fix
+    # (this one was missed in that earlier pass).
+    assert f.ROLE == Function3.VALUE
     # unlike Manifest3, results has no definition.json equivalent.
     assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS)
 

--- a/tests/references/functions/test_errors_3.py
+++ b/tests/references/functions/test_errors_3.py
@@ -1,0 +1,22 @@
+import pytest
+
+from csvpath.references.functions.errors_3 import Errors3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Errors3()
+    assert f.name == "errors"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+
+
+def test_no_arg_is_valid():
+    Errors3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Errors3(arg="x").check_valid()

--- a/tests/references/functions/test_file_3.py
+++ b/tests/references/functions/test_file_3.py
@@ -1,0 +1,44 @@
+import pytest
+
+from csvpath.references.functions.file_3 import File3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = File3(arg="orders.parquet")
+    assert f.name == "file"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+
+
+def test_required_arg_present_and_correct_type_passes():
+    File3(arg="orders.parquet").check_valid()  # should not raise
+
+
+def test_missing_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        File3().check_valid()
+
+
+def test_wrong_arg_type_is_rejected():
+    with pytest.raises(ReferenceException3):
+        File3(arg=5).check_valid()
+
+
+class TestPathTraversalGuard:
+    def test_forward_slash_is_rejected(self):
+        with pytest.raises(ReferenceException3):
+            File3(arg="sub/orders.parquet").check_valid()
+
+    def test_backslash_is_rejected(self):
+        with pytest.raises(ReferenceException3):
+            File3(arg="sub\\orders.parquet").check_valid()
+
+    def test_parent_traversal_is_rejected(self):
+        with pytest.raises(ReferenceException3):
+            File3(arg="../orders.parquet").check_valid()
+
+    def test_bare_filename_is_accepted(self):
+        File3(arg="orders.parquet").check_valid()  # should not raise

--- a/tests/references/functions/test_meta_3.py
+++ b/tests/references/functions/test_meta_3.py
@@ -1,0 +1,22 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.meta_3 import Meta3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Meta3()
+    assert f.name == "meta"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+
+
+def test_no_arg_is_valid():
+    Meta3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Meta3(arg="x").check_valid()

--- a/tests/references/functions/test_reference_function_factory_3.py
+++ b/tests/references/functions/test_reference_function_factory_3.py
@@ -1,13 +1,19 @@
 import pytest
 
 from csvpath.references.functions.all_3 import All3
+from csvpath.references.functions.data_3 import Data3
 from csvpath.references.functions.definition_3 import Definition3
+from csvpath.references.functions.errors_3 import Errors3
+from csvpath.references.functions.file_3 import File3
 from csvpath.references.functions.first_3 import First3
 from csvpath.references.functions.function_3 import Function3
 from csvpath.references.functions.index_3 import Index3
 from csvpath.references.functions.last_3 import Last3
 from csvpath.references.functions.manifest_3 import Manifest3
+from csvpath.references.functions.meta_3 import Meta3
 from csvpath.references.functions.name_3 import Name3
+from csvpath.references.functions.unmatched_3 import Unmatched3
+from csvpath.references.functions.vars_3 import Vars3
 from csvpath.references.functions.reference_function_factory_3 import (
     ReferenceFunctionFactory,
 )
@@ -49,6 +55,33 @@ class TestBuild:
     def test_builds_definition(self):
         f = ReferenceFunctionFactory.build(FunctionCall3(name="definition"))
         assert isinstance(f, Definition3)
+
+    def test_builds_errors(self):
+        f = ReferenceFunctionFactory.build(FunctionCall3(name="errors"))
+        assert isinstance(f, Errors3)
+
+    def test_builds_vars(self):
+        f = ReferenceFunctionFactory.build(FunctionCall3(name="vars"))
+        assert isinstance(f, Vars3)
+
+    def test_builds_meta(self):
+        f = ReferenceFunctionFactory.build(FunctionCall3(name="meta"))
+        assert isinstance(f, Meta3)
+
+    def test_builds_data(self):
+        f = ReferenceFunctionFactory.build(FunctionCall3(name="data"))
+        assert isinstance(f, Data3)
+
+    def test_builds_unmatched(self):
+        f = ReferenceFunctionFactory.build(FunctionCall3(name="unmatched"))
+        assert isinstance(f, Unmatched3)
+
+    def test_builds_file(self):
+        f = ReferenceFunctionFactory.build(
+            FunctionCall3(name="file", arg="orders.parquet")
+        )
+        assert isinstance(f, File3)
+        assert f.arg == "orders.parquet"
 
     def test_unknown_function_raises(self):
         with pytest.raises(ReferenceException3):

--- a/tests/references/functions/test_unmatched_3.py
+++ b/tests/references/functions/test_unmatched_3.py
@@ -1,0 +1,22 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.unmatched_3 import Unmatched3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Unmatched3()
+    assert f.name == "unmatched"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+
+
+def test_no_arg_is_valid():
+    Unmatched3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Unmatched3(arg="x").check_valid()

--- a/tests/references/functions/test_vars_3.py
+++ b/tests/references/functions/test_vars_3.py
@@ -1,0 +1,22 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.vars_3 import Vars3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Vars3()
+    assert f.name == "vars"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+
+
+def test_no_arg_is_valid():
+    Vars3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Vars3(arg="x").check_valid()

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -276,13 +276,129 @@ class TestResolve:
         assert results.results[0].data is None
 
     def test_resolving_a_named_identity_gives_none(self, acme_archive):
-        # no well-known instance-level file function is registered yet
-        # (:data()/:vars()/:meta()/:unmatched()/:errors()) -- "no
-        # default" applies uniformly until one exists.
+        # an identity alone, with no well-known-file accessor riding
+        # alongside it, has no single unambiguous payload -- "no
+        # default" (see TestWellKnownFileAccessors for the accessor
+        # case, which does resolve to something).
         results = _finder(
             "$acme.results.customers/2025:first().company_names", acme_archive
         ).resolve()
         assert results.results[0].data is None
+
+
+class TestWellKnownFileAccessors:
+    # :errors()/:vars()/:meta() resolve to parsed JSON; :data()/
+    # :unmatched() resolve to raw bytes and tolerate absence (None);
+    # :file("...") resolves an arbitrary user-named file the same way,
+    # with a bare-filename-only guard against path traversal. All ride
+    # alongside the identity/:all() selector already in name_three --
+    # they do not select the instance themselves.
+    @pytest.fixture
+    def instance_dir(self, acme_archive):
+        path = (
+            f"{acme_archive}/acme/customers/2025/2026-01-01_00-00-00"
+            "/company_names"
+        )
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def test_errors_resolves_parsed_json(self, acme_archive, instance_dir):
+        errors = [{"error": "bad row", "line": 3}]
+        with open(os.path.join(instance_dir, "errors.json"), "w") as f:
+            json.dump(errors, f)
+        results = _finder(
+            "$acme.results.customers/2025:first().company_names:errors()",
+            acme_archive,
+        ).resolve()
+        assert results.results[0].data == errors
+
+    def test_vars_resolves_parsed_json(self, acme_archive, instance_dir):
+        variables = {"count": 5, "label": "totals"}
+        with open(os.path.join(instance_dir, "vars.json"), "w") as f:
+            json.dump(variables, f)
+        results = _finder(
+            "$acme.results.customers/2025:first().company_names:vars()",
+            acme_archive,
+        ).resolve()
+        assert results.results[0].data == variables
+
+    def test_meta_resolves_parsed_json(self, acme_archive, instance_dir):
+        meta = {"identity": "company_names", "run_index": 0}
+        with open(os.path.join(instance_dir, "meta.json"), "w") as f:
+            json.dump(meta, f)
+        results = _finder(
+            "$acme.results.customers/2025:first().company_names:meta()",
+            acme_archive,
+        ).resolve()
+        assert results.results[0].data == meta
+
+    def test_data_resolves_raw_bytes(self, acme_archive, instance_dir):
+        content = b"a,b\n1,2\n"
+        with open(os.path.join(instance_dir, "data.csv"), "wb") as f:
+            f.write(content)
+        results = _finder(
+            "$acme.results.customers/2025:first().company_names:data()",
+            acme_archive,
+        ).resolve()
+        assert results.results[0].data == content
+
+    def test_data_resolves_none_when_never_written(
+        self, acme_archive, instance_dir
+    ):
+        # data.csv is only written if at least one line matched --
+        # genuinely optional, same as definition.json.
+        results = _finder(
+            "$acme.results.customers/2025:first().company_names:data()",
+            acme_archive,
+        ).resolve()
+        assert results.results[0].data is None
+
+    def test_unmatched_resolves_raw_bytes(self, acme_archive, instance_dir):
+        content = b"x,y\n9,9\n"
+        with open(os.path.join(instance_dir, "unmatched.csv"), "wb") as f:
+            f.write(content)
+        results = _finder(
+            "$acme.results.customers/2025:first().company_names:unmatched()",
+            acme_archive,
+        ).resolve()
+        assert results.results[0].data == content
+
+    def test_file_resolves_a_user_named_output(self, acme_archive, instance_dir):
+        content = b"custom output"
+        with open(os.path.join(instance_dir, "orders.parquet"), "wb") as f:
+            f.write(content)
+        results = _finder(
+            '$acme.results.customers/2025:first().company_names'
+            ':file("orders.parquet")',
+            acme_archive,
+        ).resolve()
+        assert results.results[0].data == content
+
+    def test_file_rejects_a_path_valued_argument(self, acme_archive, instance_dir):
+        finder = _finder(
+            '$acme.results.customers/2025:first().company_names'
+            ':file("../escape.txt")',
+            acme_archive,
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_accessor_combined_with_all_reads_each_instance_own_file(
+        self, acme_archive
+    ):
+        # run1 has two instances: company_names and "1".
+        base = f"{acme_archive}/acme/customers/2025/2026-01-01_00-00-00"
+        os.makedirs(f"{base}/company_names", exist_ok=True)
+        os.makedirs(f"{base}/1", exist_ok=True)
+        with open(f"{base}/company_names/meta.json", "w") as f:
+            json.dump({"which": "company_names"}, f)
+        with open(f"{base}/1/meta.json", "w") as f:
+            json.dump({"which": "1"}, f)
+        results = _finder(
+            "$acme.results.customers/2025:first().:all():meta()", acme_archive
+        ).resolve()
+        by_which = {r.data["which"] for r in results.results}
+        assert by_which == {"company_names", "1"}
 
 
 class TestScopeLimits:
@@ -310,20 +426,40 @@ class TestScopeLimits:
         with pytest.raises(ReferenceException3):
             finder.query()
 
-    def test_unregistered_function_on_name_three_not_yet_supported(
-        self, acme_archive
-    ):
+    def test_truly_unregistered_function_on_name_three_raises(self, acme_archive):
+        finder = _finder(
+            "$acme.results.customers/2025:first().:quarter()", acme_archive
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_accessor_alone_with_no_identity_or_all_raises(self, acme_archive):
+        # :data() is registered and meaningful for results, but it does
+        # not itself select which instance it applies to -- it needs a
+        # literal identity or :all() riding alongside it.
         finder = _finder(
             "$acme.results.customers/2025:first().:data()", acme_archive
         )
         with pytest.raises(ReferenceException3):
             finder.query()
 
+    def test_identity_combined_with_all_raises(self, acme_archive):
+        # contradictory: a literal identity selects one instance, :all()
+        # selects every instance.
+        finder = _finder(
+            "$acme.results.customers/2025:first().company_names:all()",
+            acme_archive,
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
     def test_manifest_function_on_name_three_not_yet_supported(self, acme_archive):
         # :manifest() is registered, but not meaningful as a name_three
-        # function for results in this pass -- only :all() is accepted.
+        # function for results in this pass -- only :all() and the
+        # well-known-file accessors are accepted there.
         finder = _finder(
-            "$acme.results.customers/2025:first().:manifest()", acme_archive
+            "$acme.results.customers/2025:first().company_names:manifest()",
+            acme_archive,
         )
         with pytest.raises(ReferenceException3):
             finder.query()


### PR DESCRIPTION
## Summary
- Add Errors3/Vars3/Meta3 (resolve to parsed JSON) and Data3/Unmatched3/File3 (resolve to raw bytes, genuinely optional) -- the results-only well-known instance-level file functions. resolve() on a results reference has always returned None until now, since none of these existed.
- All six are ROLE=VALUE, matching Manifest3/Definition3 -- they never narrow/select an instance, they only access whatever the identity/:all() selector already in name_three picked out.
- File3 additionally guards against a path-valued argument (rejects /, \, ..) to stay inside the run instance's own directory.
- Fixed a real bug found while re-checking every accessor function's role for consistency: Definition3.ROLE was still POINTER, missed in the earlier Manifest3 fix despite the commit message claiming both were done -- the test suite never caught it because the test asserted the same wrong value.
- ResultsReferenceFinder3._name_three_selector now returns (identity, match_all, accessor) and validates two new cases: an accessor with neither an identity nor :all() raises (it does not select an instance itself), and identity combined with :all() raises (the old code silently discarded the identity, a latent bug nobody had exercised).
- New shared ReferenceFinder3._read_well_known_json(), the JSON-parsing sibling of the existing _read_well_known_file.

## Test plan
- [x] `pytest tests/references/ -q` - 471 passed
- [x] `pytest -q` (full suite) - 2051 passed, 11 failed (pre-existing SFTP/S3/Nos baseline, unrelated)
- [x] Verified end to end against real files on disk for :errors()