### PR TITLE
References v3: full manifest content always resolves to exactly one entity

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -85,6 +85,29 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         manifest = self.csvpaths.paths_manager.get_manifest_for_name(root_major)
         selected_versions = self._resolve_versions(name_one, manifest)
 
+        if len(selected_versions) > 1:
+            combined = [
+                seg
+                for seg in (name_one.path[0], *name_one.functions)
+                if isinstance(seg, FunctionCall3)
+            ]
+            has_manifest = any(
+                seg.contains_function_named("manifest") for seg in combined
+            )
+            if has_manifest:
+                # Resolving full manifest content always touches exactly
+                # one entity (settled 2026-08-07, see manifest_field_
+                # functions_proposal.md's "Entity resolution and pooling"
+                # section) -- more than one version here needs a pointer
+                # to pick which one.
+                raise ReferenceException3(
+                    "CsvpathsReferenceFinder3 requires a pointer (:first()/"
+                    ":last()/:index(n)) to pick one version when combining "
+                    ":manifest() with no pointer matches more than one "
+                    "version -- resolving full manifest content always "
+                    "touches exactly one entity."
+                )
+
         name_three = reference.name_three
         if name_three is not None:
             if name_three.functions:

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -121,11 +121,22 @@ class FilesReferenceFinder3(ReferenceFinder3):
             selected = self._apply_pointer(pointers[0], candidates)
             selected_candidates = [selected] if selected is not None else []
         else:
-            # :manifest() alone, no pointer -- every version matching
-            # name_one's own path narrowing, unreduced. This is how
-            # "$acme.files.orders.:manifest()" (David's own example) is
-            # actually reached: the manifest entries of every
-            # registration under "orders", not just one.
+            # :manifest() alone, no pointer -- legal only when name_one's
+            # own path narrowing already resolves to at most one version.
+            # Resolving full manifest content always touches exactly one
+            # entity (settled 2026-08-07, see manifest_field_functions_
+            # proposal.md's "Entity resolution and pooling" section) --
+            # more than one candidate here needs a pointer to pick which
+            # one, the same as it would for any other version-selecting
+            # reference.
+            if len(candidates) > 1:
+                raise ReferenceException3(
+                    "FilesReferenceFinder3 requires a pointer (:first()/"
+                    ":last()/:index(n)) to pick one version when combining "
+                    ":manifest() with path narrowing that matches more "
+                    "than one version -- resolving full manifest content "
+                    "always touches exactly one entity."
+                )
             selected_candidates = candidates
 
         return ReferenceResults3(

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -179,14 +179,22 @@ class TestManifestFunction:
         assert results.uuids == ["v1-uuid"]
         assert results.results[0].data == ACME_MANIFEST[1]
 
-    def test_manifest_with_all_and_no_pointer_gives_every_version_entry(self):
+    def test_manifest_with_all_and_no_pointer_raises(self):
         # :all() (CONTEXT_SETTER) plus :manifest() (VALUE) -- neither is
-        # a pointer, so every version comes back unreduced, each
-        # resolving to its own manifest entry.
-        results = _finder("$acme.csvpaths.:all():manifest()").resolve()
-        assert results.uuids == ["v0-uuid", "v1-uuid"]
-        assert results.data_for_uuid("v0-uuid") == ACME_MANIFEST[0]
-        assert results.data_for_uuid("v1-uuid") == ACME_MANIFEST[1]
+        # a pointer, and ACME_MANIFEST has two versions. Resolving full
+        # manifest content always touches exactly one entity (settled
+        # 2026-08-07), so this is illegal now, not "every version,
+        # unreduced" as it used to be -- a pointer is required to pick
+        # one version.
+        finder = _finder("$acme.csvpaths.:all():manifest()")
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_manifest_with_no_pointer_and_exactly_one_version_still_works(self):
+        single_version = [ACME_MANIFEST[0]]
+        results = _finder("$acme.csvpaths.:all():manifest()", single_version).resolve()
+        assert results.uuids == ["v0-uuid"]
+        assert results.results[0].data == single_version[0]
 
 
 class TestDefinitionFunction:

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -253,16 +253,26 @@ class TestManifestCombinedWithNameThree:
     # entry, unreduced). Neither shape routes through
     # _is_bare_pointer_reference -- that is only for the sole-content
     # "$acme.files.:manifest()" case.
-    def test_manifest_alone_in_name_three_gives_every_matching_entry(self):
-        # "one.csv" has two versions in ALPHA_MANIFEST -- no pointer, so
-        # both come back, each resolving to its own manifest entry dict.
+    def test_manifest_alone_with_more_than_one_matching_version_raises(self):
+        # "one.csv" has two versions in ALPHA_MANIFEST -- resolving full
+        # manifest content always touches exactly one entity (settled
+        # 2026-08-07), so no pointer to pick between them is illegal now,
+        # not "every entry, unreduced" as it used to be.
         finder = _finder(
             '$alpha.files.:name("one.csv").:manifest()', ALPHA_HOME, ALPHA_MANIFEST
         )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_manifest_alone_with_exactly_one_matching_version_still_works(self):
+        # "zero.csv" has only one version -- no pointer needed, since
+        # there is nothing to pick between.
+        finder = _finder(
+            '$alpha.files.:name("zero.csv").:manifest()', ALPHA_HOME, ALPHA_MANIFEST
+        )
         results = finder.resolve()
-        assert results.uuids == ["u-one-1", "u-one-2"]
-        assert results.data_for_uuid("u-one-1") == ALPHA_MANIFEST[1]
-        assert results.data_for_uuid("u-one-2") == ALPHA_MANIFEST[2]
+        assert results.uuids == ["u-zero-1"]
+        assert results.results[0].data == ALPHA_MANIFEST[0]
 
     def test_manifest_beside_a_pointer_gives_the_one_matched_entry(self):
         finder = _finder(


### PR DESCRIPTION
## Summary
- Settles the entity-resolution question raised while reviewing #222: :manifest() with no pointer used to return every matching version's entry, unreduced, whenever name_one's own path narrowing (or :all()) matched more than one version, for both files and csvpaths. That is now illegal -- a pointer is required to pick one version first.
- The reasoning: making this legal or not depend on whether multiple matches happen to share one manifest.json array (cheap) versus live in separate files (expensive) leaks a storage detail into the languages user-facing semantics. Resolving full content should always mean exactly one entity, regardless of how any given entity type happens to persist its data today or in the future.
- Still legal, unchanged: no pointer when name_ones own narrowing already resolves to at most one version -- nothing to pick between, so no pointer is needed.
- This is the files/csvpaths half of the fix. The results half (run-level and instance-level) lands separately in #222, since results own :manifest() wiring is not on main yet, while files/csvpaths current behavior here already is.

## Test plan
- [x] tests/references/ (473 tests) passes
- [x] full suite passes at the existing known baseline (11 pre-existing SFTP/S3/Nos backend failures, unrelated)
- [x] updated the two existing tests that asserted the old many-entries behavior to instead assert raises, plus a new test each confirming the single-matching-version case still works unpointed