### PR TITLE
Add root_major == "*" traversal for FILES (flatten + group semantics)

### DIFF
--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -3,7 +3,7 @@ from csvpath.util.nos import Nos
 
 from .functions.function_3 import Function3
 from .functions.reference_function_factory_3 import ReferenceFunctionFactory
-from .reference_3 import Reference3, Star3
+from .reference_3 import FunctionCall3, Reference3, Star3
 from .reference_exceptions_3 import ReferenceException3
 from .reference_finder_3 import ReferenceFinder3
 from .reference_results_3 import ReferenceResult3, ReferenceResults3
@@ -12,8 +12,17 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 class FilesReferenceFinder3(ReferenceFinder3):
     #
     # first pass, deliberately narrow:
-    #  - root_major is a literal named-file name. "*" (every named-file)
-    #    is a different traversal problem, not yet built.
+    #  - root_major is a literal named-file name, or "*" (every named-
+    #    file). "*" has two exceptions carved out before general
+    #    traversal (Rule 1a/1b, a bare/ordinal-indexed :manifest() reads
+    #    the global arrivals ledger, see _pointer_before_manifest); any
+    #    other use of "*" goes through _query_star_traversal(), which
+    #    implements the spec's flatten (bare '*'/path narrowing, pooled
+    #    and reduced by one pointer) vs. group (bare ':all()', one
+    #    result per named-file+path pair) semantics -- deliberately
+    #    narrow itself: combining '*' traversal with :manifest()/:path()/
+    #    a field-accessor function is not yet supported, see that
+    #    method's own docstring.
     #  - name_one is "*", a literal path segment, or :name("...") (for a
     #    literal name containing characters -- e.g. a real filename's
     #    "." -- that cannot appear in a bare PATH_SEGMENT). any other
@@ -76,13 +85,7 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 return ReferenceResults3(
                     results=[ReferenceResult3(path=path, uuid=selected["uuid"])]
                 )
-            raise ReferenceException3(
-                "FilesReferenceFinder3 does not yet support '*' as root_major "
-                "(querying every named-file) -- use a literal named-file name, "
-                "or a bare ':manifest()' to read the global arrivals ledger, "
-                "optionally with a pointer (:first()/:last()/:index(n)) to "
-                "pick one entry by ordinal."
-            )
+            return self._query_star_traversal(reference)
 
         name_one = reference.name_one
         if name_one.name_two is not None:
@@ -109,12 +112,7 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "name_three instead."
             )
         pattern = self._compile_path_pattern(name_one.path)
-
-        manifest = self.csvpaths.file_manager.get_manifest(root_major)
-        home = self.csvpaths.file_manager.named_file_home(root_major).rstrip("/")
-        candidates = [
-            entry for entry in manifest if self._matches(entry, home, pattern)
-        ]
+        candidates = self._candidates_for_name(root_major, pattern)
 
         name_three = reference.name_three
         if name_three is None:
@@ -180,6 +178,151 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 ReferenceResult3(path=c["file"], uuid=c["uuid"])
                 for c in selected_candidates
             ]
+        )
+
+    def _query_star_traversal(self, reference: Reference3) -> ReferenceResults3:
+        """root_major == "*" -- query across every named-file, not just
+        one. Two distinct semantics (per "Why a trailing bare '*' is
+        illegal but bare ':all()' is fine" in the spec compendium):
+
+        - bare '*'/literal path narrowing (FLATTEN): every named-file's
+          matching candidates pool into one combined list, sorted by
+          each entry's own "time" so a terminal pointer means true
+          chronological order across everything, not enumeration order.
+        - bare ':all()' as name_one's entire content (GROUP): every
+          matching candidate across every named-file is partitioned by
+          its own "file_home" (already unique per named-file+path, since
+          file_home embeds the named-file's name as a path prefix), and
+          the terminal pointer is applied independently within each
+          group -- one result per (named-file, path) pair, each that
+          pair's own last/first/nth version in its own array order (no
+          time-sort needed within one already-single-manifest group).
+
+        Deliberately narrow for now, matching only the spec's own worked
+        examples: combining '*' traversal with :manifest()/:path()/a
+        field-accessor function in name_three is not yet supported --
+        those all assume exactly one already-known manifest to re-read
+        in _extract_data(), which does not hold when a result could have
+        come from any of several named-files' manifests.
+        """
+        name_one = reference.name_one
+        if name_one.name_two is not None:
+            raise ReferenceException3(
+                "FilesReferenceFinder3 does not yet support the '#worksheet' "
+                "marker (name_two)."
+            )
+        is_grouped = self._is_bare_all_reference(name_one)
+        if is_grouped:
+            candidates = []
+            for name in self.csvpaths.file_manager.named_file_names:
+                candidates.extend(self._all_candidates_for_name(name))
+        else:
+            if name_one.functions:
+                raise ReferenceException3(
+                    "FilesReferenceFinder3 does not yet support functions "
+                    "attached directly to name_one for '*' traversal -- put "
+                    "the version-selecting function in name_three instead."
+                )
+            pattern = self._compile_path_pattern(name_one.path)
+            candidates = []
+            for name in self.csvpaths.file_manager.named_file_names:
+                candidates.extend(self._candidates_for_name(name, pattern))
+
+        name_three = reference.name_three
+        if name_three is None:
+            file_homes = []
+            for entry in candidates:
+                if entry["file_home"] not in file_homes:
+                    file_homes.append(entry["file_home"])
+            return ReferenceResults3(
+                results=[
+                    ReferenceResult3(path=file_home, uuid=None)
+                    for file_home in file_homes
+                ]
+            )
+
+        if name_three.body is not None:
+            raise ReferenceException3(
+                "FilesReferenceFinder3 does not yet support a literal name_three "
+                "body -- name_three must resolve to a pointer function "
+                "(:first()/:last()/:index(n))."
+            )
+        built = ReferenceFunctionFactory.build_chain(name_three.functions)
+        pointers = [f for f in built if f.ROLE == Function3.POINTER]
+        unsupported = (
+            any(f.name == "manifest" for f in built)
+            or self._find_field_function_call(built) is not None
+            or self._find_path_call(built) is not None
+        )
+        if unsupported:
+            raise ReferenceException3(
+                "FilesReferenceFinder3 does not yet support combining '*' "
+                "traversal with :manifest(), :path(), or a field-accessor "
+                "function -- only a plain pointer (:first()/:last()/"
+                ":index(n)) is supported so far."
+            )
+        if not pointers:
+            raise ReferenceException3(
+                "FilesReferenceFinder3 requires name_three to resolve to "
+                "exactly one pointer function (:first()/:last()/:index(n)) "
+                "when traversing every named-file with '*'."
+            )
+        pointer = pointers[0]
+
+        if is_grouped:
+            by_file_home = {}
+            for entry in candidates:
+                by_file_home.setdefault(entry["file_home"], []).append(entry)
+            selected_candidates = []
+            for file_home in sorted(by_file_home):
+                selected = self._apply_pointer(pointer, by_file_home[file_home])
+                if selected is not None:
+                    selected_candidates.append(selected)
+        else:
+            pooled = sorted(candidates, key=lambda e: e["time"])
+            selected = self._apply_pointer(pointer, pooled)
+            selected_candidates = [selected] if selected is not None else []
+
+        return ReferenceResults3(
+            results=[
+                ReferenceResult3(path=c["file"], uuid=c["uuid"])
+                for c in selected_candidates
+            ]
+        )
+
+    def _candidates_for_name(self, name: str, pattern: list) -> list:
+        """every manifest entry for one named-file whose file_home
+        matches `pattern` relative to that name's own home directory --
+        the per-name-file work shared by both the literal-root_major
+        path and '*' traversal's flatten mode."""
+        manifest = self.csvpaths.file_manager.get_manifest(name)
+        home = self.csvpaths.file_manager.named_file_home(name).rstrip("/")
+        return [entry for entry in manifest if self._matches(entry, home, pattern)]
+
+    def _all_candidates_for_name(self, name: str) -> list:
+        """every manifest entry for one named-file, at any path depth --
+        ':all()' matches unconditionally, unlike a pattern (which must
+        match an exact segment count), so this skips _matches entirely."""
+        manifest = self.csvpaths.file_manager.get_manifest(name)
+        home = self.csvpaths.file_manager.named_file_home(name).rstrip("/")
+        return [
+            entry
+            for entry in manifest
+            if entry["file_home"].rstrip("/").startswith(home)
+        ]
+
+    @staticmethod
+    def _is_bare_all_reference(name_one) -> bool:
+        """true when name_one's entire content is a single, argument-
+        less ':all()' call, with no trailing function chain -- name_three
+        (the per-group reduction function) is independent and may or may
+        not be present, unlike _is_bare_pointer_reference's shape."""
+        return (
+            not name_one.functions
+            and len(name_one.path) == 1
+            and isinstance(name_one.path[0], FunctionCall3)
+            and name_one.path[0].name == "all"
+            and name_one.path[0].arg is None
         )
 
     def _extract_data(self, result: ReferenceResult3):

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -54,17 +54,38 @@ class _FakeFileDescriber:
 
 
 class _FakeFileManager:
-    def __init__(self, home, manifest, definition: dict | None = None, ledger=None):
+    def __init__(
+        self,
+        home,
+        manifest,
+        definition: dict | None = None,
+        ledger=None,
+        by_name: dict | None = None,
+    ):
         self._home = home
         self._manifest = manifest
         self._definition = definition or {}
         self._ledger = manifest if ledger is None else ledger
+        # by_name: {name: (home, manifest)} -- only used by '*' traversal
+        # tests, which need more than one distinct named-file. Every
+        # other test uses the single (home, manifest) pair above.
+        self._by_name = by_name
 
     def named_file_home(self, name):
+        if self._by_name is not None:
+            return self._by_name[name][0]
         return self._home
 
     def get_manifest(self, name):
+        if self._by_name is not None:
+            return self._by_name[name][1]
         return self._manifest
+
+    @property
+    def named_file_names(self):
+        if self._by_name is not None:
+            return list(self._by_name.keys())
+        return []
 
     @property
     def files_root_manifest(self):
@@ -93,9 +114,10 @@ def _finder(
     definition: dict | None = None,
     inputs_files_path: str | None = None,
     ledger: list | None = None,
+    by_name: dict | None = None,
 ) -> FilesReferenceFinder3:
     csvpaths = _FakeCsvPaths(
-        _FakeFileManager(home, manifest, definition, ledger=ledger),
+        _FakeFileManager(home, manifest, definition, ledger=ledger, by_name=by_name),
         inputs_files_path=inputs_files_path,
     )
     ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
@@ -213,10 +235,12 @@ class TestNameThreeAbsent:
 
 
 class TestScopeLimits:
-    def test_star_root_major_not_yet_supported(self):
+    def test_star_root_major_with_no_named_files_gives_empty_results(self):
+        # '*' traversal is supported now (see TestStarTraversal below) --
+        # with zero named-files to enumerate (no by_name given here), it
+        # correctly finds nothing rather than raising.
         finder = _finder("$*.files.*.:last()", ALPHA_HOME, ALPHA_MANIFEST)
-        with pytest.raises(ReferenceException3):
-            finder.query()
+        assert finder.query().results == []
 
     def test_name_two_worksheet_marker_not_yet_supported(self):
         finder = _finder(
@@ -323,17 +347,6 @@ class TestGlobalArrivalsLedger:
         with pytest.raises(ReferenceException3):
             finder.query()
 
-    def test_star_with_path_narrowing_is_still_not_supported(self):
-        finder = _finder(
-            "$*.files.*.:last()",
-            ALPHA_HOME,
-            ALPHA_MANIFEST,
-            inputs_files_path="inputs/named_files",
-        )
-        with pytest.raises(ReferenceException3):
-            finder.query()
-
-
 LEDGER = [
     {"named_file_name": "alpha", "uuid": "u-ledger-1"},
     {"named_file_name": "beta", "uuid": "u-ledger-2"},
@@ -411,6 +424,128 @@ class TestGlobalArrivalsLedgerOrdinalIndexing:
         results = finder.query()
         assert results.files == ["inputs/named_files/manifest.json"]
         assert results.results[0].uuid == "u-ledger-3"
+
+
+#
+# matches the spec compendium's own EXAMPLE SCENARIO exactly ("Why a
+# trailing bare '*' is illegal but bare ':all()' is fine"): named-file
+# alpha (zero.csv x1 version, one.csv x2 versions), named-file beta
+# (two.csv x2 versions). beta is listed FIRST here on purpose -- naive
+# concatenation with no time-sort would put alpha's own entries last in
+# the pooled list, so a test asserting beta's true-latest entry wins
+# would fail if the flatten case's time-sort were ever removed/broken.
+#
+STAR_ALPHA_HOME = "inputs/named_files/alpha"
+STAR_ALPHA_MANIFEST = [
+    {
+        "file": "inputs/named_files/alpha/zero.csv/aaa.csv",
+        "file_home": "inputs/named_files/alpha/zero.csv",
+        "uuid": "u-zero-1",
+        "time": "2026-01-01T00:00:00+00:00",
+    },
+    {
+        "file": "inputs/named_files/alpha/one.csv/bbb.csv",
+        "file_home": "inputs/named_files/alpha/one.csv",
+        "uuid": "u-one-1",
+        "time": "2026-01-02T00:00:00+00:00",
+    },
+    {
+        "file": "inputs/named_files/alpha/one.csv/ccc.csv",
+        "file_home": "inputs/named_files/alpha/one.csv",
+        "uuid": "u-one-2",
+        "time": "2026-01-03T00:00:00+00:00",
+    },
+]
+STAR_BETA_HOME = "inputs/named_files/beta"
+STAR_BETA_MANIFEST = [
+    {
+        "file": "inputs/named_files/beta/two.csv/ddd.csv",
+        "file_home": "inputs/named_files/beta/two.csv",
+        "uuid": "u-two-1",
+        "time": "2026-01-04T00:00:00+00:00",
+    },
+    {
+        "file": "inputs/named_files/beta/two.csv/eee.csv",
+        "file_home": "inputs/named_files/beta/two.csv",
+        "uuid": "u-two-2",
+        "time": "2026-01-05T00:00:00+00:00",
+    },
+]
+STAR_BY_NAME = {
+    "beta": (STAR_BETA_HOME, STAR_BETA_MANIFEST),
+    "alpha": (STAR_ALPHA_HOME, STAR_ALPHA_MANIFEST),
+}
+
+
+def _star_finder(reference: str) -> FilesReferenceFinder3:
+    return _finder(reference, STAR_ALPHA_HOME, STAR_ALPHA_MANIFEST, by_name=STAR_BY_NAME)
+
+
+class TestStarTraversalFlatten:
+    # bare '*'/path narrowing pools every named-file's matches into one
+    # combined list, sorted by true chronological order (each entry's
+    # own "time"), reduced by one terminal pointer.
+    def test_last_across_every_named_file_is_the_true_most_recent(self):
+        # beta's two.csv v2 (2026-01-05) is the global most-recent, not
+        # alpha's own last entry (2026-01-03) -- proves pooling crosses
+        # named-files and is truly time-sorted, not just concatenated.
+        results = _star_finder("$*.files.*.:last()").query()
+        assert results.uuids == ["u-two-2"]
+
+    def test_first_across_every_named_file_is_the_true_earliest(self):
+        results = _star_finder("$*.files.*.:first()").query()
+        assert results.uuids == ["u-zero-1"]
+
+    def test_index_selects_by_chronological_position(self):
+        # chronological order: zero-1, one-1, one-2, two-1, two-2
+        results = _star_finder("$*.files.*.:index(2)").query()
+        assert results.uuids == ["u-one-2"]
+
+    # Note: a bare, trailing "*" with no name_three (e.g. "$*.files.*")
+    # is illegal grammar -- same rule that already rejects "$alpha.
+    # files.*" alone (Reference3.check_valid()). The "no name_three"
+    # dedupe path is exercised via ':all()' instead, see
+    # TestStarTraversalGroup below.
+
+    def test_combining_with_manifest_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _star_finder("$*.files.*.:last():manifest()").query()
+
+    def test_combining_with_a_field_accessor_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _star_finder("$*.files.*.:last():uuid()").query()
+
+    def test_functions_directly_on_name_one_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _star_finder("$*.files.*:last().v1").query()
+
+
+class TestStarTraversalGroup:
+    # bare ':all()' as name_one's entire content partitions every
+    # named-file's matches by file_home (already unique per named-file+
+    # path), applying the terminal pointer independently within each
+    # group -- one result per (named-file, path) pair.
+    def test_all_with_last_gives_one_result_per_named_file_and_path(self):
+        results = _star_finder("$*.files.:all().:last()").query()
+        assert len(results.results) == 3
+        assert set(results.uuids) == {"u-zero-1", "u-one-2", "u-two-2"}
+
+    def test_all_with_first_gives_each_groups_earliest_version(self):
+        results = _star_finder("$*.files.:all().:first()").query()
+        assert len(results.results) == 3
+        assert set(results.uuids) == {"u-zero-1", "u-one-1", "u-two-1"}
+
+    def test_all_with_no_name_three_dedupes_to_file_home_directories(self):
+        results = _star_finder("$*.files.:all()").query()
+        assert set(results.files) == {
+            "inputs/named_files/alpha/zero.csv",
+            "inputs/named_files/alpha/one.csv",
+            "inputs/named_files/beta/two.csv",
+        }
+
+    def test_all_combined_with_manifest_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _star_finder("$*.files.:all().:last():manifest()").query()
 
 
 class TestManifestCombinedWithNameThree:


### PR DESCRIPTION
## Summary

The wildcard is core references-v3 syntax, and this closes the biggest remaining gap in it: root_major == "*" traversal for FILES (querying across every named-file, not just one). Previously any use of "*" beyond the global-ledger special cases (#235/#239) raised "not yet supported."

Per the spec compendium's own worked example, "*" has two distinct semantics:

- **Flatten** (bare `*`, no `:all()` anywhere): every named-file's matches pool into one combined list, sorted by each entry's own registration time (true chronological order, not enumeration order), reduced by one terminal pointer. `$*.files.*.:last()` -> the single most-recently-registered version across every named-file, period.
- **Group** (`:all()` present as name_one's entire content): every matching candidate is partitioned by `file_home` (already unique per named-file+path), and the terminal pointer is applied independently within each group -- one result per (named-file, path) pair.

Reused existing building blocks rather than writing new ones: `_apply_pointer` (ordinal reduction, unchanged), `_compile_path_pattern`/`_matches` (per-name candidate gathering, now factored into a shared `_candidates_for_name` helper used by both the literal-root_major path and traversal), and `FileManager.named_file_names` (enumeration, already existed).

Deliberately narrow for now: combining `*` traversal with `:manifest()`/`:path()`/a field-accessor function in name_three is not yet supported -- those assume exactly one already-known manifest to re-read later in `_extract_data()`, which does not hold when a result could have come from any of several named-files' manifests. Raises clearly rather than silently guessing (this also protects against a real bug: `reference.root_major` being the `*` token itself, not a literal name, if those paths were reached without a guard).

**Scoped to FILES only.** CSVPATHS and RESULTS are explicit follow-ups once this pattern is proven -- their data shapes differ enough (CSVPATHS has no path dimension to group by; RESULTS has no flat manifest array) that generalizing now would be guessing, not reusing a validated design.

## Test plan

- [x] New tests reproduce the spec's own alpha/beta worked example exactly, asserting the literal result counts/values from the compendium, not just "does it run"
- [x] Test data deliberately orders named-files so a broken/missing time-sort would fail the test (not pass by enumeration-order coincidence)
- [x] Two previously-"not yet supported" tests updated to reflect the newly-supported behavior
- [x] New tests confirming the narrow exclusions (combining with `:manifest()`/field-accessors) still raise clearly
- [x] Live check against real `Builder()`-registered named-files, not just fakes
- [x] Full suite: 2300 passed, same known 11-failure SFTP/S3/Nos baseline

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
