### PR TITLE
Persist method (instance scope) and template (results run scope) in manifests

### DIFF
--- a/csvpath/csvpaths.py
+++ b/csvpath/csvpaths.py
@@ -867,6 +867,7 @@ Cache: {cache}
             file=file,
             run_uuid=run_uuid,
             method="collect_paths",
+            template=template,
             extra_data=extra_data,
         )
         #
@@ -1038,6 +1039,7 @@ Cache: {cache}
             filename=filename,
             run_uuid=run_uuid,
             method="fast_forward_paths",
+            template=template,
             extra_data=extra_data,
         )
         #
@@ -1157,6 +1159,7 @@ Cache: {cache}
             filename=filename,
             run_uuid=run_uuid,
             method="next_paths",
+            template=template,
             extra_data=extra_data,
         )
         #
@@ -1652,6 +1655,7 @@ Cache: {cache}
             filename=filename,
             run_uuid=run_uuid,
             method="next_paths",
+            template=template,
             extra_data=extra_data,
         )
         #

--- a/csvpath/managers/results/result_registrar.py
+++ b/csvpath/managers/results/result_registrar.py
@@ -149,6 +149,7 @@ class ResultRegistrar(Registrar, Listener):
         m["valid"] = mdata.valid if mdata.valid is not None else ""
         m["completed"] = mdata.completed
         m["error_count"] = mdata.error_count
+        m["method"] = mdata.method
         m["source_mode_preceding"] = mdata.source_mode_preceding
         if mdata.source_mode_preceding:
             m["preceding_instance_identity"] = mdata.preceding_instance_identity

--- a/csvpath/managers/results/results_manager.py
+++ b/csvpath/managers/results/results_manager.py
@@ -112,6 +112,7 @@ class ResultsManager:  # pylint: disable=C0115
         file: str = None,
         run_uuid: UUID,
         method: str,
+        template: str = None,
         extra_data: Optional[dict[str, str]] = None,
     ) -> ResultsMetadata:
         """@private"""
@@ -158,6 +159,7 @@ class ResultsManager:  # pylint: disable=C0115
         mdata.named_paths_uuid_string = np_uuid
         mdata.named_results_name = pathsname
         mdata.method = method
+        mdata.template = template or ""
         rr.register_start(mdata)
         return mdata
 

--- a/csvpath/managers/results/results_metadata.py
+++ b/csvpath/managers/results/results_metadata.py
@@ -28,6 +28,7 @@ class ResultsMetadata(Metadata):
         self.by_line: bool = False
         self._run_uuid: UUID = None
         self._method: str = None
+        self.template: str = None
 
     @property
     def extra_data(self) -> dict[str, str]:
@@ -131,3 +132,4 @@ class ResultsMetadata(Metadata):
         self.error_count = m.get("error_count")
         self.all_expected_files = m.get("all_expected_files")
         self.method = m.get("method")
+        self.template = m.get("template")

--- a/csvpath/managers/results/results_registrar.py
+++ b/csvpath/managers/results/results_registrar.py
@@ -118,6 +118,7 @@ class ResultsRegistrar(Registrar, Listener):
         m["username"] = mdata.username
         m["ip_address"] = mdata.ip_address
         m["method"] = mdata.method
+        m["template"] = mdata.template or ""
         mp = mdata.manifest_path
         m["manifest_path"] = mp
         with DataFileWriter(path=mp) as file:

--- a/tests/csvpaths/managers/test_csvpaths_managers_results_manager.py
+++ b/tests/csvpaths/managers/test_csvpaths_managers_results_manager.py
@@ -145,6 +145,49 @@ class TestCsvPathsManagersResultsManager(unittest.TestCase):
             js = json.load(file.source)
         assert js["error_count"] == result.errors_count
 
+    def test_result_instance_manifest_persists_method(self):
+        # method is set on ResultMetadata but was never written into the
+        # Result Instance Manifest by ResultRegistrar.metadata_update() --
+        # confirms the fix (same bug shape as error_count / issue #227).
+        paths = Builder().build()
+        paths.file_manager.add_named_files_from_dir(FILES_DIR)
+        paths.paths_manager.add_named_paths(
+            name="method_persist_test",
+            paths=[""" ~ validation-mode: no-raise, print~ $[3][ print( "test" ) ]"""],
+        )
+        paths.fast_forward_paths(pathsname="method_persist_test", filename="food")
+        results = paths.results_manager.get_named_results("method_persist_test")
+        assert results
+        result = results[0]
+
+        m = Nos(result.instance_dir).join("manifest.json")
+        with DataFileReader(m) as file:
+            js = json.load(file.source)
+        assert js["method"] == "fast_forward_paths"
+
+    def test_results_run_manifest_persists_template(self):
+        # template was never captured on ResultsMetadata at all, so the
+        # per-run manifest.json in the run_dir (Results Run Manifest,
+        # table 5) never had a "template" key, unlike the archive-root
+        # ledger manifest (table 7, see test_results_template_captured).
+        paths = Builder().build()
+        paths.file_manager.add_named_file(name="food", path=PATH)
+        paths.paths_manager.add_named_paths(
+            name="run_template_capture",
+            paths=[""" ~ validation-mode: no-raise, print~ $[0][ print( "test" ) ]"""],
+        )
+        paths.fast_forward_paths(
+            pathsname="run_template_capture", filename="food", template=":0/:run_dir"
+        )
+        results = paths.results_manager.get_named_results("run_template_capture")
+        assert results
+        result = results[0]
+
+        m = Nos(result.run_dir).join("manifest.json")
+        with DataFileReader(m) as file:
+            js = json.load(file.source)
+        assert js["template"] == ":0/:run_dir"
+
     def test_results_template_captured(self):
         paths = Builder().build()
 


### PR DESCRIPTION
## Summary

Two persistence gaps found while building the RESULTS field-accessor batch (PR 232), same bug shape as issue 227 (error_count):

- **method** was computed and available on ResultMetadata, but ResultRegistrar.metadata_update never wrote it into the Result Instance Manifest (table 6). Fixed with a one-line addition, mirroring the 227 fix.
- **template** was never captured on ResultsMetadata at all -- the per-run manifest.json inside the run_dir (Results Run Manifest, table 5) never had a template key, unlike the archive-root ledger manifest (table 7) which already records it via RunMetadata/RunRegistrar. Added a template attribute to ResultsMetadata, threaded it through ResultsManager.start_run, and updated the 4 csvpaths.py call sites, each of which already had template as a local variable in scope but never passed it through.

## Test plan

- [x] Added test_result_instance_manifest_persists_method and test_results_run_manifest_persists_template
- [x] Confirmed both fail without the fix (stashed the fix, saw KeyError, restored)
- [x] Full suite: 2262 passed, 11 known-baseline SFTP/S3/Nos failures unrelated to this change

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
