### PR TITLE
Add global-ledger routing for star root_major (Rule 1a)

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -58,10 +58,22 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         reference = self.ref.parsed
         root_major = reference.root_major
         if isinstance(root_major, Star3):
+            if self._is_bare_pointer_reference(reference, "manifest"):
+                # Rule 1a (manifest_field_functions_proposal.md): "*" at
+                # root_major combined with a bare :manifest() is the one
+                # exception -- it resolves to the Named-Paths Loads
+                # Manifest, a single global ledger at the named-paths
+                # root tracking every load across every named-paths
+                # group (see paths_listener.py). :definition() has no
+                # equivalent global resource, so it stays unsupported
+                # here, same as any other function.
+                home = self.csvpaths.config.inputs_csvpaths_path
+                return self._query_well_known_file(home, "manifest.json")
             raise ReferenceException3(
                 "CsvpathsReferenceFinder3 does not yet support '*' as "
                 "root_major (querying every named-paths group) -- use a "
-                "literal group name."
+                "literal group name, or a bare ':manifest()' to read the "
+                "global loads ledger."
             )
 
         name_one = reference.name_one

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -49,9 +49,21 @@ class FilesReferenceFinder3(ReferenceFinder3):
         reference = self.ref.parsed
         root_major = reference.root_major
         if isinstance(root_major, Star3):
+            if self._is_bare_pointer_reference(reference, "manifest"):
+                # Rule 1a (manifest_field_functions_proposal.md): "*" at
+                # root_major combined with a bare :manifest() is the one
+                # exception -- it resolves to the Named-File Arrivals
+                # Manifest, a single global ledger at the named-files
+                # root tracking every arrival across every named-file
+                # (see files_listener.py). :definition() has no
+                # equivalent global resource, so it stays unsupported
+                # here, same as any other function.
+                home = self.csvpaths.config.inputs_files_path
+                return self._query_well_known_file(home, "manifest.json")
             raise ReferenceException3(
                 "FilesReferenceFinder3 does not yet support '*' as root_major "
-                "(querying every named-file) -- use a literal named-file name."
+                "(querying every named-file) -- use a literal named-file name, "
+                "or a bare ':manifest()' to read the global arrivals ledger."
             )
 
         name_one = reference.name_one

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -105,10 +105,20 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         reference = self.ref.parsed
         root_major = reference.root_major
         if isinstance(root_major, Star3):
+            if self._is_bare_pointer_reference(reference, "manifest"):
+                # Rule 1a (manifest_field_functions_proposal.md): "*" at
+                # root_major combined with a bare :manifest() is the one
+                # exception -- it resolves to the Archive Run Manifest,
+                # the single global ledger at the archive root already
+                # used internally by _discover_run_homes() to find every
+                # run across every named-results group.
+                archive = self.csvpaths.config.get(section="results", name="archive")
+                return self._query_well_known_file(archive, "manifest.json")
             raise ReferenceException3(
                 "ResultsReferenceFinder3 does not yet support '*' as "
                 "root_major (querying every named-results group) -- use a "
-                "literal group name."
+                "literal group name, or a bare ':manifest()' to read the "
+                "global archive ledger."
             )
 
         name_one = reference.name_one
@@ -195,6 +205,15 @@ class ResultsReferenceFinder3(ReferenceFinder3):
 
     def _extract_data(self, result: ReferenceResult3):
         reference = self.ref.parsed
+        if isinstance(reference.root_major, Star3):
+            # global-ledger case (Rule 1a) -- query()'s
+            # _query_well_known_file() branch already pointed result.path
+            # at the archive-root manifest.json itself, not a run
+            # directory, so read it directly rather than joining
+            # "manifest.json" onto it again (the ordinary, per-group
+            # has_manifest branch below does that join, but only
+            # because it deals with a run directory, not a file).
+            return self._read_well_known_json(result.path)
         name_one_calls = self._combined_name_one_calls(reference.name_one)
         has_manifest = any(
             seg.contains_function_named("manifest")

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -63,15 +63,27 @@ class _FakePathsManager:
         return _FakePathsDescriber(self._definition)
 
 
+class _FakeConfig:
+    def __init__(self, inputs_csvpaths_path: str | None = None):
+        self.inputs_csvpaths_path = inputs_csvpaths_path
+
+
 class _FakeCsvPaths:
-    def __init__(self, paths_manager):
+    def __init__(self, paths_manager, inputs_csvpaths_path: str | None = None):
         self.paths_manager = paths_manager
+        self.config = _FakeConfig(inputs_csvpaths_path)
 
 
 def _finder(
-    reference: str, manifest: list = ACME_MANIFEST, definition: dict | None = None
+    reference: str,
+    manifest: list = ACME_MANIFEST,
+    definition: dict | None = None,
+    inputs_csvpaths_path: str | None = None,
 ) -> CsvpathsReferenceFinder3:
-    csvpaths = _FakeCsvPaths(_FakePathsManager(manifest, definition=definition))
+    csvpaths = _FakeCsvPaths(
+        _FakePathsManager(manifest, definition=definition),
+        inputs_csvpaths_path=inputs_csvpaths_path,
+    )
     ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
     return CsvpathsReferenceFinder3(csvpaths=csvpaths, ref=ref)
 
@@ -212,6 +224,47 @@ class TestManifestFunction:
         results = _finder("$acme.csvpaths.:all():manifest()", single_version).resolve()
         assert results.uuids == ["v0-uuid"]
         assert results.results[0].data == single_version[0]
+
+
+class TestGlobalLoadsLedger:
+    # Rule 1a: "*" at root_major combined with a bare :manifest() is the
+    # one exception to root_major=="*" being unsupported -- it resolves
+    # to the Named-Paths Loads Manifest, a single global ledger at the
+    # named-paths root tracking every load across every named-paths
+    # group.
+    def test_query_returns_the_global_ledger_path_with_no_uuid(self):
+        results = _finder(
+            "$*.csvpaths.:manifest()",
+            inputs_csvpaths_path="inputs/named_paths",
+        ).query()
+        assert results.files == ["inputs/named_paths/manifest.json"]
+        assert results.results[0].uuid is None
+
+    def test_resolve_reads_the_global_ledgers_raw_bytes(self, tmp_path):
+        content = b'[{"named_paths_name": "acme"}, {"named_paths_name": "beta"}]'
+        root = tmp_path / "named_paths"
+        root.mkdir()
+        (root / "manifest.json").write_bytes(content)
+        finder = _finder(
+            "$*.csvpaths.:manifest()", inputs_csvpaths_path=str(root)
+        )
+        results = finder.resolve()
+        assert results.results[0].data == content
+
+    def test_star_with_definition_is_still_not_supported(self):
+        finder = _finder(
+            "$*.csvpaths.:definition()",
+            inputs_csvpaths_path="inputs/named_paths",
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_star_with_version_pointer_is_still_not_supported(self):
+        finder = _finder(
+            "$*.csvpaths.:last()", inputs_csvpaths_path="inputs/named_paths"
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
 
 
 class TestDefinitionFunction:

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -70,15 +70,28 @@ class _FakeFileManager:
         return _FakeFileDescriber(self._definition)
 
 
+class _FakeConfig:
+    def __init__(self, inputs_files_path: str | None = None):
+        self.inputs_files_path = inputs_files_path
+
+
 class _FakeCsvPaths:
-    def __init__(self, file_manager):
+    def __init__(self, file_manager, inputs_files_path: str | None = None):
         self.file_manager = file_manager
+        self.config = _FakeConfig(inputs_files_path)
 
 
 def _finder(
-    reference: str, home: str, manifest: list, definition: dict | None = None
+    reference: str,
+    home: str,
+    manifest: list,
+    definition: dict | None = None,
+    inputs_files_path: str | None = None,
 ) -> FilesReferenceFinder3:
-    csvpaths = _FakeCsvPaths(_FakeFileManager(home, manifest, definition))
+    csvpaths = _FakeCsvPaths(
+        _FakeFileManager(home, manifest, definition),
+        inputs_files_path=inputs_files_path,
+    )
     ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
     return FilesReferenceFinder3(csvpaths=csvpaths, ref=ref)
 
@@ -258,6 +271,59 @@ class TestManifestFunction:
         # "which file" pipeline, which does not recognize it as a
         # function-valued path segment.
         finder = _finder("$alpha.files.a/:manifest()", ALPHA_HOME, ALPHA_MANIFEST)
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+
+class TestGlobalArrivalsLedger:
+    # Rule 1a: "*" at root_major combined with a bare :manifest() is the
+    # one exception to root_major=="*" being unsupported -- it resolves
+    # to the Named-File Arrivals Manifest, a single global ledger at the
+    # named-files root tracking every arrival across every named-file.
+    def test_query_returns_the_global_ledger_path_with_no_uuid(self):
+        finder = _finder(
+            "$*.files.:manifest()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+        )
+        results = finder.query()
+        assert results.files == ["inputs/named_files/manifest.json"]
+        assert results.results[0].uuid is None
+
+    def test_resolve_reads_the_global_ledgers_raw_bytes(self, tmp_path):
+        content = b'[{"named_file_name": "alpha"}, {"named_file_name": "beta"}]'
+        root = tmp_path / "named_files"
+        root.mkdir()
+        (root / "manifest.json").write_bytes(content)
+        finder = _finder(
+            "$*.files.:manifest()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path=str(root),
+        )
+        results = finder.resolve()
+        assert results.results[0].data == content
+
+    def test_star_with_definition_is_still_not_supported(self):
+        # :definition() has no equivalent global resource anywhere in
+        # the codebase -- stays unsupported at "*" root_major.
+        finder = _finder(
+            "$*.files.:definition()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+        )
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_star_with_path_narrowing_is_still_not_supported(self):
+        finder = _finder(
+            "$*.files.*.:last()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+        )
         with pytest.raises(ReferenceException3):
             finder.query()
 

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -798,6 +798,33 @@ class TestWellKnownFileAccessors:
         assert results.results[0].data == {"which": "company_names"}
 
 
+class TestGlobalArchiveLedger:
+    # Rule 1a: "*" at root_major combined with a bare :manifest() is the
+    # one exception to root_major=="*" being unsupported -- it resolves
+    # to the Archive Run Manifest, the single global ledger at the
+    # archive root already used internally to discover runs.
+    def test_query_returns_the_global_ledger_path_with_no_uuid(self, acme_archive):
+        results = _finder("$*.results.:manifest()", acme_archive).query()
+        assert results.files == [f"{acme_archive}/manifest.json"]
+        assert results.results[0].uuid is None
+
+    def test_resolve_reads_the_global_ledger_as_parsed_json(self, acme_archive):
+        results = _finder("$*.results.:manifest()", acme_archive).resolve()
+        data = results.results[0].data
+        assert isinstance(data, list)
+        assert {e["named_paths_name"] for e in data} == {"acme"}
+
+    def test_star_with_a_pointer_is_still_not_supported(self, acme_archive):
+        finder = _finder("$*.results.:last()", acme_archive)
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+    def test_star_with_path_narrowing_is_still_not_supported(self, acme_archive):
+        finder = _finder("$*.results.customers/2025:last()", acme_archive)
+        with pytest.raises(ReferenceException3):
+            finder.query()
+
+
 class TestScopeLimits:
     def test_star_root_major_not_yet_supported(self, acme_archive):
         finder = _finder("$*.results.customers/2025:last()", acme_archive)


### PR DESCRIPTION
## Summary

Implements the deferred global-ledger routing item (called "A" in an earlier next-target options menu). Per manifest_field_functions_proposal.md Rule 1a, root_major == "*" combined with a bare :manifest() is the one legal exception to "*" being otherwise unsupported at root_major -- it resolves to that datatype own single global ledger:

- $*.files.:manifest() -- the Named-File Arrivals Manifest (a single array at the named-files root, written by files_listener.py, tracking every arrival across every named-file)
- $*.csvpaths.:manifest() -- the Named-Paths Loads Manifest (same shape, at the named-paths root, written by paths_listener.py)
- $*.results.:manifest() -- the Archive Run Manifest (the archive root manifest.json already read internally by the results finder own run discovery, now exposed directly)

Every other function or path combined with "*" root_major continues to raise exactly as before -- :definition() has no equivalent global resource anywhere in the codebase, so $*.files.:definition() stays unsupported, same as any real path/pointer.

Files and csvpaths needed only a query() change: their existing _extract_data() bare-manifest branch already reads result.path directly, regardless of which home directory query() pointed it at, so nothing else had to change there. Results needed one extra _extract_data() branch too, since its ordinary has_manifest branch joins "manifest.json" onto what it assumes is a run directory -- but for the global-ledger case, result.path is already the ledger file itself.

## Test plan

- [x] New finder-level tests for all three datatypes (query() path/uuid shape, resolve() content, :definition() still rejected, other paths/pointers still rejected)
- [x] Verified against real FileManager/PathsManager/ResultsManager objects via a live Builder-based registration + run, not just fakes -- confirmed all three paths exist on disk and resolve to real content
- [x] tests/references/ -- 676 passed (up from 664)
- [x] Full suite -- 2260 passed, 11 failed (known SFTP/S3/Nos baseline, unrelated, no new regressions)

Generated with Claude Code