### PR TITLE
Persist manifest_path in the Named-File Manifest

### DIFF
--- a/csvpath/managers/files/file_registrar.py
+++ b/csvpath/managers/files/file_registrar.py
@@ -131,6 +131,7 @@ class FileRegistrar(Registrar, Listener):
         if mark is not None:
             mani["mark"] = mark
         mani["template"] = mdata.template or ""
+        mani["manifest_path"] = manifest_path
         jdata = self.get_manifest(manifest_path)
         jdata.append(mani)
         self.intermediary.put_json(manifest_path, jdata)

--- a/tests/csvpaths/managers/test_csvpaths_managers_files_manager.py
+++ b/tests/csvpaths/managers/test_csvpaths_managers_files_manager.py
@@ -128,6 +128,29 @@ class TestCsvPathsManagersFileManager(unittest.TestCase):
         assert paths.file_manager.remove_named_file(nf)
         assert not paths.file_manager.has_named_file(nf)
 
+    def test_named_file_manifest_persists_manifest_path(self) -> None:
+        # manifest_path was computed by FileRegistrar.metadata_update() to
+        # know where to write, but was never written into the manifest
+        # entry itself -- same self-referential field that ResultsRegistrar
+        # and ResultRegistrar already persist for their own manifests.
+        paths = Builder().build()
+        nf = "orders"
+        if paths.file_manager.has_named_file(nf):
+            paths.file_manager.remove_named_file(nf)
+        assert not paths.file_manager.has_named_file(nf)
+
+        paths.file_manager.add_named_file(name=nf, path=FILE)
+        assert paths.file_manager.has_named_file(nf)
+
+        home = paths.file_manager.named_file_home(nf)
+        mpath = Nos(home).join("manifest.json")
+        with DataFileReader(mpath) as file:
+            js = json.load(file.source)
+        assert js[-1]["manifest_path"] == mpath
+
+        assert paths.file_manager.remove_named_file(nf)
+        assert not paths.file_manager.has_named_file(nf)
+
     #
     # base case. add zap, find zap
     #


### PR DESCRIPTION
## Summary

Small hygiene fix found while checking the manifest_field_functions_proposal doc open-gaps list, same shape as 227/236: FileRegistrar.metadata_update computed manifest_path locally to know where to write the Named-File Manifest, but never wrote it as a field into the manifest entry itself.

ResultsRegistrar and ResultRegistrar already persist this same self-referential manifest_path field for their own manifests -- this brings the Named-File Manifest in line with that pattern.

## Test plan

- [x] Added test_named_file_manifest_persists_manifest_path
- [x] Confirmed it fails without the fix (stashed the fix, saw KeyError, restored)
- [x] Full suite: 2263 passed, same known 11-failure SFTP/S3/Nos baseline

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
