### PR TITLE
Flow down file_name/username/hostname; compute named_file_name/name_home for FILES

### DIFF
--- a/csvpath/managers/files/file_registrar.py
+++ b/csvpath/managers/files/file_registrar.py
@@ -132,6 +132,9 @@ class FileRegistrar(Registrar, Listener):
             mani["mark"] = mark
         mani["template"] = mdata.template or ""
         mani["manifest_path"] = manifest_path
+        mani["file_name"] = mdata.file_name
+        mani["username"] = mdata.username
+        mani["hostname"] = mdata.hostname
         jdata = self.get_manifest(manifest_path)
         jdata.append(mani)
         self.intermediary.put_json(manifest_path, jdata)

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -216,6 +216,18 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 function_cls = ReferenceFunctionFactory.get_registered_class(
                     field_call.name
                 )
+                if function_cls.SOURCE == "computed":
+                    # never stored -- comes straight from the already-
+                    # resolved reference, no manifest/definition read at
+                    # all. see function_3.py's SOURCE comment.
+                    return self._compute_field(field_call.name, reference)
+                if field_call.name == "named_file_name":
+                    # a real, stored field at RESULTS/RESULT scope, but at
+                    # FILES scope this is just the already-known resolved
+                    # name -- reading it back from the manifest would be
+                    # redundant, so it is computed here instead, same
+                    # reasoning as the "computed" SOURCE branch above.
+                    return reference.root_major
                 key_path = function_cls.KEY.get(reference.datatype)
                 if function_cls.SOURCE == "definition":
                     config = self.csvpaths.file_manager.describer.get_config(
@@ -232,6 +244,17 @@ class FilesReferenceFinder3(ReferenceFinder3):
             f"FilesReferenceFinder3 does not yet support resolve_kind={kind!r} "
             "-- only :manifest()/:definition() and registered field-accessor "
             "functions are wired up as metadata-file/field functions so far."
+        )
+
+    def _compute_field(self, name: str, reference: "Reference3") -> object:
+        """values for SOURCE == "computed" field-accessor functions --
+        never read from a manifest/definition, always derived from the
+        already-resolved reference. See function_3.py's SOURCE comment
+        and named_file_home_3.py."""
+        if name == "named_file_home":
+            return self.csvpaths.file_manager.named_file_home(reference.root_major)
+        raise ReferenceException3(
+            f"FilesReferenceFinder3 has no computed-field handling for :{name}()"
         )
 
     @staticmethod

--- a/csvpath/references/functions/fields/named_file_home_3.py
+++ b/csvpath/references/functions/fields/named_file_home_3.py
@@ -1,0 +1,24 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class NamedFileHome3(Function3):
+    #
+    # the named-file's own root directory (the container shared by every
+    # version ever registered under this name), distinct from :home()'s
+    # FILES meaning (file_home -- where this one specific version's bytes
+    # live). FileRegistrar never stores this in the Named-File Manifest
+    # (table 1) -- it would just duplicate what FilesReferenceFinder3
+    # already computes to even find that manifest in the first place
+    # (file_manager.named_file_home(name)) -- so it is computed directly
+    # rather than read. Settled 2026-08-09, see
+    # manifest_field_functions_proposal.md.
+    #
+    NAME = "named_file_home"
+    SUMMARY = "The named-file's own root directory, shared by every version registered under this name."
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.FILES,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "computed"
+    KEY = {}

--- a/csvpath/references/functions/fields/named_file_name_3.py
+++ b/csvpath/references/functions/fields/named_file_name_3.py
@@ -3,14 +3,26 @@ from ..function_3 import Function3
 
 
 class NamedFileName3(Function3):
+    #
+    # at RESULTS/RESULT scope this reads a genuinely stored field --
+    # which named-file a run/instance consumed, operational data that
+    # cannot be derived any other way. At FILES scope it means something
+    # different: the resolved entity's own name, which is already known
+    # the moment a reference is parsed (reference.root_major) -- storing
+    # it a second time in the Named-File Manifest would just be a
+    # duplicate of something the finder already has in hand, so
+    # FilesReferenceFinder3 computes it directly rather than reading it
+    # from any manifest. Settled 2026-08-09, see
+    # manifest_field_functions_proposal.md.
+    #
     NAME = "named_file_name"
     SUMMARY = (
-        "The name of the named-file this run/instance consumed as its "
-        "input -- same literal key at every RESULTS scope it applies "
-        "to."
+        "RESULTS/RESULT: the name of the named-file a run/instance "
+        "consumed as its input. FILES: the resolved named-file's own "
+        "name."
     )
     ROLE = Function3.VALUE
-    DATATYPES = (Reference3.RESULTS,)
+    DATATYPES = (Reference3.RESULTS, Reference3.FILES)
     ARG_TYPES = ()
     ARG_REQUIRED = False
     SOURCE = "manifest"

--- a/csvpath/references/functions/function_3.py
+++ b/csvpath/references/functions/function_3.py
@@ -47,7 +47,13 @@ class Function3:
     # that resource's dict for this specific field (e.g. {Reference3.FILES:
     # "on_arrival.named_paths_group"}). A finder uses these to resolve and
     # extract the field generically, without per-function special-casing --
-    # see ReferenceFinder3._extract_field_value().
+    # see ReferenceFinder3._extract_field_value(). A third SOURCE value,
+    # "computed", marks a field that is never stored at all -- its value
+    # comes straight from the already-resolved reference/finder state
+    # (e.g. named_file_home). KEY is left empty ({}) for these; the owning
+    # finder computes the value itself, by function NAME, instead of doing
+    # a manifest/definition lookup. See named_file_home_3.py and
+    # FilesReferenceFinder3._extract_data().
     #
     SOURCE: str = None
     KEY: dict = {}

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -43,6 +43,7 @@ class ReferenceFunctionFactory:
         from .fields.manifest_path_3 import ManifestPath3
         from .fields.mark_3 import Mark3
         from .fields.method_3 import Method3
+        from .fields.named_file_home_3 import NamedFileHome3
         from .fields.named_file_name_3 import NamedFileName3
         from .fields.named_paths_count_3 import NamedPathsCount3
         from .fields.named_paths_identities_3 import NamedPathsIdentities3
@@ -108,6 +109,7 @@ class ReferenceFunctionFactory:
             Completed3.NAME: Completed3,
             FilesComplete3.NAME: FilesComplete3,
             NamedFileName3.NAME: NamedFileName3,
+            NamedFileHome3.NAME: NamedFileHome3,
             NamedResultsName3.NAME: NamedResultsName3,
             NamedPathsName3.NAME: NamedPathsName3,
             Status3.NAME: Status3,

--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -368,6 +368,7 @@ _METADATA_FIELD_FUNCTIONS = (
     "completed",
     "files_complete",
     "named_file_name",
+    "named_file_home",
     "named_results_name",
     "named_paths_name",
     "status",

--- a/tests/csvpaths/managers/test_csvpaths_managers_files_manager.py
+++ b/tests/csvpaths/managers/test_csvpaths_managers_files_manager.py
@@ -151,6 +151,33 @@ class TestCsvPathsManagersFileManager(unittest.TestCase):
         assert paths.file_manager.remove_named_file(nf)
         assert not paths.file_manager.has_named_file(nf)
 
+    def test_named_file_manifest_persists_file_name_and_registrant(self) -> None:
+        # file_name, username, and hostname were already captured on
+        # FileMetadata before FileRegistrar.metadata_update() ran, and are
+        # already persisted in the global arrivals ledger (files_listener.py),
+        # but metadata_update() never wrote them into the named-file's own
+        # per-version manifest entry.
+        paths = Builder().build()
+        nf = "orders"
+        if paths.file_manager.has_named_file(nf):
+            paths.file_manager.remove_named_file(nf)
+        assert not paths.file_manager.has_named_file(nf)
+
+        paths.file_manager.add_named_file(name=nf, path=FILE)
+        assert paths.file_manager.has_named_file(nf)
+
+        home = paths.file_manager.named_file_home(nf)
+        mpath = Nos(home).join("manifest.json")
+        with DataFileReader(mpath) as file:
+            js = json.load(file.source)
+        entry = js[-1]
+        assert entry["file_name"] == os.path.basename(FILE)
+        assert entry["username"]
+        assert entry["hostname"]
+
+        assert paths.file_manager.remove_named_file(nf)
+        assert not paths.file_manager.has_named_file(nf)
+
     #
     # base case. add zap, find zap
     #

--- a/tests/references/functions/fields/test_named_file_home_3.py
+++ b/tests/references/functions/fields/test_named_file_home_3.py
@@ -1,0 +1,24 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.named_file_home_3 import NamedFileHome3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = NamedFileHome3()
+    assert f.name == "named_file_home"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.FILES,)
+    assert f.SOURCE == "computed"
+    assert f.KEY == {}
+
+
+def test_no_arg_is_valid():
+    NamedFileHome3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        NamedFileHome3(arg="x").check_valid()

--- a/tests/references/functions/fields/test_named_file_name_3.py
+++ b/tests/references/functions/fields/test_named_file_name_3.py
@@ -10,7 +10,7 @@ def test_metadata():
     f = NamedFileName3()
     assert f.name == "named_file_name"
     assert f.ROLE == Function3.VALUE
-    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.DATATYPES == (Reference3.RESULTS, Reference3.FILES)
     assert f.SOURCE == "manifest"
     assert f.KEY == {
         Reference3.RESULTS: "named_file_name",

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -508,6 +508,30 @@ class TestFieldAccessorFunctions:
         results = finder.resolve()
         assert results.results[0].data is None
 
+    def test_named_file_name_is_computed_not_read(self):
+        # never stored in the Named-File Manifest -- reference.root_major
+        # is already the answer, so both matched entries give the same
+        # value with no pointer needed (see manifest_field_functions_
+        # proposal.md, settled 2026-08-09).
+        finder = _finder(
+            '$rich.files.:name("orders.csv").:named_file_name()',
+            RICH_HOME,
+            RICH_MANIFEST,
+        )
+        results = finder.resolve()
+        assert [r.data for r in results.results] == ["rich", "rich"]
+
+    def test_named_file_home_is_computed_not_read(self):
+        # SOURCE == "computed" -- file_manager.named_file_home(), not any
+        # manifest key, same reasoning as named_file_name above.
+        finder = _finder(
+            '$rich.files.:name("orders.csv").:first():named_file_home()',
+            RICH_HOME,
+            RICH_MANIFEST,
+        )
+        results = finder.resolve()
+        assert results.results[0].data == RICH_HOME
+
     def test_query_does_not_require_a_pointer_when_a_field_function_is_present(self):
         # this is the same "self-completing, no pointer needed" gate
         # :manifest() already gets -- a bare field function satisfies it


### PR DESCRIPTION
## Summary

Follow-up to the "ledger vs Named-File Manifest" discussion: a few fields the global arrivals ledger (files_listener.py) captures never flowed down to the Named-File Manifest itself (FileRegistrar.metadata_update()). Checked each one individually rather than treating them as one gap:

- **file_name, username, hostname** -- genuinely missing per-version facts. Already set on FileMetadata at registration time, just never written into the manifest entry. Flowed down directly, same shape as the method/template/manifest_path fixes in 236/237.
- **named_file_name, name_home** -- not stored at all, by design. Both are already known the moment a reference resolves (the literal name, and the home directory the finder computes to even find the manifest in the first place), so storing them would be pure duplication. Computed at the function layer instead of read from any file:
  - named_file_name_3.py now also covers FILES; FilesReferenceFinder3 resolves it as reference.root_major.
  - New named_file_home_3.py, using a new SOURCE = "computed" value (documented in function_3.py) for fields with no manifest/definition backing at all; resolved via file_manager.named_file_home(root_major).
- **origin_path** -- checked, already correctly unified (table 1 "from" and table 2 "origin_path" are the same concept, already handled by origin_3.py). No fix needed.
- **manifest_path** -- correctly excluded, per earlier discussion: the ledger own path is a different fact than the child own.

## Test plan

- [x] New regression test for the file_name/username/hostname flow-down, confirmed it fails without the fix
- [x] New unit tests for named_file_home_3.py, extended named_file_name_3.py tests for the new FILES datatype
- [x] New finder-level tests confirming both computed fields resolve correctly with no manifest read
- [x] Live check against a real Builder()-registered file, not just fakes
- [x] Full suite: 2269 passed, same known 11-failure SFTP/S3/Nos baseline

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
