### PR TITLE
Mirror run_uuid into vestigial uuid on ResultsMetadata

### DIFF
--- a/csvpath/managers/results/results_metadata.py
+++ b/csvpath/managers/results/results_metadata.py
@@ -61,6 +61,9 @@ class ResultsMetadata(Metadata):
         if u and not isinstance(u, UUID):
             raise ValueError("Must be a UUID")
         self._run_uuid = u
+        # uuid is a vestigial duplicate of run_uuid at this (run) scope --
+        # keep it mirrored here so it is a no-op to remove later.
+        self._uuid = u
 
     @property
     def run_uuid_string(self) -> str:
@@ -69,6 +72,7 @@ class ResultsMetadata(Metadata):
     @run_uuid_string.setter
     def run_uuid_string(self, u: str) -> None:
         self._run_uuid = UUID(u)
+        self._uuid = self._run_uuid
 
     @property
     def named_paths_uuid(self) -> UUID:

--- a/tests/csvpaths/managers/test_csvpaths_managers_results_metadata.py
+++ b/tests/csvpaths/managers/test_csvpaths_managers_results_metadata.py
@@ -1,0 +1,37 @@
+import unittest
+from uuid import UUID, uuid4
+
+from csvpath.managers.results.results_metadata import ResultsMetadata
+
+
+class TestCsvPathsManagersResultsMetadata(unittest.TestCase):
+    def test_run_uuid_setter_mirrors_into_uuid(self) -> None:
+        m = ResultsMetadata(None)
+        u = uuid4()
+        m.run_uuid = u
+        assert m.run_uuid == u
+        assert m.uuid == u
+
+    def test_run_uuid_string_setter_mirrors_into_uuid_string(self) -> None:
+        m = ResultsMetadata(None)
+        s = str(uuid4())
+        m.run_uuid_string = s
+        assert m.run_uuid_string == s
+        assert m.uuid_string == s
+
+    def test_from_manifest_run_uuid_overrides_manifests_own_uuid(self) -> None:
+        # uuid is vestigial at run scope -- from_manifest reads the
+        # manifest's own "uuid" field first (base Metadata behavior),
+        # then run_uuid_string mirrors over it so the two never diverge.
+        m = ResultsMetadata(None)
+        run_uuid = str(uuid4())
+        manifest = {
+            "run_home": "some/run/home",
+            "uuid": str(uuid4()),
+            "run_uuid": run_uuid,
+            "named_paths_uuid": str(uuid4()),
+            "named_file_uuid": str(uuid4()),
+        }
+        m.from_manifest(manifest)
+        assert m.run_uuid_string == run_uuid
+        assert m.uuid_string == run_uuid


### PR DESCRIPTION
## Summary

- ResultsMetadata.uuid is inherited from the generic Metadata base class and never read back meaningfully anywhere in the framework -- run_uuid is the field actually consumed downstream (by managers, and by the references-v3 finder layer, which deliberately treats run-scope uuid as absent).
- Rather than leave the two free to diverge, run_uuid and run_uuid_string setters now also mirror the same value into uuid/uuid_string, so eventually deleting uuid is a no-op change instead of a migration, and there is less confusion meanwhile.

## Test plan

- [x] New low-level unit tests in tests/csvpaths/managers/test_csvpaths_managers_results_metadata.py covering both setters and the from_manifest round-trip
- [x] tests/csvpaths/managers/ + tests/references/ -- 690 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)