### PR TITLE
Fix 227: persist error_count in Result Instance Manifest

### DIFF
--- a/csvpath/managers/results/result_registrar.py
+++ b/csvpath/managers/results/result_registrar.py
@@ -148,6 +148,7 @@ class ResultRegistrar(Registrar, Listener):
         m["number_of_files_generated"] = mdata.number_of_files_generated
         m["valid"] = mdata.valid if mdata.valid is not None else ""
         m["completed"] = mdata.completed
+        m["error_count"] = mdata.error_count
         m["source_mode_preceding"] = mdata.source_mode_preceding
         if mdata.source_mode_preceding:
             m["preceding_instance_identity"] = mdata.preceding_instance_identity

--- a/tests/csvpaths/managers/test_csvpaths_managers_results_manager.py
+++ b/tests/csvpaths/managers/test_csvpaths_managers_results_manager.py
@@ -118,6 +118,33 @@ class TestCsvPathsManagersResultsManager(unittest.TestCase):
         results = paths.results_manager.get_named_results("print_test")
         assert results
 
+    def test_result_instance_manifest_persists_error_count(self):
+        # issue #227: error_count is computed by ResultRegistrar.
+        # register_complete() but was never written into the Result
+        # Instance Manifest by metadata_update() -- confirms the fix.
+        paths = Builder().build()
+        paths.file_manager.add_named_files_from_dir(FILES_DIR)
+        paths.paths_manager.add_named_paths(
+            name="error_count_test",
+            paths=[
+                """
+                ~ validation-mode: no-raise, print
+                $[3][
+                    add( "test", none() )
+                ]"""
+            ],
+        )
+        paths.fast_forward_paths(pathsname="error_count_test", filename="food")
+        results = paths.results_manager.get_named_results("error_count_test")
+        assert results
+        result = results[0]
+        assert result.errors_count > 0
+
+        m = Nos(result.instance_dir).join("manifest.json")
+        with DataFileReader(m) as file:
+            js = json.load(file.source)
+        assert js["error_count"] == result.errors_count
+
     def test_results_template_captured(self):
         paths = Builder().build()
 


### PR DESCRIPTION
## Summary

Fixes issue 227. ResultRegistrar.register_complete() computes error_count on the metadata object (mdata.error_count = self.result.errors_count), but metadata_update(), the method that actually serializes the instance manifest.json, never referenced it -- the value was silently dropped rather than persisted.

Fix is the one line the issue itself suggested: m["error_count"] = mdata.error_count, alongside the other fields already written there.

## Test plan

- [x] New regression test in test_csvpaths_managers_results_manager.py: runs a csvpath that deliberately raises a validation error (validation-mode no-raise, add() with a bad argument), then reads the resulting instance manifest.json directly and asserts error_count matches Result.errors_count
- [x] Confirmed the test fails without the fix (reverted result_registrar.py locally, saw a KeyError) and passes with it
- [x] Full suite -- 2248 passed, 11 failed (known SFTP/S3/Nos baseline, unrelated, no new regressions)

Generated with Claude Code