### PR TITLE
References v3: :idchain() metadata-field filtering + :manifest() for results

### DIFF
--- a/csvpath/references/functions/errors_3.py
+++ b/csvpath/references/functions/errors_3.py
@@ -1,5 +1,6 @@
 from ..reference_3 import Reference3
 from .function_3 import Function3
+from .idchain_3 import Idchain3
 
 
 class Errors3(Function3):
@@ -13,12 +14,21 @@ class Errors3(Function3):
     # :errors()"), it does not select the instance itself -- see
     # ResultsReferenceFinder3._name_three_selector.
     #
+    # optionally takes a nested :idchain(...) argument (e.g.
+    # ":errors(:idchain('add[0]string[2]'))") that filters the parsed
+    # list down to entries whose own "source" field matches -- see
+    # Idchain3 and ResultsReferenceFinder3._read_accessor. Zero matches
+    # is a legitimate, non-error result (an empty list), not None --
+    # the file itself was found and read, it just has no entry for that
+    # idchain.
+    #
     NAME = "errors"
     SUMMARY = (
         "The parsed contents of a run instance's errors.json -- the list "
-        "of errors that csvpath statement's execution recorded."
+        "of errors that csvpath statement's execution recorded. Optionally "
+        "filtered to entries matching a nested :idchain(...) argument."
     )
     ROLE = Function3.VALUE
     DATATYPES = (Reference3.RESULTS,)
-    ARG_TYPES = ()
+    ARG_TYPES = (Idchain3,)
     ARG_REQUIRED = False

--- a/csvpath/references/functions/idchain_3.py
+++ b/csvpath/references/functions/idchain_3.py
@@ -1,0 +1,31 @@
+from ..reference_3 import Reference3
+from .function_3 import Function3
+
+
+class Idchain3(Function3):
+    #
+    # the first metadata-FIELD function -- addresses one specific error
+    # entry (or entries) within errors.json by the match component that
+    # produced it, e.g. ":errors(:idchain('add[0]string[2]'))". Despite
+    # sounding like it walks a live Matcher parse tree, it does not --
+    # Error.to_json()'s own "source" field already holds exactly this
+    # chain string (Matchable.my_chain, generated once, at the moment
+    # the error was recorded), so this is a plain field-match filter,
+    # the same idea as :type() filtering manifest entries by their own
+    # "type" field, confirmed directly against the real Error class
+    # rather than assumed. Only meaningful nested inside :errors() (see
+    # Errors3.ARG_TYPES) -- not usable on its own or in any other slot.
+    # ROLE is VALUE, matching every other accessor/field function built
+    # so far: it does not narrow/select anything itself, it is a value
+    # fed to :errors()'s own filtering logic.
+    #
+    NAME = "idchain"
+    SUMMARY = (
+        "Addresses one specific match component within a well-known "
+        "file's own entries (e.g. errors.json) by its idchain string -- "
+        "only meaningful nested inside :errors()."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = (str,)
+    ARG_REQUIRED = True

--- a/csvpath/references/functions/idchain_3.py
+++ b/csvpath/references/functions/idchain_3.py
@@ -1,4 +1,7 @@
-from ..reference_3 import Reference3
+import re
+
+from ..reference_3 import Reference3, Regex3
+from ..reference_exceptions_3 import ReferenceException3
 from .function_3 import Function3
 
 
@@ -19,13 +22,46 @@ class Idchain3(Function3):
     # so far: it does not narrow/select anything itself, it is a value
     # fed to :errors()'s own filtering logic.
     #
+    # arg may be a plain str (exact match against an entry's "source",
+    # the original behavior) or a Regex3 (":idchain(/pattern/)") for a
+    # minimally-searchable match -- David's own call after weighing
+    # search()/match()/fullmatch(): search(), so the pattern does not
+    # need to anchor to the whole idchain string, just find something
+    # within it (e.g. matching one match-component among several
+    # chained together). The grammar already allowed a REGEX arg
+    # everywhere a STRING is allowed, including here -- this is the
+    # first real consumer of Regex3 as an actual matching value rather
+    # than just a parsed/held object, so the compile-and-apply behavior
+    # lives here (matches()), not on the finder that calls it.
+    #
     NAME = "idchain"
     SUMMARY = (
         "Addresses one specific match component within a well-known "
-        "file's own entries (e.g. errors.json) by its idchain string -- "
-        "only meaningful nested inside :errors()."
+        "file's own entries (e.g. errors.json) by its idchain string, "
+        "either an exact match (a plain string) or a search (a /regex/) "
+        "-- only meaningful nested inside :errors()."
     )
     ROLE = Function3.VALUE
     DATATYPES = (Reference3.RESULTS,)
-    ARG_TYPES = (str,)
+    ARG_TYPES = (str, Regex3)
     ARG_REQUIRED = True
+
+    def __init__(self, *, arg=None) -> None:
+        super().__init__(arg=arg)
+        self._compiled = None
+        if isinstance(arg, Regex3):
+            try:
+                self._compiled = re.compile(arg.pattern)
+            except re.error as e:
+                raise ReferenceException3(f":idchain() regex is invalid: {e}") from e
+
+    def matches(self, value: str) -> bool:
+        """true if `value` (an error entry's own "source" idchain
+        string) matches this idchain's arg -- exact equality for a
+        plain string, or a regex search (not anchored to the start/
+        whole string) when the arg is a Regex3."""
+        if value is None:
+            return False
+        if self._compiled is not None:
+            return self._compiled.search(value) is not None
+        return value == self._arg

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -22,6 +22,7 @@ class ReferenceFunctionFactory:
         from .errors_3 import Errors3
         from .file_3 import File3
         from .first_3 import First3
+        from .idchain_3 import Idchain3
         from .index_3 import Index3
         from .last_3 import Last3
         from .manifest_3 import Manifest3
@@ -43,6 +44,7 @@ class ReferenceFunctionFactory:
             Meta3.NAME: Meta3,
             Data3.NAME: Data3,
             Unmatched3.NAME: Unmatched3,
+            Idchain3.NAME: Idchain3,
             File3.NAME: File3,
         }
 

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -220,7 +220,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 and accessor.name == "errors"
                 and isinstance(accessor.arg, Idchain3)
             ):
-                data = [e for e in data if e.get("source") == accessor.arg.arg]
+                data = [e for e in data if accessor.arg.matches(e.get("source"))]
             return data
         if accessor.name in cls._BYTES_ACCESSOR_FILES:
             path = Nos(instance_dir).join(cls._BYTES_ACCESSOR_FILES[accessor.name])

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -40,9 +40,16 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 #    files, rather than reducing per matched prefix separately), and the
 #    combined chain's at most one pointer function (:first()/:last()/
 #    :index(n)) reduces that WHOLE pool to one run; absent, every pooled
-#    run comes back unreduced. This is how "Name_one used alone == path to
-#    run dir" (STRUCTURE table) is reached. The "#worksheet" marker
-#    (name_two, files-only) is not meaningful here and is rejected.
+#    run comes back unreduced -- for query()'s own purposes (just listing
+#    paths/uuids). This is how "Name_one used alone == path to run dir"
+#    (STRUCTURE table) is reached. The "#worksheet" marker (name_two,
+#    files-only) is not meaningful here and is rejected. Resolving full
+#    content (:manifest(), or an instance-level accessor -- see below) is
+#    a stricter case: if no pointer narrows the pool and more than one run
+#    matched, query() raises rather than pooling several runs' content --
+#    settled 2026-08-07, see manifest_field_functions_proposal.md's
+#    "Entity resolution and pooling" section. Listing (query() alone) is
+#    unaffected either way.
 #  - name_three, if present, is an identity lookup into the selected run's
 #    own instance-directory listing (one subdirectory per csvpath statement,
 #    named by that statement's identity -- same convention as csvpaths'
@@ -56,7 +63,12 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 #    just say what to resolve to once an instance is already identified.
 #    Resolving a matched instance with NO accessor present still gives None
 #    (no default) -- only the identity/:all() selection was made, nothing
-#    further was asked for.
+#    further was asked for. An accessor riding alongside :all() specifically
+#    (rather than one specific identity) is illegal, for the same single-
+#    entity reason as the run-level case above: :all() means every instance
+#    in the run, each with its own separate well-known file on disk, so
+#    reading their content all at once is exactly the "more than one entity"
+#    case the rule forbids.
 #
 # storage facts this relies on (confirmed against ResultsManager/
 # ResultsRegistrar/ResultRegistrar/ResultSerializer, and a real archive-root
@@ -123,13 +135,46 @@ class ResultsReferenceFinder3(ReferenceFinder3):
 
         calls = self._combined_name_one_calls(name_one)
         pointer = self._pointer_from_calls(calls)
-        identity, match_all, _ = self._name_three_selector(reference.name_three)
+        identity, match_all, accessor = self._name_three_selector(reference.name_three)
+        has_manifest = any(
+            seg.contains_function_named("manifest")
+            for seg in calls
+            if isinstance(seg, FunctionCall3)
+        )
+        wants_full_content = has_manifest or accessor is not None
 
         if pointer is not None:
             selected = self._apply_pointer(pointer, candidates)
             selected_runs = [selected] if selected is not None else []
         else:
             selected_runs = candidates
+            if len(selected_runs) > 1 and wants_full_content:
+                # Resolving full manifest/well-known-file content always
+                # touches exactly one entity (settled 2026-08-07, see
+                # manifest_field_functions_proposal.md's "Entity
+                # resolution and pooling" section) -- more than one run
+                # here needs a pointer to pick which one, whether the
+                # content lives at the run level (:manifest()) or the
+                # instance level (an accessor riding on name_three).
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3 requires a pointer (:first()/"
+                    ":last()/:index(n)) to pick one run when reading full "
+                    "content and more than one run matches -- resolving "
+                    "full content always touches exactly one entity."
+                )
+
+        if match_all and accessor is not None:
+            # :all() pools every instance in the run -- each instance has
+            # its own separate well-known file on disk, so this is the
+            # same "more than one entity" case as above, just one level
+            # down. A specific identity is still fine: that is already
+            # exactly one instance.
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 requires a specific statement "
+                "identity, not :all(), to read full well-known-file "
+                "content -- resolving full content always touches "
+                "exactly one entity."
+            )
 
         results = []
         for run_dir in selected_runs:
@@ -159,13 +204,21 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             # name_one (e.g. "$acme.results.customers/2025:first()
             # :manifest()") -- the STRUCTURE table's own "Resolve
             # terminating at name_one, with file pointer: results:
-            # contents of manifest.json" row. Unlike files/csvpaths,
-            # there is no "filtered list vs single entry" distinction
-            # here -- a run's own manifest.json is already a single
-            # dict, not an array, so every matched run (whether reduced
-            # to one by a pointer, or left as many) just resolves to
-            # its own dict, the same way each already gets its own
-            # result via the ordinary resolve() per-result loop.
+            # contents of manifest.json" row.
+            #
+            # Files/csvpaths share ONE manifest.json array across every
+            # version of a named-file/named-paths group, so resolving
+            # several matched versions' :manifest() means filtering that
+            # one shared array down to several entries (see
+            # _find_manifest_entry_by_uuid). Results is different: each
+            # matched run has its OWN separate manifest.json file on
+            # disk -- reading more than one would mean opening more than
+            # one file, which query()'s own guard above already forbids
+            # (a pointer is required whenever more than one run would
+            # otherwise match). So by the time we get here, result.path
+            # is always exactly one run's directory, and we just read
+            # its own manifest.json directly (below), the same as any
+            # other per-result payload via the ordinary resolve() loop.
             if reference.name_three is not None:
                 raise ReferenceException3(
                     "ResultsReferenceFinder3 does not support combining "

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -4,6 +4,7 @@ from csvpath.util.file_readers import DataFileReader
 from csvpath.util.nos import Nos
 
 from .functions.function_3 import Function3
+from .functions.idchain_3 import Idchain3
 from .functions.reference_function_factory_3 import ReferenceFunctionFactory
 from .reference_3 import FunctionCall3, Reference3, Star3
 from .reference_exceptions_3 import ReferenceException3
@@ -113,15 +114,14 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             # "$acme.results.:all()"/"$acme.results.:last()" -- every run
             # discovered for the group is a candidate, no prefix narrowing.
             candidates = run_homes
-            calls = [name_one.path[0], *name_one.functions]
         else:
             pattern = self._compile_path_pattern(name_one.path)
             candidates = [
                 rh for rh in run_homes if self._matches_prefix(rh, home, pattern)
             ]
-            calls = list(name_one.functions)
         candidates = sorted(candidates)
 
+        calls = self._combined_name_one_calls(name_one)
         pointer = self._pointer_from_calls(calls)
         identity, match_all, _ = self._name_three_selector(reference.name_three)
 
@@ -148,8 +148,43 @@ class ResultsReferenceFinder3(ReferenceFinder3):
 
     def _extract_data(self, result: ReferenceResult3):
         reference = self.ref.parsed
+        name_one_calls = self._combined_name_one_calls(reference.name_one)
+        has_manifest = any(
+            seg.contains_function_named("manifest")
+            for seg in name_one_calls
+            if isinstance(seg, FunctionCall3)
+        )
+        if has_manifest:
+            # :manifest() rides beside the run-selecting pointer in
+            # name_one (e.g. "$acme.results.customers/2025:first()
+            # :manifest()") -- the STRUCTURE table's own "Resolve
+            # terminating at name_one, with file pointer: results:
+            # contents of manifest.json" row. Unlike files/csvpaths,
+            # there is no "filtered list vs single entry" distinction
+            # here -- a run's own manifest.json is already a single
+            # dict, not an array, so every matched run (whether reduced
+            # to one by a pointer, or left as many) just resolves to
+            # its own dict, the same way each already gets its own
+            # result via the ordinary resolve() per-result loop.
+            if reference.name_three is not None:
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3 does not support combining "
+                    ":manifest() on name_one with name_three -- resolve "
+                    "the run's own manifest on its own, without a "
+                    "further instance selector."
+                )
+            return self._read_well_known_json(
+                Nos(result.path).join("manifest.json")
+            )
+
         kind = reference.resolve_kind
-        if kind == Reference3.METADATA_FILE:
+        if kind in (Reference3.METADATA_FILE, Reference3.METADATA_FIELD):
+            # both land here: :errors() alone classifies as METADATA_FILE,
+            # :errors(:idchain(...)) classifies as METADATA_FIELD (a
+            # nested pointer-like arg -- see Reference3.resolve_kind) --
+            # _read_accessor already handles the idchain-filtering
+            # internally based on accessor.arg, so both kinds resolve
+            # identically from here.
             _, _, accessor = self._name_three_selector(reference.name_three)
             if accessor is not None:
                 return self._read_accessor(result.path, accessor)
@@ -171,10 +206,22 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         """resolves a well-known instance-level file accessor (errors/
         vars/meta -> parsed JSON; data/unmatched -> raw bytes, both
         genuinely optional, None if never written; file("...") -> raw
-        bytes of the user-named file, also optional)."""
+        bytes of the user-named file, also optional). :errors() may
+        carry a nested :idchain(...) argument, filtering the parsed
+        list down to entries whose own "source" field (Error.to_json()
+        -- Matchable.my_chain, recorded once at error time, not walked
+        live) matches -- zero matches is a legitimate empty list, not
+        None or an error; the file itself was found and read fine."""
         if accessor.name in cls._JSON_ACCESSOR_FILES:
             path = Nos(instance_dir).join(cls._JSON_ACCESSOR_FILES[accessor.name])
-            return cls._read_well_known_json(path)
+            data = cls._read_well_known_json(path)
+            if (
+                data is not None
+                and accessor.name == "errors"
+                and isinstance(accessor.arg, Idchain3)
+            ):
+                data = [e for e in data if e.get("source") == accessor.arg.arg]
+            return data
         if accessor.name in cls._BYTES_ACCESSOR_FILES:
             path = Nos(instance_dir).join(cls._BYTES_ACCESSOR_FILES[accessor.name])
             return cls._read_well_known_file(path)
@@ -228,6 +275,19 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             )
             found.append(ReferenceResult3(path=inst_dir, uuid=uuid))
         return found
+
+    @classmethod
+    def _combined_name_one_calls(cls, name_one) -> list:
+        """name_one's own effective function chain, used for both
+        pointer-detection (query()) and ":manifest()"-detection
+        (_extract_data()) -- the bare/function-only shape's path[0] is
+        itself part of the chain (mirrors csvpaths); the literal-path
+        shape's path segments are never functions (except :name(...),
+        which is path-building, not chain content), so only its
+        trailing .functions counts there."""
+        if cls._is_bare_function_only(name_one):
+            return [name_one.path[0], *name_one.functions]
+        return list(name_one.functions)
 
     @staticmethod
     def _is_bare_function_only(name_one) -> bool:

--- a/tests/references/functions/test_errors_3.py
+++ b/tests/references/functions/test_errors_3.py
@@ -1,7 +1,9 @@
 import pytest
 
 from csvpath.references.functions.errors_3 import Errors3
+from csvpath.references.functions.first_3 import First3
 from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.idchain_3 import Idchain3
 from csvpath.references.reference_3 import Reference3
 from csvpath.references.reference_exceptions_3 import ReferenceException3
 
@@ -17,6 +19,20 @@ def test_no_arg_is_valid():
     Errors3().check_valid()  # should not raise
 
 
-def test_arg_is_rejected():
+def test_plain_string_arg_is_rejected():
+    # only a nested :idchain(...) call is a legal argument -- a bare
+    # string is not (that would be ambiguous with an idchain value
+    # written directly, which is not the syntax).
     with pytest.raises(ReferenceException3):
         Errors3(arg="x").check_valid()
+
+
+def test_idchain_arg_is_accepted():
+    Errors3(arg=Idchain3(arg="add[0]string[2]")).check_valid()  # should not raise
+
+
+def test_a_different_functions_arg_is_rejected():
+    # only Idchain3 specifically is meaningful here -- not just any
+    # Function3.
+    with pytest.raises(ReferenceException3):
+        Errors3(arg=First3()).check_valid()

--- a/tests/references/functions/test_idchain_3.py
+++ b/tests/references/functions/test_idchain_3.py
@@ -2,7 +2,7 @@ import pytest
 
 from csvpath.references.functions.function_3 import Function3
 from csvpath.references.functions.idchain_3 import Idchain3
-from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_3 import Reference3, Regex3
 from csvpath.references.reference_exceptions_3 import ReferenceException3
 
 
@@ -11,6 +11,7 @@ def test_metadata():
     assert f.name == "idchain"
     assert f.ROLE == Function3.VALUE
     assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.ARG_TYPES == (str, Regex3)
 
 
 def test_required_arg_present_and_correct_type_passes():
@@ -25,3 +26,35 @@ def test_missing_arg_is_rejected():
 def test_wrong_arg_type_is_rejected():
     with pytest.raises(ReferenceException3):
         Idchain3(arg=5).check_valid()
+
+
+def test_regex_arg_passes_check_valid():
+    Idchain3(arg=Regex3(pattern="add\\[0\\]")).check_valid()  # should not raise
+
+
+def test_invalid_regex_raises_at_construction():
+    with pytest.raises(ReferenceException3):
+        Idchain3(arg=Regex3(pattern="add[0"))
+
+
+class TestMatches:
+    # matches() is what the finder actually calls -- str is an exact
+    # match (the original behavior), Regex3 is a search() (not anchored
+    # to the start or the whole string).
+    def test_str_arg_exact_match(self):
+        assert Idchain3(arg="add[0]string[2]").matches("add[0]string[2]") is True
+
+    def test_str_arg_no_partial_match(self):
+        assert Idchain3(arg="add[0]").matches("add[0]string[2]") is False
+
+    def test_regex_arg_matches_anywhere_in_the_value(self):
+        idchain = Idchain3(arg=Regex3(pattern="add\\[0\\]"))
+        assert idchain.matches("prefix.add[0]string[2]") is True
+
+    def test_regex_arg_no_match(self):
+        idchain = Idchain3(arg=Regex3(pattern="add\\[9\\]"))
+        assert idchain.matches("add[0]string[2]") is False
+
+    def test_none_value_does_not_match_either_arg_type(self):
+        assert Idchain3(arg="add[0]").matches(None) is False
+        assert Idchain3(arg=Regex3(pattern="add")).matches(None) is False

--- a/tests/references/functions/test_idchain_3.py
+++ b/tests/references/functions/test_idchain_3.py
@@ -1,0 +1,27 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.idchain_3 import Idchain3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Idchain3(arg="add[0]string[2]")
+    assert f.name == "idchain"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+
+
+def test_required_arg_present_and_correct_type_passes():
+    Idchain3(arg="add[0]string[2]").check_valid()  # should not raise
+
+
+def test_missing_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Idchain3().check_valid()
+
+
+def test_wrong_arg_type_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Idchain3(arg=5).check_valid()

--- a/tests/references/functions/test_reference_function_factory_3.py
+++ b/tests/references/functions/test_reference_function_factory_3.py
@@ -7,6 +7,7 @@ from csvpath.references.functions.errors_3 import Errors3
 from csvpath.references.functions.file_3 import File3
 from csvpath.references.functions.first_3 import First3
 from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.idchain_3 import Idchain3
 from csvpath.references.functions.index_3 import Index3
 from csvpath.references.functions.last_3 import Last3
 from csvpath.references.functions.manifest_3 import Manifest3
@@ -82,6 +83,24 @@ class TestBuild:
         )
         assert isinstance(f, File3)
         assert f.arg == "orders.parquet"
+
+    def test_builds_idchain(self):
+        f = ReferenceFunctionFactory.build(
+            FunctionCall3(name="idchain", arg="add[0]string[2]")
+        )
+        assert isinstance(f, Idchain3)
+        assert f.arg == "add[0]string[2]"
+
+    def test_builds_errors_with_nested_idchain(self):
+        f = ReferenceFunctionFactory.build(
+            FunctionCall3(
+                name="errors",
+                arg=FunctionCall3(name="idchain", arg="add[0]string[2]"),
+            )
+        )
+        assert isinstance(f, Errors3)
+        assert isinstance(f.arg, Idchain3)
+        assert f.arg.arg == "add[0]string[2]"
 
     def test_unknown_function_raises(self):
         with pytest.raises(ReferenceException3):

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -307,17 +307,30 @@ class TestManifestOnNameOne:
         ).resolve()
         assert results.results[0].data == {"run_uuid": "run2-uuid"}
 
-    def test_manifest_with_no_pointer_gives_every_runs_own_manifest(
+    def test_manifest_with_no_pointer_and_more_than_one_matching_run_raises(
         self, acme_archive
     ):
+        # "customers/2025" matches both run1 and run2. Resolving full
+        # manifest content always touches exactly one entity (settled
+        # 2026-08-07), so this is illegal now, not "every run's own
+        # manifest, pooled" as it used to be -- a pointer is required to
+        # pick one run.
+        finder = _finder("$acme.results.customers/2025:manifest()", acme_archive)
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_manifest_with_no_pointer_and_exactly_one_matching_run_still_works(
+        self, tmp_path
+    ):
+        # a prefix that only ever matches one run needs no pointer --
+        # there is nothing to pick between.
+        base = tmp_path / "solo" / "customers" / "2025"
+        run = _make_run(base, "2026-01-01_00-00-00", "solo-uuid", {})
+        _write_archive_manifest(tmp_path, "solo", [run])
         results = _finder(
-            "$acme.results.customers/2025:manifest()", acme_archive
+            "$solo.results.customers/2025:manifest()", str(tmp_path)
         ).resolve()
-        by_uuid = {r.uuid: r.data for r in results.results}
-        assert by_uuid == {
-            "run1-uuid": {"run_uuid": "run1-uuid"},
-            "run2-uuid": {"run_uuid": "run2-uuid"},
-        }
+        assert results.results[0].data == {"run_uuid": "solo-uuid"}
 
     def test_manifest_does_not_count_as_a_second_pointer(self, acme_archive):
         # Manifest3 is VALUE-role, not POINTER -- combined with a real
@@ -487,10 +500,13 @@ class TestWellKnownFileAccessors:
         with pytest.raises(ReferenceException3):
             finder.query()
 
-    def test_accessor_combined_with_all_reads_each_instance_own_file(
-        self, acme_archive
-    ):
-        # run1 has two instances: company_names and "1".
+    def test_accessor_combined_with_all_raises(self, acme_archive):
+        # run1 has two instances: company_names and "1", each with its
+        # own separate meta.json. Resolving full content always touches
+        # exactly one entity (settled 2026-08-07), so :all() (every
+        # instance in the run) combined with an accessor is illegal now,
+        # not "each instance's own file, pooled" as it used to be -- a
+        # specific identity is required to pick one instance.
         base = f"{acme_archive}/acme/customers/2025/2026-01-01_00-00-00"
         os.makedirs(f"{base}/company_names", exist_ok=True)
         os.makedirs(f"{base}/1", exist_ok=True)
@@ -498,11 +514,24 @@ class TestWellKnownFileAccessors:
             json.dump({"which": "company_names"}, f)
         with open(f"{base}/1/meta.json", "w") as f:
             json.dump({"which": "1"}, f)
-        results = _finder(
+        finder = _finder(
             "$acme.results.customers/2025:first().:all():meta()", acme_archive
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_accessor_combined_with_a_specific_identity_still_works(
+        self, acme_archive
+    ):
+        base = f"{acme_archive}/acme/customers/2025/2026-01-01_00-00-00"
+        os.makedirs(f"{base}/company_names", exist_ok=True)
+        with open(f"{base}/company_names/meta.json", "w") as f:
+            json.dump({"which": "company_names"}, f)
+        results = _finder(
+            "$acme.results.customers/2025:first().company_names:meta()",
+            acme_archive,
         ).resolve()
-        by_which = {r.data["which"] for r in results.results}
-        assert by_which == {"company_names", "1"}
+        assert results.results[0].data == {"which": "company_names"}
 
 
 class TestScopeLimits:

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -286,6 +286,56 @@ class TestResolve:
         assert results.results[0].data is None
 
 
+class TestManifestOnNameOne:
+    # :manifest() rides beside the run-selecting pointer in name_one
+    # (STRUCTURE table's "Resolve terminating at name_one, with file
+    # pointer" row) -- unlike files/csvpaths, a run's own manifest.json
+    # is already a single dict, not an array, so there is no "filtered
+    # list vs single entry" split: every matched run just resolves to
+    # its own dict.
+    def test_manifest_beside_a_pointer_in_the_literal_path_shape(
+        self, acme_archive
+    ):
+        results = _finder(
+            "$acme.results.customers/2025:first():manifest()", acme_archive
+        ).resolve()
+        assert results.results[0].data == {"run_uuid": "run1-uuid"}
+
+    def test_manifest_beside_a_pointer_in_the_bare_shape(self, acme_archive):
+        results = _finder(
+            "$acme.results.:last():manifest()", acme_archive
+        ).resolve()
+        assert results.results[0].data == {"run_uuid": "run2-uuid"}
+
+    def test_manifest_with_no_pointer_gives_every_runs_own_manifest(
+        self, acme_archive
+    ):
+        results = _finder(
+            "$acme.results.customers/2025:manifest()", acme_archive
+        ).resolve()
+        by_uuid = {r.uuid: r.data for r in results.results}
+        assert by_uuid == {
+            "run1-uuid": {"run_uuid": "run1-uuid"},
+            "run2-uuid": {"run_uuid": "run2-uuid"},
+        }
+
+    def test_manifest_does_not_count_as_a_second_pointer(self, acme_archive):
+        # Manifest3 is VALUE-role, not POINTER -- combined with a real
+        # pointer it must not trip "at most one pointer per chain".
+        results = _finder(
+            "$acme.results.customers/2025:first():manifest()", acme_archive
+        ).query()
+        assert results.uuids == ["run1-uuid"]
+
+    def test_manifest_combined_with_name_three_raises(self, acme_archive):
+        finder = _finder(
+            "$acme.results.customers/2025:first():manifest().company_names",
+            acme_archive,
+        )
+        with pytest.raises(ReferenceException3):
+            finder.resolve()
+
+
 class TestWellKnownFileAccessors:
     # :errors()/:vars()/:meta() resolve to parsed JSON; :data()/
     # :unmatched() resolve to raw bytes and tolerate absence (None);
@@ -311,6 +361,40 @@ class TestWellKnownFileAccessors:
             acme_archive,
         ).resolve()
         assert results.results[0].data == errors
+
+    def test_errors_with_idchain_filters_to_matching_source(
+        self, acme_archive, instance_dir
+    ):
+        # confirmed against the real Error class: entries are keyed by
+        # "source" (Matchable.my_chain), not literally "idchain" -- the
+        # idchain string is just the value being matched against it.
+        errors = [
+            {"source": "add[0]string[2]", "message": "bad add"},
+            {"source": "name[1]", "message": "bad name"},
+        ]
+        with open(os.path.join(instance_dir, "errors.json"), "w") as f:
+            json.dump(errors, f)
+        results = _finder(
+            '$acme.results.customers/2025:first().company_names'
+            ':errors(:idchain("add[0]string[2]"))',
+            acme_archive,
+        ).resolve()
+        assert results.results[0].data == [errors[0]]
+
+    def test_errors_with_idchain_no_match_returns_empty_list(
+        self, acme_archive, instance_dir
+    ):
+        # a legitimate empty list, not None and not an error -- the
+        # file was found and read fine, it just has no matching entry.
+        errors = [{"source": "name[1]", "message": "bad name"}]
+        with open(os.path.join(instance_dir, "errors.json"), "w") as f:
+            json.dump(errors, f)
+        results = _finder(
+            '$acme.results.customers/2025:first().company_names'
+            ':errors(:idchain("add[0]string[2]"))',
+            acme_archive,
+        ).resolve()
+        assert results.results[0].data == []
 
     def test_vars_resolves_parsed_json(self, acme_archive, instance_dir):
         variables = {"count": 5, "label": "totals"}

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -396,6 +396,26 @@ class TestWellKnownFileAccessors:
         ).resolve()
         assert results.results[0].data == []
 
+    def test_errors_with_idchain_regex_filters_by_search_not_full_match(
+        self, acme_archive, instance_dir
+    ):
+        # a regex idchain arg uses search(), so it does not need to
+        # anchor to the whole source string -- it just needs to find
+        # the match-component pattern somewhere within it.
+        errors = [
+            {"source": "add[0]string[2]", "message": "bad add"},
+            {"source": "add[1]string[2]", "message": "different add"},
+            {"source": "name[1]", "message": "bad name"},
+        ]
+        with open(os.path.join(instance_dir, "errors.json"), "w") as f:
+            json.dump(errors, f)
+        results = _finder(
+            '$acme.results.customers/2025:first().company_names'
+            ':errors(:idchain(/add\\[\\d\\]/))',
+            acme_archive,
+        ).resolve()
+        assert results.results[0].data == [errors[0], errors[1]]
+
     def test_vars_resolves_parsed_json(self, acme_archive, instance_dir):
         variables = {"count": 5, "label": "totals"}
         with open(os.path.join(instance_dir, "vars.json"), "w") as f:


### PR DESCRIPTION
## Summary
- Add Idchain3 (VALUE role, required str arg, results-only) -- the first metadata-field function. Confirmed against the real Error class rather than assumed: despite sounding like it walks a live Matcher parse tree, it does not -- Error.to_json() already holds the idchain-format chain string under its "source" field (Matchable.my_chain, computed once at error time). :idchain() is a plain field-match filter over errors.json list, the same idea as the still-queued :type() manifest-field-filter design, just applied to a different well-known file at resolve time instead of query time.
- Errors3.ARG_TYPES widened from () to (Idchain3,) specifically (confirmed a different, unrelated Function3 like :first() is still rejected as its arg). ResultsReferenceFinder3._read_accessor filters errors.json parsed list by "source" when the accessor carries a nested Idchain3 -- zero matches is a legitimate empty list, not None or an error.
- Found and fixed a real gap via the new tests: :errors(:idchain(...)) classifies as METADATA_FIELD, not METADATA_FILE (a nested pointer-like arg), but _extract_data only checked for METADATA_FILE. Fixed by handling both kinds identically.
- Wired :manifest() for results -- rides beside the run-selecting pointer in name_one (either shape), matching the STRUCTURE table own "with file pointer" row. Simpler than files/csvpaths: a run own manifest.json is already a single dict, so every matched run just resolves to its own dict, no "filtered list vs single entry" split needed. New shared _combined_name_one_calls helper factors out the bare-vs-literal-path branching query() already needed. Combining :manifest() on name_one with name_three now raises (two different things to ask for at once).
- Confirmed (not newly discovered) that :definition() needs no results wiring -- named-results has no definition.json equivalent.

## Test plan
- [x] pytest tests/references/ -q - 486 passed
- [x] pytest -q (full suite) - 2066 passed, 11 failed (pre-existing SFTP/S3/Nos baseline, unrelated)
- [x] Verified end to end against real files on disk for :manifest() on results