### PR TITLE
Add ordinal indexing into the global ledger manifests (Rule 1b)

### DIFF
--- a/csvpath/managers/files/file_manager.py
+++ b/csvpath/managers/files/file_manager.py
@@ -199,15 +199,30 @@ class FileManager:
                 return _["reference"]
         return None
 
-    def get_arrivals_ledger(self) -> list:
+    @property
+    def files_root_manifest_path(self) -> str:
+        """@private"""
+        r = self.csvpaths.config.get(section="inputs", name="files")
+        p = Nos(r).join("manifest.json")
+        nos = Nos(r)
+        if not nos.dir_exists():
+            nos.makedirs()
+        nos.path = p
+        if not nos.exists():
+            with DataFileWriter(path=p) as file:
+                file.write("[]")
+        return p
+
+    @property
+    def files_root_manifest(self) -> list:
         """the Named-File Arrivals Manifest -- a single global ledger
         tracking every named-file arrival across every name, distinct
-        from get_manifest()'s per-name manifest. used by
-        FilesReferenceFinder3 to resolve "*" root_major references
-        (bare :manifest(), optionally with a pointer to select one
-        entry by ordinal)."""
-        lst = FilesListener(self.csvpaths)
-        return lst.get_manifest(lst.manifest_path())
+        from get_manifest()'s per-name manifest. mirrors PathsManager's
+        paths_root_manifest. used by FilesReferenceFinder3 to resolve
+        "*" root_major references (bare :manifest(), optionally with a
+        pointer to select one entry by ordinal)."""
+        with DataFileReader(self.files_root_manifest_path) as reader:
+            return json.load(reader.source)
 
     def get_manifest(self, name: NamedFileName) -> json:
         if name is None:

--- a/csvpath/managers/files/file_manager.py
+++ b/csvpath/managers/files/file_manager.py
@@ -199,6 +199,16 @@ class FileManager:
                 return _["reference"]
         return None
 
+    def get_arrivals_ledger(self) -> list:
+        """the Named-File Arrivals Manifest -- a single global ledger
+        tracking every named-file arrival across every name, distinct
+        from get_manifest()'s per-name manifest. used by
+        FilesReferenceFinder3 to resolve "*" root_major references
+        (bare :manifest(), optionally with a pointer to select one
+        entry by ordinal)."""
+        lst = FilesListener(self.csvpaths)
+        return lst.get_manifest(lst.manifest_path())
+
     def get_manifest(self, name: NamedFileName) -> json:
         if name is None:
             raise ValueError("Paths name cannot be None")

--- a/csvpath/managers/results/results_manager.py
+++ b/csvpath/managers/results/results_manager.py
@@ -61,6 +61,15 @@ class ResultsManager:  # pylint: disable=C0115
         """@private"""
         self._csvpaths = cs
 
+    def get_archive_ledger(self) -> list:
+        """the Archive Run Manifest -- a single global ledger tracking
+        every run across every named-results group, at the archive
+        root. distinct from any per-group results manifest. used by
+        ResultsReferenceFinder3 to resolve "*" root_major references
+        (bare :manifest(), optionally with a pointer to select one
+        entry by ordinal)."""
+        return RunRegistrar(self.csvpaths).manifest
+
     def complete_run(self, *, run_dir, pathsname, results) -> None:
         """@private"""
         rr = ResultsRegistrar(

--- a/csvpath/managers/results/results_manager.py
+++ b/csvpath/managers/results/results_manager.py
@@ -1,4 +1,5 @@
 # pylint: disable=C0114
+import json
 import os
 import re
 from uuid import UUID
@@ -10,6 +11,7 @@ from csvpath.util.references.reference_parser import ReferenceParser
 from csvpath.util.references.results_reference_finder_2 import (
     ResultsReferenceFinder2 as ResultsReferenceFinder,
 )
+from csvpath.util.file_readers import DataFileReader
 from csvpath.util.file_writers import DataFileWriter
 from csvpath.util.nos import Nos
 
@@ -61,14 +63,31 @@ class ResultsManager:  # pylint: disable=C0115
         """@private"""
         self._csvpaths = cs
 
-    def get_archive_ledger(self) -> list:
+    @property
+    def results_root_manifest_path(self) -> str:
+        """@private"""
+        r = self.csvpaths.config.get(section="results", name="archive")
+        p = Nos(r).join("manifest.json")
+        nos = Nos(r)
+        if not nos.dir_exists():
+            nos.makedirs()
+        nos.path = p
+        if not nos.exists():
+            with DataFileWriter(path=p) as file:
+                file.write("[]")
+        return p
+
+    @property
+    def results_root_manifest(self) -> list:
         """the Archive Run Manifest -- a single global ledger tracking
         every run across every named-results group, at the archive
-        root. distinct from any per-group results manifest. used by
+        root. distinct from any per-group results manifest. mirrors
+        PathsManager's paths_root_manifest. used by
         ResultsReferenceFinder3 to resolve "*" root_major references
         (bare :manifest(), optionally with a pointer to select one
         entry by ordinal)."""
-        return RunRegistrar(self.csvpaths).manifest
+        with DataFileReader(self.results_root_manifest_path) as reader:
+            return json.load(reader.source)
 
     def complete_run(self, *, run_dir, pathsname, results) -> None:
         """@private"""

--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -1,3 +1,5 @@
+from csvpath.util.nos import Nos
+
 from .functions.function_3 import Function3
 from .functions.reference_function_factory_3 import ReferenceFunctionFactory
 from .reference_3 import FunctionCall3, Reference3, Star3
@@ -69,11 +71,27 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 # here, same as any other function.
                 home = self.csvpaths.config.inputs_csvpaths_path
                 return self._query_well_known_file(home, "manifest.json")
+            pointer_call = self._pointer_before_manifest(reference, "manifest")
+            if pointer_call is not None:
+                # Rule 1b -- a pointer riding before the bare :manifest()
+                # (e.g. "$*.csvpaths.:last():manifest()") selects one
+                # entry out of the global ledger by ordinal position,
+                # instead of dumping the whole thing.
+                home = self.csvpaths.config.inputs_csvpaths_path
+                path = Nos(home).join("manifest.json")
+                ledger = self.csvpaths.paths_manager.paths_root_manifest
+                selected = self._apply_pointer(pointer_call, ledger)
+                if selected is None:
+                    return ReferenceResults3(results=[])
+                return ReferenceResults3(
+                    results=[ReferenceResult3(path=path, uuid=selected["uuid"])]
+                )
             raise ReferenceException3(
                 "CsvpathsReferenceFinder3 does not yet support '*' as "
                 "root_major (querying every named-paths group) -- use a "
                 "literal group name, or a bare ':manifest()' to read the "
-                "global loads ledger."
+                "global loads ledger, optionally with a pointer "
+                "(:first()/:last()/:index(n)) to pick one entry by ordinal."
             )
 
         name_one = reference.name_one
@@ -176,6 +194,13 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 # path itself (set by query()'s _query_well_known_file()
                 # branch above).
                 return self._read_well_known_file(result.path)
+            if isinstance(reference.root_major, Star3) and result.uuid is not None:
+                # Rule 1b -- a pointer already reduced the global ledger
+                # to one entry in query(); re-derive it the same way the
+                # per-group branch below does, just against the ledger
+                # instead of a named-paths groups own manifest.
+                ledger = self.csvpaths.paths_manager.paths_root_manifest
+                return self._find_manifest_entry_by_uuid(ledger, result.uuid)
             name_one = reference.name_one
             has_manifest = any(
                 seg.contains_function_named("manifest")

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -1,4 +1,5 @@
 from csvpath.util.file_readers import DataFileReader
+from csvpath.util.nos import Nos
 
 from .functions.function_3 import Function3
 from .functions.reference_function_factory_3 import ReferenceFunctionFactory
@@ -60,10 +61,27 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 # here, same as any other function.
                 home = self.csvpaths.config.inputs_files_path
                 return self._query_well_known_file(home, "manifest.json")
+            pointer_call = self._pointer_before_manifest(reference, "manifest")
+            if pointer_call is not None:
+                # Rule 1b -- a pointer riding before the bare :manifest()
+                # (e.g. "$*.files.:last():manifest()") selects one entry
+                # out of the global ledger by ordinal position, instead
+                # of dumping the whole thing.
+                home = self.csvpaths.config.inputs_files_path
+                path = Nos(home).join("manifest.json")
+                ledger = self.csvpaths.file_manager.get_arrivals_ledger()
+                selected = self._apply_pointer(pointer_call, ledger)
+                if selected is None:
+                    return ReferenceResults3(results=[])
+                return ReferenceResults3(
+                    results=[ReferenceResult3(path=path, uuid=selected["uuid"])]
+                )
             raise ReferenceException3(
                 "FilesReferenceFinder3 does not yet support '*' as root_major "
                 "(querying every named-file) -- use a literal named-file name, "
-                "or a bare ':manifest()' to read the global arrivals ledger."
+                "or a bare ':manifest()' to read the global arrivals ledger, "
+                "optionally with a pointer (:first()/:last()/:index(n)) to "
+                "pick one entry by ordinal."
             )
 
         name_one = reference.name_one
@@ -197,6 +215,13 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 # path itself (set by query()'s _query_well_known_file()
                 # branch above).
                 return self._read_well_known_file(result.path)
+            if isinstance(reference.root_major, Star3) and result.uuid is not None:
+                # Rule 1b -- a pointer already reduced the global ledger
+                # to one entry in query(); re-derive it the same way the
+                # per-entity branch below does, just against the ledger
+                # instead of a named-file's own manifest.
+                ledger = self.csvpaths.file_manager.get_arrivals_ledger()
+                return self._find_manifest_entry_by_uuid(ledger, result.uuid)
             if reference.name_three is not None and any(
                 f.contains_function_named("manifest")
                 for f in reference.name_three.functions

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -69,7 +69,7 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 # of dumping the whole thing.
                 home = self.csvpaths.config.inputs_files_path
                 path = Nos(home).join("manifest.json")
-                ledger = self.csvpaths.file_manager.get_arrivals_ledger()
+                ledger = self.csvpaths.file_manager.files_root_manifest
                 selected = self._apply_pointer(pointer_call, ledger)
                 if selected is None:
                     return ReferenceResults3(results=[])
@@ -220,7 +220,7 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 # to one entry in query(); re-derive it the same way the
                 # per-entity branch below does, just against the ledger
                 # instead of a named-file's own manifest.
-                ledger = self.csvpaths.file_manager.get_arrivals_ledger()
+                ledger = self.csvpaths.file_manager.files_root_manifest
                 return self._find_manifest_entry_by_uuid(ledger, result.uuid)
             if reference.name_three is not None and any(
                 f.contains_function_named("manifest")

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -119,6 +119,42 @@ class ReferenceFinder3(ABC):
         )
 
     @staticmethod
+    def _pointer_before_manifest(
+        reference: Reference3, name: str
+    ) -> "FunctionCall3 | None":
+        """returns the pointer function call riding immediately before a
+        bare ":name()" call in name_one (e.g. "$*.files.:last():manifest()"
+        parses as name_one.path == [:last()], name_one.functions ==
+        [:manifest()]), or None if this reference is not shaped that
+        way. Ordinal indexing into a global ledger (Rule 1b,
+        manifest_field_functions_proposal.md) -- a pointer here selects
+        one entry out of the whole ledger array, same position-based
+        selection _apply_pointer() already does for a named entitys own
+        manifest, just applied to the ledger instead. Shared by files/
+        csvpaths/results since all three ledgers are flat arrays in
+        arrival order."""
+        name_one = reference.name_one
+        if reference.name_three is not None:
+            return None
+        if len(name_one.path) != 1 or len(name_one.functions) != 1:
+            return None
+        pointer_call = name_one.path[0]
+        manifest_call = name_one.functions[0]
+        if not isinstance(pointer_call, FunctionCall3) or pointer_call.name not in (
+            "first",
+            "last",
+            "index",
+        ):
+            return None
+        if (
+            not isinstance(manifest_call, FunctionCall3)
+            or manifest_call.name != name
+            or manifest_call.arg is not None
+        ):
+            return None
+        return pointer_call
+
+    @staticmethod
     def _query_well_known_file(home: str, filename: str) -> ReferenceResults3:
         """query() branch for a fixed, home-directory-scoped JSON
         resource (manifest.json, definition.json) -- one result,

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -114,11 +114,30 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 # run across every named-results group.
                 archive = self.csvpaths.config.get(section="results", name="archive")
                 return self._query_well_known_file(archive, "manifest.json")
+            pointer_call = self._pointer_before_manifest(reference, "manifest")
+            if pointer_call is not None:
+                # Rule 1b -- a pointer riding before the bare :manifest()
+                # (e.g. "$*.results.:last():manifest()") selects one
+                # entry out of the global ledger by ordinal position,
+                # instead of dumping the whole thing. the archive ledger
+                # has no "uuid" key of its own (only "run_uuid" -- see
+                # RunRegistrar.metadata_update()), so run_uuid is used as
+                # the locator instead of the usual uuid.
+                archive = self.csvpaths.config.get(section="results", name="archive")
+                path = Nos(archive).join("manifest.json")
+                ledger = self.csvpaths.results_manager.get_archive_ledger()
+                selected = self._apply_pointer(pointer_call, ledger)
+                if selected is None:
+                    return ReferenceResults3(results=[])
+                return ReferenceResults3(
+                    results=[ReferenceResult3(path=path, uuid=selected["run_uuid"])]
+                )
             raise ReferenceException3(
                 "ResultsReferenceFinder3 does not yet support '*' as "
                 "root_major (querying every named-results group) -- use a "
                 "literal group name, or a bare ':manifest()' to read the "
-                "global archive ledger."
+                "global archive ledger, optionally with a pointer "
+                "(:first()/:last()/:index(n)) to pick one entry by ordinal."
             )
 
         name_one = reference.name_one
@@ -206,6 +225,14 @@ class ResultsReferenceFinder3(ReferenceFinder3):
     def _extract_data(self, result: ReferenceResult3):
         reference = self.ref.parsed
         if isinstance(reference.root_major, Star3):
+            if result.uuid is not None:
+                # Rule 1b -- a pointer already reduced the global ledger
+                # to one entry in query(); re-derive it by run_uuid
+                # (the archive ledgers own locator -- see query()).
+                ledger = self.csvpaths.results_manager.get_archive_ledger()
+                return next(
+                    (e for e in ledger if e["run_uuid"] == result.uuid), None
+                )
             # global-ledger case (Rule 1a) -- query()'s
             # _query_well_known_file() branch already pointed result.path
             # at the archive-root manifest.json itself, not a run

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -125,7 +125,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 # the locator instead of the usual uuid.
                 archive = self.csvpaths.config.get(section="results", name="archive")
                 path = Nos(archive).join("manifest.json")
-                ledger = self.csvpaths.results_manager.get_archive_ledger()
+                ledger = self.csvpaths.results_manager.results_root_manifest
                 selected = self._apply_pointer(pointer_call, ledger)
                 if selected is None:
                     return ReferenceResults3(results=[])
@@ -229,7 +229,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 # Rule 1b -- a pointer already reduced the global ledger
                 # to one entry in query(); re-derive it by run_uuid
                 # (the archive ledgers own locator -- see query()).
-                ledger = self.csvpaths.results_manager.get_archive_ledger()
+                ledger = self.csvpaths.results_manager.results_root_manifest
                 return next(
                     (e for e in ledger if e["run_uuid"] == result.uuid), None
                 )

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -47,16 +47,23 @@ class _FakePathsDescriber:
 
 
 class _FakePathsManager:
-    def __init__(self, manifest, home=GROUP_HOME, definition: dict | None = None):
+    def __init__(
+        self, manifest, home=GROUP_HOME, definition: dict | None = None, ledger=None
+    ):
         self._manifest = manifest
         self._home = home
         self._definition = definition or {}
+        self._ledger = manifest if ledger is None else ledger
 
     def get_manifest_for_name(self, name):
         return self._manifest
 
     def named_paths_home(self, name):
         return self._home
+
+    @property
+    def paths_root_manifest(self):
+        return self._ledger
 
     @property
     def describer(self):
@@ -79,9 +86,10 @@ def _finder(
     manifest: list = ACME_MANIFEST,
     definition: dict | None = None,
     inputs_csvpaths_path: str | None = None,
+    ledger: list | None = None,
 ) -> CsvpathsReferenceFinder3:
     csvpaths = _FakeCsvPaths(
-        _FakePathsManager(manifest, definition=definition),
+        _FakePathsManager(manifest, definition=definition, ledger=ledger),
         inputs_csvpaths_path=inputs_csvpaths_path,
     )
     ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
@@ -265,6 +273,55 @@ class TestGlobalLoadsLedger:
         )
         with pytest.raises(ReferenceException3):
             finder.query()
+
+
+LOADS_LEDGER = [
+    {"named_paths_name": "acme", "uuid": "u-loads-1"},
+    {"named_paths_name": "beta", "uuid": "u-loads-2"},
+    {"named_paths_name": "gamma", "uuid": "u-loads-3"},
+]
+
+
+class TestGlobalLoadsLedgerOrdinalIndexing:
+    # Rule 1b: a pointer (:first()/:last()/:index(n)) riding before the
+    # bare :manifest() selects one entry out of the ledger by ordinal
+    # position, instead of dumping the whole thing.
+    def test_last_gives_the_most_recent_load(self):
+        finder = _finder(
+            "$*.csvpaths.:last():manifest()",
+            inputs_csvpaths_path="inputs/named_paths",
+            ledger=LOADS_LEDGER,
+        )
+        results = finder.resolve()
+        assert results.results[0].data == LOADS_LEDGER[-1]
+
+    def test_index_gives_the_nth_load(self):
+        finder = _finder(
+            "$*.csvpaths.:index(0):manifest()",
+            inputs_csvpaths_path="inputs/named_paths",
+            ledger=LOADS_LEDGER,
+        )
+        results = finder.resolve()
+        assert results.results[0].data == LOADS_LEDGER[0]
+
+    def test_out_of_range_index_gives_no_results(self):
+        finder = _finder(
+            "$*.csvpaths.:index(99):manifest()",
+            inputs_csvpaths_path="inputs/named_paths",
+            ledger=LOADS_LEDGER,
+        )
+        results = finder.query()
+        assert len(results.results) == 0
+
+    def test_query_gives_the_ledger_path_with_the_entrys_own_uuid(self):
+        finder = _finder(
+            "$*.csvpaths.:last():manifest()",
+            inputs_csvpaths_path="inputs/named_paths",
+            ledger=LOADS_LEDGER,
+        )
+        results = finder.query()
+        assert results.files == ["inputs/named_paths/manifest.json"]
+        assert results.results[0].uuid == "u-loads-3"
 
 
 class TestDefinitionFunction:

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -66,7 +66,8 @@ class _FakeFileManager:
     def get_manifest(self, name):
         return self._manifest
 
-    def get_arrivals_ledger(self):
+    @property
+    def files_root_manifest(self):
         return self._ledger
 
     @property

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -54,16 +54,20 @@ class _FakeFileDescriber:
 
 
 class _FakeFileManager:
-    def __init__(self, home, manifest, definition: dict | None = None):
+    def __init__(self, home, manifest, definition: dict | None = None, ledger=None):
         self._home = home
         self._manifest = manifest
         self._definition = definition or {}
+        self._ledger = manifest if ledger is None else ledger
 
     def named_file_home(self, name):
         return self._home
 
     def get_manifest(self, name):
         return self._manifest
+
+    def get_arrivals_ledger(self):
+        return self._ledger
 
     @property
     def describer(self):
@@ -87,9 +91,10 @@ def _finder(
     manifest: list,
     definition: dict | None = None,
     inputs_files_path: str | None = None,
+    ledger: list | None = None,
 ) -> FilesReferenceFinder3:
     csvpaths = _FakeCsvPaths(
-        _FakeFileManager(home, manifest, definition),
+        _FakeFileManager(home, manifest, definition, ledger=ledger),
         inputs_files_path=inputs_files_path,
     )
     ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
@@ -326,6 +331,85 @@ class TestGlobalArrivalsLedger:
         )
         with pytest.raises(ReferenceException3):
             finder.query()
+
+
+LEDGER = [
+    {"named_file_name": "alpha", "uuid": "u-ledger-1"},
+    {"named_file_name": "beta", "uuid": "u-ledger-2"},
+    {"named_file_name": "gamma", "uuid": "u-ledger-3"},
+]
+
+
+class TestGlobalArrivalsLedgerOrdinalIndexing:
+    # Rule 1b: a pointer (:first()/:last()/:index(n)) riding before the
+    # bare :manifest() selects one entry out of the ledger by ordinal
+    # position, instead of dumping the whole thing.
+    def test_last_gives_the_most_recent_arrival(self):
+        finder = _finder(
+            "$*.files.:last():manifest()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+            ledger=LEDGER,
+        )
+        results = finder.resolve()
+        assert results.results[0].data == LEDGER[-1]
+
+    def test_first_gives_the_earliest_arrival(self):
+        finder = _finder(
+            "$*.files.:first():manifest()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+            ledger=LEDGER,
+        )
+        results = finder.resolve()
+        assert results.results[0].data == LEDGER[0]
+
+    def test_index_gives_the_nth_arrival(self):
+        finder = _finder(
+            "$*.files.:index(1):manifest()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+            ledger=LEDGER,
+        )
+        results = finder.resolve()
+        assert results.results[0].data == LEDGER[1]
+
+    def test_negative_index_counts_from_the_end(self):
+        finder = _finder(
+            "$*.files.:index(-1):manifest()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+            ledger=LEDGER,
+        )
+        results = finder.resolve()
+        assert results.results[0].data == LEDGER[-1]
+
+    def test_out_of_range_index_gives_no_results(self):
+        finder = _finder(
+            "$*.files.:index(99):manifest()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+            ledger=LEDGER,
+        )
+        results = finder.query()
+        assert len(results.results) == 0
+
+    def test_query_gives_the_ledger_path_with_the_entrys_own_uuid(self):
+        finder = _finder(
+            "$*.files.:last():manifest()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+            ledger=LEDGER,
+        )
+        results = finder.query()
+        assert results.files == ["inputs/named_files/manifest.json"]
+        assert results.results[0].uuid == "u-ledger-3"
 
 
 class TestManifestCombinedWithNameThree:

--- a/tests/references/test_reference_finder_3.py
+++ b/tests/references/test_reference_finder_3.py
@@ -144,6 +144,95 @@ class TestIsBarePointerReference:
         assert not ReferenceFinder3._is_bare_pointer_reference(r, "manifest")
 
 
+class TestPointerBeforeManifest:
+    # shared by every finder that supports ordinal indexing into a
+    # global ledger (Rule 1b) -- files/csvpaths/results all read a flat
+    # array in arrival order, so a pointer riding before the bare
+    # :manifest() (e.g. ":last():manifest()", parsed as name_one.path
+    # == [:last()], name_one.functions == [:manifest()]) means the same
+    # thing everywhere.
+    @staticmethod
+    def _ref(name_one, name_three=None) -> Reference3:
+        return Reference3(
+            root_major="acme",
+            datatype=Reference3.FILES,
+            name_one=name_one,
+            name_three=name_three,
+        )
+
+    def test_true_for_pointer_then_bare_manifest(self):
+        r = self._ref(
+            NameOne3(
+                path=[FunctionCall3(name="last")],
+                functions=[FunctionCall3(name="manifest")],
+            )
+        )
+        pointer = ReferenceFinder3._pointer_before_manifest(r, "manifest")
+        assert pointer is not None
+        assert pointer.name == "last"
+
+    def test_index_pointer_keeps_its_arg(self):
+        r = self._ref(
+            NameOne3(
+                path=[FunctionCall3(name="index", arg=3)],
+                functions=[FunctionCall3(name="manifest")],
+            )
+        )
+        pointer = ReferenceFinder3._pointer_before_manifest(r, "manifest")
+        assert pointer.name == "index"
+        assert pointer.arg == 3
+
+    def test_none_when_no_trailing_function(self):
+        r = self._ref(NameOne3(path=[FunctionCall3(name="last")]))
+        assert ReferenceFinder3._pointer_before_manifest(r, "manifest") is None
+
+    def test_none_when_path_segment_is_not_a_pointer(self):
+        r = self._ref(
+            NameOne3(
+                path=[FunctionCall3(name="all")],
+                functions=[FunctionCall3(name="manifest")],
+            )
+        )
+        assert ReferenceFinder3._pointer_before_manifest(r, "manifest") is None
+
+    def test_none_when_trailing_function_is_not_the_named_one(self):
+        r = self._ref(
+            NameOne3(
+                path=[FunctionCall3(name="last")],
+                functions=[FunctionCall3(name="definition")],
+            )
+        )
+        assert ReferenceFinder3._pointer_before_manifest(r, "manifest") is None
+
+    def test_none_when_trailing_function_has_an_arg(self):
+        r = self._ref(
+            NameOne3(
+                path=[FunctionCall3(name="last")],
+                functions=[FunctionCall3(name="manifest", arg="x")],
+            )
+        )
+        assert ReferenceFinder3._pointer_before_manifest(r, "manifest") is None
+
+    def test_none_when_name_three_present(self):
+        r = self._ref(
+            NameOne3(
+                path=[FunctionCall3(name="last")],
+                functions=[FunctionCall3(name="manifest")],
+            ),
+            name_three=NameThree3(body="v1"),
+        )
+        assert ReferenceFinder3._pointer_before_manifest(r, "manifest") is None
+
+    def test_none_with_extra_path_segments(self):
+        r = self._ref(
+            NameOne3(
+                path=[FunctionCall3(name="last"), "extra"],
+                functions=[FunctionCall3(name="manifest")],
+            )
+        )
+        assert ReferenceFinder3._pointer_before_manifest(r, "manifest") is None
+
+
 class TestQueryWellKnownFile:
     # shared query() branch for a fixed, home-directory-scoped JSON
     # resource (manifest.json, definition.json) -- both files and

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -37,6 +37,10 @@ class _FakeResultsManager:
     def get_named_results_home(self, name):
         return os.path.join(self._archive, name)
 
+    def get_archive_ledger(self):
+        with open(os.path.join(self._archive, "manifest.json")) as f:
+            return json.load(f)
+
 
 class _FakeCsvPaths:
     def __init__(self, archive: str):
@@ -823,6 +827,48 @@ class TestGlobalArchiveLedger:
         finder = _finder("$*.results.customers/2025:last()", acme_archive)
         with pytest.raises(ReferenceException3):
             finder.query()
+
+
+class TestGlobalArchiveLedgerOrdinalIndexing:
+    # Rule 1b: a pointer (:first()/:last()/:index(n)) riding before the
+    # bare :manifest() selects one entry out of the ledger by ordinal
+    # position, instead of dumping the whole thing. The archive ledger
+    # has no "uuid" key of its own (only "run_uuid"), unlike the files/
+    # csvpaths ledgers -- a separate, minimal fixture is used here rather
+    # than the shared acme_archive fixture, which does not write
+    # "run_uuid" into its entries at all.
+    LEDGER = [
+        {"named_paths_name": "acme", "run_uuid": "run-1"},
+        {"named_paths_name": "acme", "run_uuid": "run-2"},
+        {"named_paths_name": "acme", "run_uuid": "run-3"},
+    ]
+
+    def _archive(self, tmp_path) -> str:
+        _write_json(tmp_path / "manifest.json", self.LEDGER)
+        return str(tmp_path)
+
+    def test_last_gives_the_most_recent_run(self, tmp_path):
+        archive = self._archive(tmp_path)
+        results = _finder("$*.results.:last():manifest()", archive).resolve()
+        assert results.results[0].data == self.LEDGER[-1]
+
+    def test_index_gives_the_nth_run(self, tmp_path):
+        archive = self._archive(tmp_path)
+        results = _finder("$*.results.:index(1):manifest()", archive).resolve()
+        assert results.results[0].data == self.LEDGER[1]
+
+    def test_out_of_range_index_gives_no_results(self, tmp_path):
+        archive = self._archive(tmp_path)
+        results = _finder("$*.results.:index(99):manifest()", archive).query()
+        assert len(results.results) == 0
+
+    def test_query_gives_the_ledger_path_with_the_entrys_own_run_uuid(
+        self, tmp_path
+    ):
+        archive = self._archive(tmp_path)
+        results = _finder("$*.results.:last():manifest()", archive).query()
+        assert results.files == [f"{archive}/manifest.json"]
+        assert results.results[0].uuid == "run-3"
 
 
 class TestScopeLimits:

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -37,7 +37,8 @@ class _FakeResultsManager:
     def get_named_results_home(self, name):
         return os.path.join(self._archive, name)
 
-    def get_archive_ledger(self):
+    @property
+    def results_root_manifest(self):
         with open(os.path.join(self._archive, "manifest.json")) as f:
             return json.load(f)
 


### PR DESCRIPTION
## Summary

Extends the global-ledger routing from #235 (Rule 1a: "*" root_major + bare :manifest() reads the whole ledger) with a pointer riding before it -- Rule 1b: "$*.files.:last():manifest()" selects one entry out of the ledger by ordinal position, instead of dumping the whole thing.

- Reuses the existing `ReferenceFinder3._apply_pointer()` helper unchanged (already does plain list-position lookups, negative indices included) -- this is purely a new place to call it.
- New shared helper `_pointer_before_manifest(reference, name)` on the ABC, mirroring `_is_bare_pointer_reference()`'s existing style, detecting the "$*.<type>.:last():manifest()" shape.
- Manager access, kept minimal per scope: `FileManager.get_arrivals_ledger()` and `ResultsManager.get_archive_ledger()` are new, thin wrappers around the existing FilesListener/RunRegistrar. CSVPATHS needed no manager change at all -- `PathsManager` already exposed `paths_root_manifest` for exactly this.
- The archive ledger (results, table 7) has no "uuid" key of its own, only "run_uuid" -- handled with a small, results-finder-specific lookup rather than forcing the shared `_find_manifest_entry_by_uuid` helper to special-case a different key name.

Scope kept tight per the working agreement: no changes outside references v3 classes plus the two small manager methods noted above.

## Test plan

- [x] New unit tests for the shared `_pointer_before_manifest()` helper
- [x] New finder-level tests for all three datatypes (files/csvpaths/results), covering :first()/:last()/:index(n)/negative index/out-of-range
- [x] Verified against real Builder()-registered data for all three datatypes, not just fakes
- [x] Full suite: 2291 passed, same known 11-failure SFTP/S3/Nos baseline

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
