### PR TITLE
Round out remaining RESULTS field accessors (batch 3)

### DIFF
--- a/csvpath/references/functions/fields/actual_data_file_3.py
+++ b/csvpath/references/functions/fields/actual_data_file_3.py
@@ -1,0 +1,24 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class ActualDataFile3(Function3):
+    #
+    # kept as a pair with origin_data_file_3.py -- they only mean
+    # anything in contrast to each other, per manifest_field_functions_
+    # proposal.md's Part B.
+    #
+    NAME = "actual_data_file"
+    SUMMARY = (
+        "The real input file path this instance actually read -- may "
+        "not match the named-file path (e.g. source-mode-preceding or "
+        "by_line runs read a different instance's data.csv instead)."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULT: "actual_data_file",
+    }

--- a/csvpath/references/functions/fields/completed_3.py
+++ b/csvpath/references/functions/fields/completed_3.py
@@ -1,0 +1,26 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class Completed3(Function3):
+    #
+    # aggregate/individual pair, same shape as valid_3.py: run scope has
+    # no field literally called "completed" -- it has "all_completed",
+    # an aggregate across every statement in the run. Instance scope has
+    # "completed", this one statement's own completion state.
+    #
+    NAME = "completed"
+    SUMMARY = (
+        "Run scope: true if every csvpath statement in the run reports "
+        "completed. Instance scope: true if this one statement reports "
+        "completed."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULTS: "all_completed",
+        Reference3.RESULT: "completed",
+    }

--- a/csvpath/references/functions/fields/file_fingerprints_3.py
+++ b/csvpath/references/functions/fields/file_fingerprints_3.py
@@ -1,0 +1,24 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class FileFingerprints3(Function3):
+    #
+    # dict-shaped (per generated file), not a scalar -- structurally
+    # different from fingerprint_3.py, per manifest_field_functions_
+    # proposal.md's Part B.
+    #
+    NAME = "file_fingerprints"
+    SUMMARY = (
+        "The content-integrity hashes of the resolved instance's own "
+        "generated files (data.csv, meta.json, etc.), keyed by "
+        "filename."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULT: "file_fingerprints",
+    }

--- a/csvpath/references/functions/fields/files_complete_3.py
+++ b/csvpath/references/functions/fields/files_complete_3.py
@@ -1,0 +1,27 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class FilesComplete3(Function3):
+    #
+    # aggregate/individual pair, same shape as valid_3.py/completed_3.py.
+    # name deliberately avoids reusing either source key
+    # (all_expected_files/files_expected), since both are slightly
+    # misleading in isolation per manifest_field_functions_proposal.md's
+    # Part A.
+    #
+    NAME = "files_complete"
+    SUMMARY = (
+        "Run scope: true if every csvpath statement in the run has all "
+        "of its expected files present. Instance scope: true if this "
+        "one statement has all of its expected files present."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULTS: "all_expected_files",
+        Reference3.RESULT: "files_expected",
+    }

--- a/csvpath/references/functions/fields/home_3.py
+++ b/csvpath/references/functions/fields/home_3.py
@@ -9,20 +9,24 @@ class Home3(Function3):
     # concept across every datatype (file_home, named_paths_home,
     # run_home, instance_home) -- strong natural fit for one shared name,
     # per manifest_field_functions_proposal.md's Part A. RESULTS scopes
-    # (run_home/instance_home) are deferred with the rest of RESULTS.
+    # widened in now that the run-vs-instance dispatch (Reference3.RESULT)
+    # exists.
     #
     NAME = "home"
     SUMMARY = (
         "The path to the resolved entity's own root/working directory -- "
         "file_home for a named-file version, named_paths_home for a "
-        "named-paths group."
+        "named-paths group, run_home for a results run, instance_home "
+        "for a results instance."
     )
     ROLE = Function3.VALUE
-    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS)
+    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
     SOURCE = "manifest"
     KEY = {
         Reference3.FILES: "file_home",
         Reference3.CSVPATHS: "named_paths_home",
+        Reference3.RESULTS: "run_home",
+        Reference3.RESULT: "instance_home",
     }

--- a/csvpath/references/functions/fields/hostname_3.py
+++ b/csvpath/references/functions/fields/hostname_3.py
@@ -1,0 +1,15 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class Hostname3(Function3):
+    NAME = "hostname"
+    SUMMARY = "The hostname of the machine that executed the resolved run."
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULTS: "hostname",
+    }

--- a/csvpath/references/functions/fields/identity_3.py
+++ b/csvpath/references/functions/fields/identity_3.py
@@ -1,0 +1,24 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class Identity3(Function3):
+    #
+    # instance scope only -- a run has no single "identity" of its own,
+    # it is a collection of instances, each with its own. No
+    # Reference3.RESULTS entry, same pattern as uuid_3.py at run scope.
+    #
+    NAME = "identity"
+    SUMMARY = (
+        "The csvpath-statement identity of the resolved instance -- "
+        "explicit :id/:name metadata, or the stringified load-time "
+        "index for an unnamed statement."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULT: "instance_identity",
+    }

--- a/csvpath/references/functions/fields/manifest_path_3.py
+++ b/csvpath/references/functions/fields/manifest_path_3.py
@@ -1,0 +1,28 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class ManifestPath3(Function3):
+    #
+    # not applicable to FILES -- table 1 has no equivalent stored field.
+    # RESULTS instance scope IS present in the real manifest (result_
+    # registrar.py writes it), despite manifest_field_functions_
+    # proposal.md flagging it as an open gap when that doc was written
+    # -- confirmed against current code, not the doc, before including
+    # it.
+    #
+    NAME = "manifest_path"
+    SUMMARY = (
+        "The filesystem path to the resolved entity's own manifest.json, "
+        "as recorded inside that same manifest."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.CSVPATHS, Reference3.RESULTS)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.CSVPATHS: "manifest_path",
+        Reference3.RESULTS: "manifest_path",
+        Reference3.RESULT: "manifest_path",
+    }

--- a/csvpath/references/functions/fields/method_3.py
+++ b/csvpath/references/functions/fields/method_3.py
@@ -1,0 +1,15 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class Method3(Function3):
+    NAME = "method"
+    SUMMARY = "The run method used for the resolved run (e.g. collect, fast_forward)."
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULTS: "method",
+    }

--- a/csvpath/references/functions/fields/named_file_name_3.py
+++ b/csvpath/references/functions/fields/named_file_name_3.py
@@ -1,0 +1,20 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class NamedFileName3(Function3):
+    NAME = "named_file_name"
+    SUMMARY = (
+        "The name of the named-file this run/instance consumed as its "
+        "input -- same literal key at every RESULTS scope it applies "
+        "to."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULTS: "named_file_name",
+        Reference3.RESULT: "named_file_name",
+    }

--- a/csvpath/references/functions/fields/named_paths_name_3.py
+++ b/csvpath/references/functions/fields/named_paths_name_3.py
@@ -1,0 +1,27 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class NamedPathsName3(Function3):
+    #
+    # CSVPATHS self-reference (this group's own registered name, read
+    # off its own manifest) plus RESULTS run scope (which named-paths
+    # group the run belongs to). Not instance scope -- the Result
+    # Instance Manifest does not carry this field, confirmed against
+    # result_registrar.py's metadata_update().
+    #
+    NAME = "named_paths_name"
+    SUMMARY = (
+        "The name of the resolved named-paths group -- its own name for "
+        "CSVPATHS, or the run's named-paths group for RESULTS run "
+        "scope."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.CSVPATHS, Reference3.RESULTS)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.CSVPATHS: "named_paths_name",
+        Reference3.RESULTS: "named_paths_name",
+    }

--- a/csvpath/references/functions/fields/named_results_name_3.py
+++ b/csvpath/references/functions/fields/named_results_name_3.py
@@ -1,0 +1,19 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class NamedResultsName3(Function3):
+    NAME = "named_results_name"
+    SUMMARY = (
+        "The name this run/instance's results are filed under -- same "
+        "literal key at every RESULTS scope it applies to."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULTS: "named_results_name",
+        Reference3.RESULT: "named_results_name",
+    }

--- a/csvpath/references/functions/fields/origin_data_file_3.py
+++ b/csvpath/references/functions/fields/origin_data_file_3.py
@@ -1,0 +1,28 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class OriginDataFile3(Function3):
+    #
+    # kept as a pair with actual_data_file_3.py -- they only mean
+    # anything in contrast to each other, per manifest_field_functions_
+    # proposal.md's Part B. Deliberately NOT the same concept as
+    # origin_3.py's FILES/CSVPATHS "origin" (where registered content
+    # originally came from) -- this is about which physical file this
+    # instance would read if every instance used the named-file
+    # directly.
+    #
+    NAME = "origin_data_file"
+    SUMMARY = (
+        "The input file path this instance would read if all instances "
+        "used the named-file directly, regardless of what it actually "
+        "read -- see :actual_data_file() for that."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULT: "origin_data_file",
+    }

--- a/csvpath/references/functions/fields/preceding_instance_identity_3.py
+++ b/csvpath/references/functions/fields/preceding_instance_identity_3.py
@@ -1,0 +1,27 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class PrecedingInstanceIdentity3(Function3):
+    #
+    # only written into the manifest when source_mode_preceding is true
+    # (see result_registrar.py's metadata_update) -- absent otherwise,
+    # which _extract_field_value's tolerant missing-key handling already
+    # treats as None, not an error.
+    #
+    NAME = "preceding_instance_identity"
+    SUMMARY = (
+        "The identity of the preceding instance whose data.csv this "
+        "instance actually read, when source_mode_preceding is true -- "
+        "None otherwise. Carries issue #223: this value can be wrong "
+        "when statements are skipped/reordered, see that issue for "
+        "detail."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULT: "preceding_instance_identity",
+    }

--- a/csvpath/references/functions/fields/source_mode_preceding_3.py
+++ b/csvpath/references/functions/fields/source_mode_preceding_3.py
@@ -1,0 +1,18 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class SourceModePreceding3(Function3):
+    NAME = "source_mode_preceding"
+    SUMMARY = (
+        "True if this instance's actual data file is the preceding "
+        "instance's data.csv, rather than the named-file directly."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULT: "source_mode_preceding",
+    }

--- a/csvpath/references/functions/fields/status_3.py
+++ b/csvpath/references/functions/fields/status_3.py
@@ -1,0 +1,25 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class Status3(Function3):
+    #
+    # run scope only -- a lifecycle marker ("started"/"complete"), not
+    # to be confused with the FILES ledger's own "status" (a failure
+    # message, unexposed today) -- different concept, same literal key,
+    # per manifest_field_functions_proposal.md's Part B note on this
+    # function.
+    #
+    NAME = "status"
+    SUMMARY = (
+        "The lifecycle status of the resolved run -- 'started' or "
+        "'complete'."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULTS: "status",
+    }

--- a/csvpath/references/functions/fields/time_3.py
+++ b/csvpath/references/functions/fields/time_3.py
@@ -7,19 +7,23 @@ class Time3(Function3):
     # see uuid_3.py for the shared field-accessor design this follows.
     # "time" is the cleanest case in the manifest catalog -- the literal
     # key is identical across every manifest that has it, no per-
-    # datatype renaming needed.
+    # datatype renaming needed. RESULTS scopes widened in now that the
+    # run-vs-instance dispatch (Reference3.RESULT) exists.
     #
     NAME = "time"
     SUMMARY = (
-        "The moment the resolved named-file/named-paths version was "
-        "registered/loaded, read straight off its manifest entry."
+        "The moment the resolved entity's manifest entry was created -- "
+        "registration/load time for named-file/named-paths versions, "
+        "start time for a results run or instance."
     )
     ROLE = Function3.VALUE
-    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS)
+    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
     SOURCE = "manifest"
     KEY = {
         Reference3.FILES: "time",
         Reference3.CSVPATHS: "time",
+        Reference3.RESULTS: "time",
+        Reference3.RESULT: "time",
     }

--- a/csvpath/references/functions/fields/time_completed_3.py
+++ b/csvpath/references/functions/fields/time_completed_3.py
@@ -1,0 +1,26 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class TimeCompleted3(Function3):
+    #
+    # not applicable to FILES -- table 1 has no equivalent (a version
+    # registration has no separate "completed" moment). Same literal
+    # key at both scopes it does apply to. RESULTS instance scope is
+    # deliberately excluded -- the Result Instance Manifest has no
+    # "time_completed" field (confirmed against result_registrar.py).
+    #
+    NAME = "time_completed"
+    SUMMARY = (
+        "The moment the resolved named-paths load, or results run, "
+        "finished -- absent (None) while still in progress."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.CSVPATHS, Reference3.RESULTS)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.CSVPATHS: "time_completed",
+        Reference3.RESULTS: "time_completed",
+    }

--- a/csvpath/references/functions/fields/username_3.py
+++ b/csvpath/references/functions/fields/username_3.py
@@ -1,0 +1,15 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class Username3(Function3):
+    NAME = "username"
+    SUMMARY = "The username that executed the resolved run."
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KEY = {
+        Reference3.RESULTS: "username",
+    }

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -31,20 +31,39 @@ class ReferenceFunctionFactory:
         from .well_known_files.unmatched_3 import Unmatched3
         from .well_known_files.vars_3 import Vars3
 
+        from .fields.actual_data_file_3 import ActualDataFile3
+        from .fields.completed_3 import Completed3
         from .fields.destinations_3 import Destinations3
+        from .fields.file_fingerprints_3 import FileFingerprints3
+        from .fields.files_complete_3 import FilesComplete3
         from .fields.fingerprint_3 import Fingerprint3
         from .fields.home_3 import Home3
+        from .fields.hostname_3 import Hostname3
+        from .fields.identity_3 import Identity3
+        from .fields.manifest_path_3 import ManifestPath3
         from .fields.mark_3 import Mark3
+        from .fields.method_3 import Method3
+        from .fields.named_file_name_3 import NamedFileName3
         from .fields.named_paths_count_3 import NamedPathsCount3
         from .fields.named_paths_identities_3 import NamedPathsIdentities3
+        from .fields.named_paths_name_3 import NamedPathsName3
+        from .fields.named_results_name_3 import NamedResultsName3
         from .fields.on_arrival_3 import OnArrival3
         from .fields.origin_3 import Origin3
+        from .fields.origin_data_file_3 import OriginDataFile3
+        from .fields.preceding_instance_identity_3 import (
+            PrecedingInstanceIdentity3,
+        )
         from .fields.run_uuid_3 import RunUuid3
         from .fields.scripts_3 import Scripts3
         from .fields.serial_3 import Serial3
+        from .fields.source_mode_preceding_3 import SourceModePreceding3
         from .fields.sources_3 import Sources3
+        from .fields.status_3 import Status3
         from .fields.time_3 import Time3
+        from .fields.time_completed_3 import TimeCompleted3
         from .fields.transfers_3 import Transfers3
+        from .fields.username_3 import Username3
         from .fields.uuid_3 import Uuid3
         from .fields.valid_3 import Valid3
         from .fields.webhooks_3 import Webhooks3
@@ -86,6 +105,23 @@ class ReferenceFunctionFactory:
             RunUuid3.NAME: RunUuid3,
             Serial3.NAME: Serial3,
             Valid3.NAME: Valid3,
+            Completed3.NAME: Completed3,
+            FilesComplete3.NAME: FilesComplete3,
+            NamedFileName3.NAME: NamedFileName3,
+            NamedResultsName3.NAME: NamedResultsName3,
+            NamedPathsName3.NAME: NamedPathsName3,
+            Status3.NAME: Status3,
+            Method3.NAME: Method3,
+            Hostname3.NAME: Hostname3,
+            Username3.NAME: Username3,
+            TimeCompleted3.NAME: TimeCompleted3,
+            ManifestPath3.NAME: ManifestPath3,
+            Identity3.NAME: Identity3,
+            ActualDataFile3.NAME: ActualDataFile3,
+            OriginDataFile3.NAME: OriginDataFile3,
+            FileFingerprints3.NAME: FileFingerprints3,
+            SourceModePreceding3.NAME: SourceModePreceding3,
+            PrecedingInstanceIdentity3.NAME: PrecedingInstanceIdentity3,
         }
 
     @classmethod

--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -365,6 +365,23 @@ _METADATA_FIELD_FUNCTIONS = (
     "run_uuid",
     "serial",
     "valid",
+    "completed",
+    "files_complete",
+    "named_file_name",
+    "named_results_name",
+    "named_paths_name",
+    "status",
+    "method",
+    "hostname",
+    "username",
+    "time_completed",
+    "manifest_path",
+    "identity",
+    "actual_data_file",
+    "origin_data_file",
+    "file_fingerprints",
+    "source_mode_preceding",
+    "preceding_instance_identity",
 )
 
 

--- a/tests/references/functions/fields/test_actual_data_file_3.py
+++ b/tests/references/functions/fields/test_actual_data_file_3.py
@@ -1,0 +1,24 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.actual_data_file_3 import ActualDataFile3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = ActualDataFile3()
+    assert f.name == "actual_data_file"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {Reference3.RESULT: "actual_data_file"}
+
+
+def test_no_arg_is_valid():
+    ActualDataFile3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        ActualDataFile3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_completed_3.py
+++ b/tests/references/functions/fields/test_completed_3.py
@@ -1,0 +1,27 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.completed_3 import Completed3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Completed3()
+    assert f.name == "completed"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {
+        Reference3.RESULTS: "all_completed",
+        Reference3.RESULT: "completed",
+    }
+
+
+def test_no_arg_is_valid():
+    Completed3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Completed3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_file_fingerprints_3.py
+++ b/tests/references/functions/fields/test_file_fingerprints_3.py
@@ -1,0 +1,26 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.file_fingerprints_3 import (
+    FileFingerprints3,
+)
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = FileFingerprints3()
+    assert f.name == "file_fingerprints"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {Reference3.RESULT: "file_fingerprints"}
+
+
+def test_no_arg_is_valid():
+    FileFingerprints3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        FileFingerprints3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_files_complete_3.py
+++ b/tests/references/functions/fields/test_files_complete_3.py
@@ -1,0 +1,27 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.files_complete_3 import FilesComplete3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = FilesComplete3()
+    assert f.name == "files_complete"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {
+        Reference3.RESULTS: "all_expected_files",
+        Reference3.RESULT: "files_expected",
+    }
+
+
+def test_no_arg_is_valid():
+    FilesComplete3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        FilesComplete3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_home_3.py
+++ b/tests/references/functions/fields/test_home_3.py
@@ -10,11 +10,17 @@ def test_metadata():
     f = Home3()
     assert f.name == "home"
     assert f.ROLE == Function3.VALUE
-    assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS)
+    assert f.DATATYPES == (
+        Reference3.FILES,
+        Reference3.CSVPATHS,
+        Reference3.RESULTS,
+    )
     assert f.SOURCE == "manifest"
     assert f.KEY == {
         Reference3.FILES: "file_home",
         Reference3.CSVPATHS: "named_paths_home",
+        Reference3.RESULTS: "run_home",
+        Reference3.RESULT: "instance_home",
     }
 
 

--- a/tests/references/functions/fields/test_hostname_3.py
+++ b/tests/references/functions/fields/test_hostname_3.py
@@ -1,0 +1,24 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.hostname_3 import Hostname3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Hostname3()
+    assert f.name == "hostname"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {Reference3.RESULTS: "hostname"}
+
+
+def test_no_arg_is_valid():
+    Hostname3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Hostname3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_identity_3.py
+++ b/tests/references/functions/fields/test_identity_3.py
@@ -1,0 +1,24 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.identity_3 import Identity3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Identity3()
+    assert f.name == "identity"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {Reference3.RESULT: "instance_identity"}
+
+
+def test_no_arg_is_valid():
+    Identity3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Identity3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_manifest_path_3.py
+++ b/tests/references/functions/fields/test_manifest_path_3.py
@@ -1,0 +1,28 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.manifest_path_3 import ManifestPath3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = ManifestPath3()
+    assert f.name == "manifest_path"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.CSVPATHS, Reference3.RESULTS)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {
+        Reference3.CSVPATHS: "manifest_path",
+        Reference3.RESULTS: "manifest_path",
+        Reference3.RESULT: "manifest_path",
+    }
+
+
+def test_no_arg_is_valid():
+    ManifestPath3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        ManifestPath3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_method_3.py
+++ b/tests/references/functions/fields/test_method_3.py
@@ -1,0 +1,24 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.method_3 import Method3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Method3()
+    assert f.name == "method"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {Reference3.RESULTS: "method"}
+
+
+def test_no_arg_is_valid():
+    Method3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Method3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_named_file_name_3.py
+++ b/tests/references/functions/fields/test_named_file_name_3.py
@@ -1,0 +1,27 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.named_file_name_3 import NamedFileName3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = NamedFileName3()
+    assert f.name == "named_file_name"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {
+        Reference3.RESULTS: "named_file_name",
+        Reference3.RESULT: "named_file_name",
+    }
+
+
+def test_no_arg_is_valid():
+    NamedFileName3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        NamedFileName3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_named_paths_name_3.py
+++ b/tests/references/functions/fields/test_named_paths_name_3.py
@@ -1,0 +1,27 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.named_paths_name_3 import NamedPathsName3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = NamedPathsName3()
+    assert f.name == "named_paths_name"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.CSVPATHS, Reference3.RESULTS)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {
+        Reference3.CSVPATHS: "named_paths_name",
+        Reference3.RESULTS: "named_paths_name",
+    }
+
+
+def test_no_arg_is_valid():
+    NamedPathsName3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        NamedPathsName3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_named_results_name_3.py
+++ b/tests/references/functions/fields/test_named_results_name_3.py
@@ -1,0 +1,29 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.named_results_name_3 import (
+    NamedResultsName3,
+)
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = NamedResultsName3()
+    assert f.name == "named_results_name"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {
+        Reference3.RESULTS: "named_results_name",
+        Reference3.RESULT: "named_results_name",
+    }
+
+
+def test_no_arg_is_valid():
+    NamedResultsName3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        NamedResultsName3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_origin_data_file_3.py
+++ b/tests/references/functions/fields/test_origin_data_file_3.py
@@ -1,0 +1,24 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.origin_data_file_3 import OriginDataFile3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = OriginDataFile3()
+    assert f.name == "origin_data_file"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {Reference3.RESULT: "origin_data_file"}
+
+
+def test_no_arg_is_valid():
+    OriginDataFile3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        OriginDataFile3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_preceding_instance_identity_3.py
+++ b/tests/references/functions/fields/test_preceding_instance_identity_3.py
@@ -1,0 +1,26 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.preceding_instance_identity_3 import (
+    PrecedingInstanceIdentity3,
+)
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = PrecedingInstanceIdentity3()
+    assert f.name == "preceding_instance_identity"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {Reference3.RESULT: "preceding_instance_identity"}
+
+
+def test_no_arg_is_valid():
+    PrecedingInstanceIdentity3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        PrecedingInstanceIdentity3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_source_mode_preceding_3.py
+++ b/tests/references/functions/fields/test_source_mode_preceding_3.py
@@ -1,0 +1,26 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.source_mode_preceding_3 import (
+    SourceModePreceding3,
+)
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = SourceModePreceding3()
+    assert f.name == "source_mode_preceding"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {Reference3.RESULT: "source_mode_preceding"}
+
+
+def test_no_arg_is_valid():
+    SourceModePreceding3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        SourceModePreceding3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_status_3.py
+++ b/tests/references/functions/fields/test_status_3.py
@@ -1,0 +1,24 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.status_3 import Status3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Status3()
+    assert f.name == "status"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {Reference3.RESULTS: "status"}
+
+
+def test_no_arg_is_valid():
+    Status3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Status3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_time_3.py
+++ b/tests/references/functions/fields/test_time_3.py
@@ -10,9 +10,18 @@ def test_metadata():
     f = Time3()
     assert f.name == "time"
     assert f.ROLE == Function3.VALUE
-    assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS)
+    assert f.DATATYPES == (
+        Reference3.FILES,
+        Reference3.CSVPATHS,
+        Reference3.RESULTS,
+    )
     assert f.SOURCE == "manifest"
-    assert f.KEY == {Reference3.FILES: "time", Reference3.CSVPATHS: "time"}
+    assert f.KEY == {
+        Reference3.FILES: "time",
+        Reference3.CSVPATHS: "time",
+        Reference3.RESULTS: "time",
+        Reference3.RESULT: "time",
+    }
 
 
 def test_no_arg_is_valid():

--- a/tests/references/functions/fields/test_time_completed_3.py
+++ b/tests/references/functions/fields/test_time_completed_3.py
@@ -1,0 +1,27 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.time_completed_3 import TimeCompleted3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = TimeCompleted3()
+    assert f.name == "time_completed"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.CSVPATHS, Reference3.RESULTS)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {
+        Reference3.CSVPATHS: "time_completed",
+        Reference3.RESULTS: "time_completed",
+    }
+
+
+def test_no_arg_is_valid():
+    TimeCompleted3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        TimeCompleted3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_username_3.py
+++ b/tests/references/functions/fields/test_username_3.py
@@ -1,0 +1,24 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.username_3 import Username3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Username3()
+    assert f.name == "username"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KEY == {Reference3.RESULTS: "username"}
+
+
+def test_no_arg_is_valid():
+    Username3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Username3(arg="x").check_valid()

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 
 import pytest
 
@@ -468,6 +469,148 @@ class TestFieldAccessorFunctions:
             "$widgets.results.:first().company_names:valid()", str(tmp_path)
         ).resolve()
         assert instance_valid.results[0].data is True
+
+    def test_run_only_field_accessors(self, tmp_path):
+        # status/method/hostname/username/time_completed/manifest_path/
+        # named_paths_name -- run scope only, confirmed real keys in
+        # results_registrar.py.
+        base = tmp_path / "acme" / "widgets"
+        run_dir = base / "2026-01-01_00-00-00"
+        _write_json(
+            run_dir / "manifest.json",
+            {
+                "run_uuid": "run-uuid",
+                "status": "complete",
+                "method": "collect",
+                "hostname": "box1",
+                "username": "auser",
+                "time_completed": "2026-08-09T00:00:00",
+                "manifest_path": str(run_dir / "manifest.json"),
+                "named_paths_name": "widgets",
+            },
+        )
+        _write_archive_manifest(tmp_path, "widgets", [str(run_dir)])
+
+        def resolve(fn):
+            return _finder(
+                f"$widgets.results.:first():{fn}()", str(tmp_path)
+            ).resolve().results[0].data
+
+        assert resolve("status") == "complete"
+        assert resolve("method") == "collect"
+        assert resolve("hostname") == "box1"
+        assert resolve("username") == "auser"
+        assert resolve("time_completed") == "2026-08-09T00:00:00"
+        assert resolve("manifest_path") == str(run_dir / "manifest.json")
+        assert resolve("named_paths_name") == "widgets"
+
+    def test_completed_and_files_complete_scope_dependent_keys(self, tmp_path):
+        base = tmp_path / "acme" / "widgets"
+        run_dir = base / "2026-01-01_00-00-00"
+        _write_json(
+            run_dir / "manifest.json",
+            {
+                "run_uuid": "run-uuid",
+                "all_completed": True,
+                "all_expected_files": False,
+            },
+        )
+        _write_json(
+            run_dir / "company_names" / "manifest.json",
+            {"uuid": "inst-uuid", "completed": True, "files_expected": True},
+        )
+        _write_archive_manifest(tmp_path, "widgets", [str(run_dir)])
+
+        run_completed = _finder(
+            "$widgets.results.:first():completed()", str(tmp_path)
+        ).resolve()
+        assert run_completed.results[0].data is True
+
+        run_files_complete = _finder(
+            "$widgets.results.:first():files_complete()", str(tmp_path)
+        ).resolve()
+        assert run_files_complete.results[0].data is False
+
+        instance_completed = _finder(
+            "$widgets.results.:first().company_names:completed()", str(tmp_path)
+        ).resolve()
+        assert instance_completed.results[0].data is True
+
+        instance_files_complete = _finder(
+            "$widgets.results.:first().company_names:files_complete()",
+            str(tmp_path),
+        ).resolve()
+        assert instance_files_complete.results[0].data is True
+
+    def test_named_file_name_shared_key_both_scopes(self, tmp_path):
+        base = tmp_path / "acme" / "widgets"
+        run_dir = base / "2026-01-01_00-00-00"
+        _write_json(
+            run_dir / "manifest.json",
+            {"run_uuid": "run-uuid", "named_file_name": "orders.csv"},
+        )
+        _write_json(
+            run_dir / "company_names" / "manifest.json",
+            {"uuid": "inst-uuid", "named_file_name": "orders.csv"},
+        )
+        _write_archive_manifest(tmp_path, "widgets", [str(run_dir)])
+
+        run_name = _finder(
+            "$widgets.results.:first():named_file_name()", str(tmp_path)
+        ).resolve()
+        assert run_name.results[0].data == "orders.csv"
+
+        instance_name = _finder(
+            "$widgets.results.:first().company_names:named_file_name()",
+            str(tmp_path),
+        ).resolve()
+        assert instance_name.results[0].data == "orders.csv"
+
+    def test_instance_only_field_accessors(self, acme_archive):
+        run_dir = acme_archive + "/acme/customers/2025/2026-01-01_00-00-00"
+        _write_json(
+            Path(run_dir) / "company_names" / "manifest.json",
+            {
+                "uuid": "inst1-uuid",
+                "instance_identity": "company_names",
+                "actual_data_file": "/data/acme/actual.csv",
+                "origin_data_file": "/data/acme/origin.csv",
+                "file_fingerprints": {"data.csv": "abc123"},
+                "source_mode_preceding": True,
+                "preceding_instance_identity": "0",
+            },
+        )
+
+        def resolve(fn):
+            ref = f"$acme.results.customers/2025:first().company_names:{fn}()"
+            return _finder(ref, acme_archive).resolve().results[0].data
+
+        assert resolve("identity") == "company_names"
+        assert resolve("actual_data_file") == "/data/acme/actual.csv"
+        assert resolve("origin_data_file") == "/data/acme/origin.csv"
+        assert resolve("file_fingerprints") == {"data.csv": "abc123"}
+        assert resolve("source_mode_preceding") is True
+        assert resolve("preceding_instance_identity") == "0"
+
+    def test_manifest_path_reachable_at_instance_scope_too(self, tmp_path):
+        # confirmed present in the real Result Instance Manifest despite
+        # manifest_field_functions_proposal.md flagging it as a gap when
+        # that doc was written.
+        base = tmp_path / "acme" / "widgets"
+        run_dir = base / "2026-01-01_00-00-00"
+        instance_manifest_path = str(run_dir / "company_names" / "manifest.json")
+        _write_json(run_dir / "manifest.json", {"run_uuid": "run-uuid"})
+        _write_json(
+            run_dir / "company_names" / "manifest.json",
+            {"uuid": "inst-uuid", "manifest_path": instance_manifest_path},
+        )
+        _write_archive_manifest(tmp_path, "widgets", [str(run_dir)])
+
+        result = _finder(
+            "$widgets.results.:first().company_names:manifest_path()",
+            str(tmp_path),
+        ).resolve()
+        assert result.results[0].data == instance_manifest_path
 
 
 class TestWellKnownFileAccessors:


### PR DESCRIPTION
## Summary

Closes out manifest_field_functions_proposal.md Part A/B list for RESULTS run/instance scope, now that the Reference3.RESULT/RESULTS run-vs-instance dispatch (see PR 230) is proven:

- Aggregate/individual pairs (same shape as valid): completed, files_complete
- Shared literal key at both scopes: named_file_name, named_results_name
- Run scope only: status, method, hostname, username, named_paths_name (also applies to CSVPATHS self-reference)
- CSVPATHS + RESULTS run: time_completed, manifest_path
- RESULTS instance scope only: identity, actual_data_file, origin_data_file, file_fingerprints, source_mode_preceding, preceding_instance_identity (carries the caveat noted in issue 223, in its SUMMARY)
- Widened home() and time() to also cover RESULTS run/instance scope (run_home/instance_home, time/time)

Every new key mapping was verified directly against the real registrar write paths (results_registrar.py, result_registrar.py, paths_registrar.py) rather than trusted from the proposal doc alone -- manifest_path turned out to already be reachable at instance scope too, ahead of what the doc had flagged as an open gap when it was written.

Deliberately out of scope, per manifest_field_functions_proposal.md: template() (multi-datatype, needs definition.json tables 8/9 too) and reference() (FILES-only gap, no RESULTS equivalent field exists). Also out of scope: issue 227 (error_count never persisted at instance scope) and the deferred global-ledger routing item.

## Test plan

- [x] New unit tests for every new/widened function class (tests/references/functions/fields/)
- [x] New finder-level tests in test_results_reference_finder_3.py covering run-only, instance-only, shared-both-scopes, and aggregate/individual-pair shapes end to end
- [x] tests/references/ -- 664 passed (up from 608)
- [x] Full suite -- 2247 passed, 11 failed (known SFTP/S3/Nos baseline, unrelated, no new regressions)

Generated with Claude Code