### PR TITLE
Add root_major == "*" traversal for CSVPATHS and RESULTS

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -13,8 +13,14 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
     # first pass, deliberately narrow, mirroring FilesReferenceFinder3's
     # scoping approach -- but note the roles of name_one/name_three are
     # REVERSED from files here:
-    #  - root_major is a literal named-paths group name. "*" (every
-    #    group) is a different traversal problem, not yet built.
+    #  - root_major is a literal named-paths group name, or "*" (every
+    #    group). "*" has two exceptions carved out before general
+    #    traversal (Rule 1a/1b, a bare/ordinal-indexed :manifest() reads
+    #    the global loads ledger); any other use of "*" goes through
+    #    _query_star_traversal(), which generalizes name_one's own
+    #    version-selecting chain across every group -- see that
+    #    method's docstring for the flatten-vs-group distinction and
+    #    its own narrower scope.
     #  - name_one IS the version selector for csvpaths (STRUCTURE table:
     #    "name_one is always one or more versions of a named-paths
     #    group's group.csvpaths file"). Its combined function chain
@@ -86,13 +92,7 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 return ReferenceResults3(
                     results=[ReferenceResult3(path=path, uuid=selected["uuid"])]
                 )
-            raise ReferenceException3(
-                "CsvpathsReferenceFinder3 does not yet support '*' as "
-                "root_major (querying every named-paths group) -- use a "
-                "literal group name, or a bare ':manifest()' to read the "
-                "global loads ledger, optionally with a pointer "
-                "(:first()/:last()/:index(n)) to pick one entry by ordinal."
-            )
+            return self._query_star_traversal(reference)
 
         name_one = reference.name_one
         if name_one.name_two is not None:
@@ -168,6 +168,113 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 )
             )
         return ReferenceResults3(results=results)
+
+    def _query_star_traversal(self, reference: Reference3) -> ReferenceResults3:
+        """root_major == "*" -- query across every named-paths group,
+        not just one. Unlike FILES, csvpaths' version-selecting pointer
+        and ':all()' both already live in name_one's own combined chain
+        (see _resolve_versions) -- there is no separate name_three
+        pointer slot to borrow the way FILES uses. Two semantics, each
+        generalizing this datatype's own existing single-group
+        precedent rather than copying FILES' shape verbatim:
+
+        - bare pointer, no ':all()' (FLATTEN): every named-paths
+          group's whole manifest pools into one combined list, sorted
+          by each entry's own "time" so the pointer means true
+          chronological order across everything, not enumeration order
+          (csvpaths has no path dimension the way files does, so there
+          is nothing to pattern-match -- every entry in every group's
+          manifest is a candidate).
+        - ':all()' present in the combined chain (GROUP): the pointer
+          is applied independently within each group's own manifest
+          (plain array order -- no time-sort needed within one group)
+          -- one result per group. With ':all()' and no pointer, this
+          extends csvpaths' own existing single-group precedent
+          (_resolve_versions: no pointer means every version,
+          unreduced) across every group instead of deduping to
+          anything -- there is no path dimension to dedupe to, unlike
+          FILES.
+
+        Deliberately narrow, matching FILES' own scoping: combining '*'
+        traversal with :manifest()/a field-accessor function, or
+        name_three, is not yet supported -- raises clearly rather than
+        guessing (this also avoids a real bug: those code paths call
+        get_manifest_for_name(reference.root_major), which would break
+        if root_major were the '*' token instead of a literal name).
+        """
+        name_one = reference.name_one
+        if name_one.name_two is not None:
+            raise ReferenceException3(
+                "CsvpathsReferenceFinder3 does not support the '#worksheet' "
+                "marker (name_two) -- it is files-only."
+            )
+        if reference.name_three is not None:
+            raise ReferenceException3(
+                "CsvpathsReferenceFinder3 does not yet support name_three "
+                "(a statement identity lookup) combined with '*' traversal."
+            )
+        if len(name_one.path) != 1 or not isinstance(name_one.path[0], FunctionCall3):
+            raise ReferenceException3(
+                "CsvpathsReferenceFinder3 requires name_one to be a version-"
+                "selecting function chain (e.g. :last(), :all()) when "
+                "traversing every named-paths group with '*'."
+            )
+        # a plain pointer + :manifest() (e.g. ":last():manifest()") never
+        # reaches this method at all -- query()'s own _pointer_before_
+        # manifest() check above already claims that exact shape as
+        # Rule 1b (the global-ledger ordinal case). Only a manifest
+        # combined with ':all()' (not a pointer-first shape) or a
+        # 3+-function chain reaches the guard below.
+        calls = [name_one.path[0], *name_one.functions]
+        built = ReferenceFunctionFactory.build_chain(calls)
+        is_grouped = any(f.name == "all" for f in built)
+        pointers = [f for f in built if f.ROLE == Function3.POINTER]
+        unsupported = (
+            any(f.name == "manifest" for f in built)
+            or self._find_field_function_call(calls) is not None
+        )
+        if unsupported:
+            raise ReferenceException3(
+                "CsvpathsReferenceFinder3 does not yet support combining "
+                "'*' traversal with :manifest() or a field-accessor "
+                "function -- only a plain pointer (:first()/:last()/"
+                ":index(n)), optionally combined with :all() for one "
+                "result per group, is supported so far."
+            )
+
+        if is_grouped:
+            selected_versions = []
+            for name in self.csvpaths.paths_manager.named_paths_names:
+                manifest = self.csvpaths.paths_manager.get_manifest_for_name(name)
+                if pointers:
+                    selected = self._apply_pointer(pointers[0], manifest)
+                    if selected is not None:
+                        selected_versions.append(selected)
+                else:
+                    selected_versions.extend(manifest)
+        else:
+            if not pointers:
+                raise ReferenceException3(
+                    "CsvpathsReferenceFinder3 requires a pointer (:first()/"
+                    ":last()/:index(n)) when traversing every named-paths "
+                    "group with '*' -- use :all() for one result per "
+                    "group instead."
+                )
+            pooled = []
+            for name in self.csvpaths.paths_manager.named_paths_names:
+                pooled.extend(
+                    self.csvpaths.paths_manager.get_manifest_for_name(name)
+                )
+            pooled.sort(key=lambda e: e["time"])
+            selected = self._apply_pointer(pointers[0], pooled)
+            selected_versions = [selected] if selected is not None else []
+
+        return ReferenceResults3(
+            results=[
+                ReferenceResult3(path=c["group_file_path"], uuid=c["uuid"])
+                for c in selected_versions
+            ]
+        )
 
     def _extract_data(self, result: ReferenceResult3):
         reference = self.ref.parsed

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -18,6 +18,7 @@ class ReferenceFunctionFactory:
     def _load(cls) -> None:
         from .selectors.all_3 import All3
         from .selectors.first_3 import First3
+        from .selectors.flatten_3 import Flatten3
         from .selectors.index_3 import Index3
         from .selectors.last_3 import Last3
         from .selectors.name_3 import Name3
@@ -79,6 +80,7 @@ class ReferenceFunctionFactory:
             Index3.NAME: Index3,
             Name3.NAME: Name3,
             All3.NAME: All3,
+            Flatten3.NAME: Flatten3,
             Manifest3.NAME: Manifest3,
             Definition3.NAME: Definition3,
             Errors3.NAME: Errors3,

--- a/csvpath/references/functions/selectors/flatten_3.py
+++ b/csvpath/references/functions/selectors/flatten_3.py
@@ -1,0 +1,31 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class Flatten3(Function3):
+    #
+    # RESULTS-only. Settled 2026-08-10, alongside redefining a bare
+    # pointer to mean zero-level-only (see ResultsReferenceFinder3's
+    # module docstring and _query_star_traversal). Once bare stopped
+    # meaning "any depth, pooled," that capability needed a new,
+    # explicit name -- :flatten() is it. Unlike "*"/:all() (which are
+    # depth PEERS, both requiring exactly one level), :flatten() pools
+    # every run matching its own position (bare, or after a literal
+    # prefix) at ANY remaining depth into one combined list, the same
+    # way a bare pointer used to. A deferred peer, :groups(), would do
+    # the same any-depth matching but partition instead of pool --
+    # ResultsReferenceFinder3 keeps candidate-gathering and pool-vs-
+    # reduce as separate steps specifically so that peer is a small
+    # addition later, not a rework, when/if it is needed.
+    #
+    NAME = "flatten"
+    SUMMARY = (
+        "Pools every run matching this position at any remaining depth "
+        "into one combined list, reduced by a pointer riding alongside "
+        "it -- the any-depth counterpart to '*'/':all()', which are "
+        "both restricted to exactly one level."
+    )
+    ROLE = Function3.CONTEXT_SETTER
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -122,37 +122,34 @@ class ReferenceFinder3(ABC):
     def _pointer_before_manifest(
         reference: Reference3, name: str
     ) -> "FunctionCall3 | None":
-        """returns the pointer function call riding immediately before a
-        bare ":name()" call in name_one (e.g. "$*.files.:last():manifest()"
-        parses as name_one.path == [:last()], name_one.functions ==
-        [:manifest()]), or None if this reference is not shaped that
-        way. Ordinal indexing into a global ledger (Rule 1b,
-        manifest_field_functions_proposal.md) -- a pointer here selects
-        one entry out of the whole ledger array, same position-based
-        selection _apply_pointer() already does for a named entitys own
-        manifest, just applied to the ledger instead. Shared by files/
-        csvpaths/results since all three ledgers are flat arrays in
-        arrival order."""
+        """returns the pointer function call riding alongside a bare
+        ":name()" call in name_one -- in either order (both
+        "$*.files.:last():manifest()" and "$*.files.:manifest():last()"
+        parse to one segment in name_one.path and one in
+        name_one.functions, just swapped), or None if this reference is
+        not shaped that way. Ordinal indexing into a global ledger (Rule
+        1b, manifest_field_functions_proposal.md) -- a pointer here
+        selects one entry out of the whole ledger array, same
+        position-based selection _apply_pointer() already does for a
+        named entity's own manifest, just applied to the ledger instead.
+        Shared by files/csvpaths/results since all three ledgers are
+        flat arrays in arrival order. Order-insensitive on purpose,
+        matching every literal-root query() path, which never cares
+        which of pointer/:name() came first in a combined chain --
+        confirmed missing here and fixed 2026-08-10."""
         name_one = reference.name_one
         if reference.name_three is not None:
             return None
         if len(name_one.path) != 1 or len(name_one.functions) != 1:
             return None
-        pointer_call = name_one.path[0]
-        manifest_call = name_one.functions[0]
-        if not isinstance(pointer_call, FunctionCall3) or pointer_call.name not in (
-            "first",
-            "last",
-            "index",
-        ):
+        calls = (name_one.path[0], name_one.functions[0])
+        if not all(isinstance(c, FunctionCall3) for c in calls):
             return None
-        if (
-            not isinstance(manifest_call, FunctionCall3)
-            or manifest_call.name != name
-            or manifest_call.arg is not None
-        ):
+        pointer_calls = [c for c in calls if c.name in ("first", "last", "index")]
+        manifest_calls = [c for c in calls if c.name == name and c.arg is None]
+        if len(pointer_calls) != 1 or len(manifest_calls) != 1:
             return None
-        return pointer_call
+        return pointer_calls[0]
 
     @staticmethod
     def _query_well_known_file(home: str, filename: str) -> ReferenceResults3:

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -21,8 +21,14 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 # result directory within the selected run(s).
 #
 #  - root_major is a literal named-results name (the same name as the named-
-#    paths group that was run). "*" (every named-results group) is a
-#    different traversal problem, not yet built.
+#    paths group that was run), or "*" (every named-results group). "*" has
+#    two exceptions carved out before general traversal (Rule 1a/1b, a
+#    bare/ordinal-indexed :manifest() reads the global archive ledger); any
+#    other use of "*" goes through _query_star_traversal(), which is
+#    deliberately the narrowest of the three datatypes' traversals (bare
+#    pointer only, no path narrowing/:all()/name_three/:manifest()/field
+#    accessors) -- see that method's own docstring for why the wider cases
+#    are genuinely harder here, not just unbuilt yet.
 #  - name_one has TWO legal shapes, matching the spec's own examples
 #    ("$acme.results.:all()"/"$acme.results.:last()" alongside
 #    "$acme.results.customers/2025:first()"):
@@ -132,13 +138,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 return ReferenceResults3(
                     results=[ReferenceResult3(path=path, uuid=selected["run_uuid"])]
                 )
-            raise ReferenceException3(
-                "ResultsReferenceFinder3 does not yet support '*' as "
-                "root_major (querying every named-results group) -- use a "
-                "literal group name, or a bare ':manifest()' to read the "
-                "global archive ledger, optionally with a pointer "
-                "(:first()/:last()/:index(n)) to pick one entry by ordinal."
-            )
+            return self._query_star_traversal(reference)
 
         name_one = reference.name_one
         if name_one.name_two is not None:
@@ -211,6 +211,92 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         for run_dir in selected_runs:
             results.extend(self._results_for_run(run_dir, identity, match_all))
         return ReferenceResults3(results=results)
+
+    def _query_star_traversal(self, reference: Reference3) -> ReferenceResults3:
+        """root_major == "*" -- query across every named-results group,
+        not just one. Deliberately the narrowest '*' traversal of the
+        three datatypes: only a bare pointer (:first()/:last()/
+        :index(n)), no path narrowing, no name_three, no ':all()', no
+        :manifest()/a field-accessor function. Two things make the
+        wider cases genuinely harder here, not just unbuilt yet (unlike
+        files/csvpaths, where the same shapes were straightforward
+        generalizations):
+
+        - RESULTS' own ':all()' already means something different --
+          pooling every csvpath-statement instance WITHIN one already-
+          selected run, at name_three (see _name_three_selector) -- so
+          there is no existing syntactic home for a "group by named-
+          results-group" trigger the way files/csvpaths both have via
+          a bare ':all()' in name_one.
+        - Path narrowing (_matches_prefix) needs a candidate's own
+          group's home directory to compute a relative match -- a bare
+          run_home string, once pooled from _discover_run_homes(), no
+          longer carries which group it came from. Generalizing that
+          safely needs real design work, not reuse.
+
+        So this only generalizes _discover_run_homes() (root_major=None
+        skips its group filter -- it already reads the same archive-
+        wide ledger Rule 1a/1b use, so no separate group-name
+        enumeration is needed at all) and reuses _results_for_run()'s
+        existing no-name_three case unchanged. The one real design
+        decision: chronological order across every group cannot be a
+        plain sort of full run_home path strings the way one group's
+        own query() does (line ~163 above) -- different groups' run
+        directories live under different prefixes, so a full-path sort
+        would sort by group name first, not by timestamp. Sorting by
+        each run_home's own trailing directory-name segment (the
+        "%Y-%m-%d_%H-%M-%S[_N]" timestamp itself) fixes this.
+        """
+        name_one = reference.name_one
+        if name_one.name_two is not None:
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 does not support the '#worksheet' "
+                "marker (name_two) -- it is files-only."
+            )
+        if not self._is_bare_function_only(name_one):
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 does not yet support path "
+                "narrowing combined with '*' traversal -- only a bare "
+                "pointer (:first()/:last()/:index(n)) is supported so "
+                "far, e.g. '$*.results.:last()'."
+            )
+        if reference.name_three is not None:
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 does not yet support name_three "
+                "(an instance selector) combined with '*' traversal."
+            )
+        calls = self._combined_name_one_calls(name_one)
+        built = ReferenceFunctionFactory.build_chain(calls)
+        if any(f.name in ("all", "manifest") for f in built):
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 does not yet support ':all()' or "
+                "':manifest()' combined with '*' traversal -- only a "
+                "bare pointer (:first()/:last()/:index(n)) is supported "
+                "so far."
+            )
+        if self._find_field_function_call(calls) is not None:
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 does not yet support a field-"
+                "accessor function combined with '*' traversal."
+            )
+        pointer = self._pointer_from_calls(calls)
+        if pointer is None:
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 requires a pointer (:first()/"
+                ":last()/:index(n)) when traversing every named-results "
+                "group with '*'."
+            )
+
+        run_homes = self._discover_run_homes(None)
+        run_homes = sorted(
+            run_homes, key=lambda rh: rh.rstrip("/").rsplit("/", 1)[-1]
+        )
+        selected = self._apply_pointer(pointer, run_homes)
+        if selected is None:
+            return ReferenceResults3(results=[])
+        return ReferenceResults3(
+            results=self._results_for_run(selected, None, False)
+        )
 
     _JSON_ACCESSOR_FILES = {
         "errors": "errors.json",
@@ -370,14 +456,19 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         path = Nos(instance_dir).join(accessor.arg)
         return cls._read_well_known_file(path)
 
-    def _discover_run_homes(self, root_major: str) -> list[str]:
-        """every distinct, still-existing run_home for this group, read
-        from the archive-root manifest.json -- see this module's own
-        docstring for why this replaces directory-walking entirely (no
-        need to know/guess the group's template depth). Many entries can
-        share the same run_home (one entry per csvpath-statement
-        execution, several statements per run), so dedupe; a stale entry
-        (the run since deleted) is dropped via an existence check."""
+    def _discover_run_homes(self, root_major: str | None) -> list[str]:
+        """every distinct, still-existing run_home, read from the
+        archive-root manifest.json -- see this module's own docstring
+        for why this replaces directory-walking entirely (no need to
+        know/guess a group's template depth). root_major is a literal
+        group name to filter to (the ordinary, single-group case), or
+        None to skip the filter entirely and discover across every
+        group -- used by '*' traversal, which already has this same
+        archive-wide ledger in hand for Rule 1a/1b, so no separate
+        group-name enumeration is needed. Many entries can share the
+        same run_home (one entry per csvpath-statement execution,
+        several statements per run), so dedupe; a stale entry (the run
+        since deleted) is dropped via an existence check."""
         archive = self.csvpaths.config.get(section="results", name="archive")
         manifest_path = Nos(archive).join("manifest.json")
         if not Nos(manifest_path).exists():
@@ -386,7 +477,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             entries = json.load(reader.source)
         homes = []
         for entry in entries:
-            if entry.get("named_paths_name") != root_major:
+            if root_major is not None and entry.get("named_paths_name") != root_major:
                 continue
             run_home = entry.get("run_home")
             if run_home and run_home not in homes:

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -188,25 +188,42 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         home = self.csvpaths.results_manager.get_named_results_home(root_major)
         run_homes = [rh for rh, _ in self._discover_run_homes(root_major)]
         calls = self._combined_name_one_calls(name_one)
+        pointer = self._pointer_from_calls(calls)
+        is_grouped = any(
+            isinstance(c, FunctionCall3) and c.name == "all" for c in calls
+        )
+        # group_key_for: set only when ':all()' + a pointer together
+        # mean "partition by observed value, reduce each partition" --
+        # David's three-templates example (three different one-level
+        # templates all group correctly by whatever directory each run
+        # actually landed in, not by which template produced it).
+        # Left None otherwise -- including ':all()' with NO pointer,
+        # which keeps its own separate, unchanged precedent (every run,
+        # any depth, unreduced, mirroring csvpaths' own bare ':all()').
+        group_key_for = None
 
         if self._is_bare_function_only(name_one):
-            is_grouped = any(
-                isinstance(c, FunctionCall3) and c.name == "all" for c in calls
-            )
             is_flattened = any(
                 isinstance(c, FunctionCall3) and c.name == "flatten" for c in calls
             )
-            if is_grouped or is_flattened:
-                # ':all()' or ':flatten()' present (bare, or bare + a
-                # pointer) -- every run discovered for the group is a
-                # candidate, any depth, no prefix narrowing. This is
+            if is_grouped and pointer is not None:
+                # bare ':all()' + a pointer -- exactly one level,
+                # wildcarded, grouped by the run's own actual value
+                # there (peer of a bare '*', which is illegal on its
+                # own but this is the same one-level restriction).
+                pattern = [Star3()]
+                candidates = [
+                    rh for rh in run_homes if self._matches_prefix(rh, home, pattern)
+                ]
+                group_key_for = {
+                    rh: self._prefix_segments(rh, home)[-1] for rh in candidates
+                }
+            elif is_grouped or is_flattened:
+                # ':all()' with no pointer, or ':flatten()' (with or
+                # without one) -- every run discovered for the group is
+                # a candidate, any depth, no prefix narrowing. This is
                 # exactly what a bare pointer alone used to do before
-                # 2026-08-10 -- ':flatten()' is now its explicit name;
-                # ':all()' additionally groups-by-observed-value once a
-                # pointer reduces it (a later stage of this same
-                # refactor, not built in this commit -- for now this
-                # just preserves the "every run" candidate set,
-                # unreduced-per-group, same as before that stage lands).
+                # 2026-08-10 -- ':flatten()' is now its explicit name.
                 candidates = run_homes
             else:
                 # a plain pointer alone, e.g. "$acme.results.:last()" --
@@ -236,6 +253,27 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 for rh in run_homes
                 if self._matches_prefix_at_least(rh, home, prefix_pattern)
             ]
+        elif isinstance(name_one.path[-1], FunctionCall3) and name_one.path[
+            -1
+        ].name == "all":
+            # a literal/wildcard prefix, then ':all()' as the last
+            # segment, e.g. "beta/:all():last()" -- matches exactly one
+            # level beyond the prefix (like "beta/*" would), grouped by
+            # the run's own actual value at that position instead of
+            # pooled.
+            if name_one.path[-1].arg is not None:
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3's ':all()' does not take an "
+                    "argument."
+                )
+            pattern = self._compile_path_pattern(name_one.path[:-1]) + [Star3()]
+            candidates = [
+                rh for rh in run_homes if self._matches_prefix(rh, home, pattern)
+            ]
+            if pointer is not None:
+                group_key_for = {
+                    rh: self._prefix_segments(rh, home)[-1] for rh in candidates
+                }
         else:
             pattern = self._compile_path_pattern(name_one.path)
             candidates = [
@@ -243,7 +281,6 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             ]
         candidates = sorted(candidates, key=self._run_dir_sort_key)
 
-        pointer = self._pointer_from_calls(calls)
         identity, match_all, accessor, _ = self._name_three_selector(
             reference.name_three
         )
@@ -253,8 +290,30 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             if isinstance(seg, FunctionCall3)
         )
         wants_full_content = has_manifest or accessor is not None
+        if group_key_for and (
+            wants_full_content or self._find_field_function_call(calls) is not None
+        ):
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 does not yet support combining "
+                "':all()' grouping with :manifest() or a run-level field "
+                "accessor -- resolve the grouped runs on their own first."
+            )
 
-        if pointer is not None:
+        if group_key_for:
+            # partition candidates by their own observed group key,
+            # apply the pointer independently within each partition --
+            # one result per distinct value observed. candidates is
+            # already sorted by _run_dir_sort_key, so each partition
+            # keeps correct arrival order internally.
+            groups: dict = {}
+            for rh in candidates:
+                groups.setdefault(group_key_for[rh], []).append(rh)
+            selected_runs = []
+            for key in sorted(groups):
+                selected = self._apply_pointer(pointer, groups[key])
+                if selected is not None:
+                    selected_runs.append(selected)
+        elif pointer is not None:
             selected = self._apply_pointer(pointer, candidates)
             selected_runs = [selected] if selected is not None else []
         else:
@@ -732,21 +791,32 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         return body, match_all, accessor, field_call
 
     @staticmethod
-    def _matches_prefix(run_home: str, home: str, pattern: list) -> bool:
-        """true if run_home's own prefix -- everything between `home`
-        and the run directory's own name (the last path segment) --
-        matches `pattern` position-by-position (Star3 as wildcard).
-        Similar in spirit to FilesReferenceFinder3._matches, but the run
-        directory's own name is excluded from the comparison first,
-        since (unlike a file's file_home) run_home already includes
-        that final, version-identifying segment itself."""
+    def _prefix_segments(run_home: str, home: str) -> "list[str] | None":
+        """everything between `home` and the run directory's own name
+        (the last path segment), split into segments -- None if
+        run_home is not even under `home` at all. Shared by
+        _matches_prefix/_matches_prefix_at_least (matching) and
+        query()'s ':all()' grouping (extracting the actual value at a
+        wildcarded position, once a candidate is already known to
+        match)."""
         home = home.rstrip("/")
         if not run_home.startswith(home):
-            return False
+            return None
         rel = run_home[len(home) :].lstrip("/")
         segments = rel.split("/") if rel else []
-        prefix_segments = segments[:-1]
-        if len(prefix_segments) != len(pattern):
+        return segments[:-1]
+
+    @classmethod
+    def _matches_prefix(cls, run_home: str, home: str, pattern: list) -> bool:
+        """true if run_home's own prefix matches `pattern` position-by-
+        position (Star3 as wildcard), with EXACTLY len(pattern) segments
+        -- no more, no fewer. Similar in spirit to
+        FilesReferenceFinder3._matches, but the run directory's own name
+        is excluded from the comparison first, since (unlike a file's
+        file_home) run_home already includes that final, version-
+        identifying segment itself."""
+        prefix_segments = cls._prefix_segments(run_home, home)
+        if prefix_segments is None or len(prefix_segments) != len(pattern):
             return False
         for actual, expected in zip(prefix_segments, pattern):
             if isinstance(expected, Star3):
@@ -755,8 +825,8 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 return False
         return True
 
-    @staticmethod
-    def _matches_prefix_at_least(run_home: str, home: str, pattern: list) -> bool:
+    @classmethod
+    def _matches_prefix_at_least(cls, run_home: str, home: str, pattern: list) -> bool:
         """like _matches_prefix, but matches when run_home's own prefix
         has AT LEAST len(pattern) segments matching `pattern` position-
         by-position, with any number of additional segments (including
@@ -764,13 +834,8 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         the ':flatten()' case (see that function and its own docstring):
         match this literal/wildcard prefix, then anything, at any
         remaining depth, instead of requiring an exact segment count."""
-        home = home.rstrip("/")
-        if not run_home.startswith(home):
-            return False
-        rel = run_home[len(home) :].lstrip("/")
-        segments = rel.split("/") if rel else []
-        prefix_segments = segments[:-1]
-        if len(prefix_segments) < len(pattern):
+        prefix_segments = cls._prefix_segments(run_home, home)
+        if prefix_segments is None or len(prefix_segments) < len(pattern):
             return False
         for actual, expected in zip(prefix_segments, pattern):
             if isinstance(expected, Star3):

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -257,6 +257,22 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 # ordinary job (reading the field off whatever got
                 # selected) -- no order-sensitivity trap, since nothing
                 # here depends on which of the two is written first.
+                # There is NO prefixed equivalent ("beta/:home()") --
+                # considered and removed 2026-08-12: a literal prefix
+                # segment with nothing trailing already means "every
+                # run under this exact prefix, unreduced" (long-
+                # standing, pre-dates this whole depth refactor --
+                # confirmed "$acme.results.beta" and
+                # "$acme.results.beta/:home()" give identical results
+                # in every case tested). ':home()' is only load-bearing
+                # at the bare/root position, where the grammar cannot
+                # express "zero segments" any other way -- a literal
+                # prefix already covers every other depth, so adding
+                # ':home()' there would just be a second, more
+                # confusing spelling of something that already has one
+                # (David: explicit felt "more mysterious than the
+                # default," and collided with the unrelated ":run_dir"
+                # template token in a reader's head).
                 candidates = [
                     rh for rh in run_homes if self._matches_prefix(rh, home, [])
                 ]
@@ -300,28 +316,6 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 group_key_for = {
                     rh: self._prefix_segments(rh, home)[-1] for rh in candidates
                 }
-        elif isinstance(name_one.path[-1], FunctionCall3) and name_one.path[
-            -1
-        ].name == "home":
-            # a literal/wildcard prefix, then ':home()' as the last
-            # segment, e.g. "beta/:home()" -- every run directly under
-            # `beta`, no additional nesting -- the same "zero
-            # ADDITIONAL levels beyond the prefix" idea as the bare
-            # case above, just relative to a prefix instead of the
-            # group's own root. Settled 2026-08-11, alongside the bare
-            # case. Uses the exact-length _matches_prefix (like '*'/
-            # ':all()' do), not _matches_prefix_at_least (':flatten()'s
-            # any-depth matcher) -- ':home()' never means "any depth,"
-            # only "stop exactly here."
-            if name_one.path[-1].arg is not None:
-                raise ReferenceException3(
-                    "ResultsReferenceFinder3's ':home()' does not take "
-                    "an argument."
-                )
-            prefix_pattern = self._compile_path_pattern(name_one.path[:-1])
-            candidates = [
-                rh for rh in run_homes if self._matches_prefix(rh, home, prefix_pattern)
-            ]
         else:
             pattern = self._compile_path_pattern(name_one.path)
             candidates = [

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -243,7 +243,20 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 # zero-level (direct children of the group's own root)
                 # only, NOT "ignore depth entirely" -- settled
                 # 2026-08-10. ':flatten()' above is the new home for
-                # the any-depth case this used to cover.
+                # the any-depth case this used to cover. A bare
+                # ':home()' ALONE (no pointer/:all()/:flatten() also
+                # present) reaches this same branch and needs no
+                # special-casing at all -- settled 2026-08-11: ':home()'
+                # is a VALUE-role field accessor, never a POINTER, so
+                # _pointer_from_calls() below naturally finds none,
+                # leaving every zero-level candidate unreduced -- "every
+                # run whose home is right here" (David's own framing).
+                # The moment a real pointer joins the chain (either
+                # order -- ":home():last()" or ":last():home()"), that
+                # pointer reduces to one and ':home()' reverts to its
+                # ordinary job (reading the field off whatever got
+                # selected) -- no order-sensitivity trap, since nothing
+                # here depends on which of the two is written first.
                 candidates = [
                     rh for rh in run_homes if self._matches_prefix(rh, home, [])
                 ]
@@ -287,6 +300,28 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 group_key_for = {
                     rh: self._prefix_segments(rh, home)[-1] for rh in candidates
                 }
+        elif isinstance(name_one.path[-1], FunctionCall3) and name_one.path[
+            -1
+        ].name == "home":
+            # a literal/wildcard prefix, then ':home()' as the last
+            # segment, e.g. "beta/:home()" -- every run directly under
+            # `beta`, no additional nesting -- the same "zero
+            # ADDITIONAL levels beyond the prefix" idea as the bare
+            # case above, just relative to a prefix instead of the
+            # group's own root. Settled 2026-08-11, alongside the bare
+            # case. Uses the exact-length _matches_prefix (like '*'/
+            # ':all()' do), not _matches_prefix_at_least (':flatten()'s
+            # any-depth matcher) -- ':home()' never means "any depth,"
+            # only "stop exactly here."
+            if name_one.path[-1].arg is not None:
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3's ':home()' does not take "
+                    "an argument."
+                )
+            prefix_pattern = self._compile_path_pattern(name_one.path[:-1])
+            candidates = [
+                rh for rh in run_homes if self._matches_prefix(rh, home, prefix_pattern)
+            ]
         else:
             pattern = self._compile_path_pattern(name_one.path)
             candidates = [

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from csvpath.util.file_readers import DataFileReader
 from csvpath.util.nos import Nos
@@ -96,8 +97,15 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 # this exact same manifest+run_home+existence-check approach rather than
 # directory-walking. Stale entries are handled by an existence check
 # (Nos(run_home).exists()), same as v2 does. Run directories are named
-# "%Y-%m-%d_%H-%M-%S[_N]" (RunHomeMaker), lexicographically sortable =
-# chronological (confirmed separately by direct experiment). Each run
+# "%Y-%m-%d_%H-%M-%S[_N]" (RunHomeMaker) -- the timestamp itself is
+# fixed-width/zero-padded, so plain lexicographic sort is safe for it,
+# but "_N" (RunHomeMaker.get_run_dir, appended starting at "_0" when a
+# run collides with one already claimed for the same group+prefix
+# within the same second -- confirmed by David not to be rare during
+# test suite runs) is a plain, unpadded integer -- lexicographic sort
+# of THAT alone is not safe ("_10" sorts before "_9" as strings). See
+# _run_dir_sort_key(), used everywhere a list of run_home paths/
+# segments needs true chronological order. Each run
 # directory has its own manifest.json (a single dict; "run_uuid" identifies
 # the run itself). Each run directory contains one subdirectory per csvpath
 # statement, named by that statement's own identity
@@ -107,6 +115,31 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 
 
 class ResultsReferenceFinder3(ReferenceFinder3):
+    #
+    # matches a run directory's disambiguating "_N" suffix (RunHomeMaker
+    # -- appended starting at "_0" when a run collides with one already
+    # claimed for the same group+prefix within the same second). Requires
+    # the WHOLE tail after the last "_" to be digits, which the plain
+    # "%H-%M-%S" timestamp tail (always containing "-") never is -- so
+    # this only ever matches a genuine disambiguation suffix, never a
+    # bare timestamp.
+    #
+    _RUN_SUFFIX_RE = re.compile(r"^(.*)_(\d+)$")
+
+    @classmethod
+    def _run_dir_sort_key(cls, run_home: str) -> tuple:
+        """true chronological sort key for a run directory path or bare
+        segment -- see this module's own docstring for why plain
+        lexicographic sort of the full string is not safe once a "_N"
+        disambiguation suffix is involved. A run with no suffix at all
+        sorts before any suffixed collision for the same timestamp
+        (suffixes start at "_0", so -1 correctly sorts before 0)."""
+        seg = run_home.rstrip("/").rsplit("/", 1)[-1]
+        m = cls._RUN_SUFFIX_RE.match(seg)
+        if m:
+            return (m.group(1), int(m.group(2)))
+        return (seg, -1)
+
     def query(self) -> ReferenceResults3:
         reference = self.ref.parsed
         root_major = reference.root_major
@@ -160,7 +193,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             candidates = [
                 rh for rh in run_homes if self._matches_prefix(rh, home, pattern)
             ]
-        candidates = sorted(candidates)
+        candidates = sorted(candidates, key=self._run_dir_sort_key)
 
         calls = self._combined_name_one_calls(name_one)
         pointer = self._pointer_from_calls(calls)
@@ -239,13 +272,15 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         wide ledger Rule 1a/1b use, so no separate group-name
         enumeration is needed at all) and reuses _results_for_run()'s
         existing no-name_three case unchanged. The one real design
-        decision: chronological order across every group cannot be a
-        plain sort of full run_home path strings the way one group's
-        own query() does (line ~163 above) -- different groups' run
-        directories live under different prefixes, so a full-path sort
-        would sort by group name first, not by timestamp. Sorting by
-        each run_home's own trailing directory-name segment (the
-        "%Y-%m-%d_%H-%M-%S[_N]" timestamp itself) fixes this.
+        decision: chronological order across every group cannot use a
+        full-path string sort the way one group's own query() case can
+        get away with (different groups' run directories live under
+        different prefixes, so a full-path sort would sort by group
+        name first, not by timestamp) -- _run_dir_sort_key() extracts
+        just the trailing directory-name segment, AND handles that
+        segment's own disambiguating "_N" suffix numerically rather
+        than as a string (see this module's own docstring for why that
+        suffix specifically cannot be sorted as a plain string).
         """
         name_one = reference.name_one
         if name_one.name_two is not None:
@@ -288,9 +323,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             )
 
         run_homes = self._discover_run_homes(None)
-        run_homes = sorted(
-            run_homes, key=lambda rh: rh.rstrip("/").rsplit("/", 1)[-1]
-        )
+        run_homes = sorted(run_homes, key=self._run_dir_sort_key)
         selected = self._apply_pointer(pointer, run_homes)
         if selected is None:
             return ReferenceResults3(results=[])

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -193,24 +193,49 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             is_grouped = any(
                 isinstance(c, FunctionCall3) and c.name == "all" for c in calls
             )
-            if is_grouped:
-                # ':all()' present (bare, or bare + a pointer) -- every
-                # run discovered for the group is a candidate, any
-                # depth, no prefix narrowing. Grouping-by-observed-value
-                # (David's three-templates example) is a later stage of
-                # this same refactor, not built in this commit -- for
-                # now this just preserves the existing "every run"
-                # candidate set unreduced-per-group.
+            is_flattened = any(
+                isinstance(c, FunctionCall3) and c.name == "flatten" for c in calls
+            )
+            if is_grouped or is_flattened:
+                # ':all()' or ':flatten()' present (bare, or bare + a
+                # pointer) -- every run discovered for the group is a
+                # candidate, any depth, no prefix narrowing. This is
+                # exactly what a bare pointer alone used to do before
+                # 2026-08-10 -- ':flatten()' is now its explicit name;
+                # ':all()' additionally groups-by-observed-value once a
+                # pointer reduces it (a later stage of this same
+                # refactor, not built in this commit -- for now this
+                # just preserves the "every run" candidate set,
+                # unreduced-per-group, same as before that stage lands).
                 candidates = run_homes
             else:
                 # a plain pointer alone, e.g. "$acme.results.:last()" --
                 # zero-level (direct children of the group's own root)
                 # only, NOT "ignore depth entirely" -- settled
-                # 2026-08-10. ':flatten()' is the new home for the any-
-                # depth case this used to cover; see that function.
+                # 2026-08-10. ':flatten()' above is the new home for
+                # the any-depth case this used to cover.
                 candidates = [
                     rh for rh in run_homes if self._matches_prefix(rh, home, [])
                 ]
+        elif isinstance(name_one.path[-1], FunctionCall3) and name_one.path[
+            -1
+        ].name == "flatten":
+            # a literal/wildcard prefix, then ':flatten()' as the last
+            # segment, e.g. "beta/:flatten():last()" -- matches this
+            # prefix, then anything, at any remaining depth, instead of
+            # requiring an exact segment count the way a plain literal/
+            # '*' pattern does.
+            if name_one.path[-1].arg is not None:
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3's ':flatten()' does not take "
+                    "an argument."
+                )
+            prefix_pattern = self._compile_path_pattern(name_one.path[:-1])
+            candidates = [
+                rh
+                for rh in run_homes
+                if self._matches_prefix_at_least(rh, home, prefix_pattern)
+            ]
         else:
             pattern = self._compile_path_pattern(name_one.path)
             candidates = [
@@ -336,12 +361,18 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             )
         calls = self._combined_name_one_calls(name_one)
         built = ReferenceFunctionFactory.build_chain(calls)
-        if any(f.name in ("all", "manifest") for f in built):
+        if any(f.name in ("all", "flatten", "manifest") for f in built):
+            # ':flatten()' would be a no-op here anyway -- traversal
+            # already pools every discovered run at the same (zero)
+            # level, unlike the literal-root case's plain bare pointer
+            # -- but rejecting it explicitly avoids silently applying
+            # the zero-level filter to what should be an any-depth
+            # query, rather than quietly doing the wrong thing.
             raise ReferenceException3(
-                "ResultsReferenceFinder3 does not yet support ':all()' or "
-                "':manifest()' combined with '*' traversal -- only a "
-                "bare pointer (:first()/:last()/:index(n)) is supported "
-                "so far."
+                "ResultsReferenceFinder3 does not yet support ':all()', "
+                "':flatten()', or ':manifest()' combined with '*' "
+                "traversal -- only a bare pointer (:first()/:last()/"
+                ":index(n)) is supported so far."
             )
         if self._find_field_function_call(calls) is not None:
             raise ReferenceException3(
@@ -716,6 +747,30 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         segments = rel.split("/") if rel else []
         prefix_segments = segments[:-1]
         if len(prefix_segments) != len(pattern):
+            return False
+        for actual, expected in zip(prefix_segments, pattern):
+            if isinstance(expected, Star3):
+                continue
+            if actual != expected:
+                return False
+        return True
+
+    @staticmethod
+    def _matches_prefix_at_least(run_home: str, home: str, pattern: list) -> bool:
+        """like _matches_prefix, but matches when run_home's own prefix
+        has AT LEAST len(pattern) segments matching `pattern` position-
+        by-position, with any number of additional segments (including
+        zero) allowed after them before the run's own trailing name --
+        the ':flatten()' case (see that function and its own docstring):
+        match this literal/wildcard prefix, then anything, at any
+        remaining depth, instead of requiring an exact segment count."""
+        home = home.rstrip("/")
+        if not run_home.startswith(home):
+            return False
+        rel = run_home[len(home) :].lstrip("/")
+        segments = rel.split("/") if rel else []
+        prefix_segments = segments[:-1]
+        if len(prefix_segments) < len(pattern):
             return False
         for actual, expected in zip(prefix_segments, pattern):
             if isinstance(expected, Star3):

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -35,9 +35,14 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 #    "$acme.results.customers/2025:first()"):
 #      (a) bare/function-only, no literal path at all (mirrors csvpaths --
 #          the sole path "segment" is itself a version-selecting function,
-#          e.g. :all()/:first()/:last()/:index(n)). Used when there is no
-#          template, or the caller does not care about path narrowing at
-#          all -- every run discovered for the group is a candidate.
+#          e.g. :all()/:first()/:last()/:index(n)). A bare POINTER alone
+#          (no :all()) means zero-level only -- direct children of the
+#          group's own root, no template -- settled 2026-08-10; see
+#          :flatten() for the any-depth case this used to cover. A bare
+#          ':all()' (with or without a trailing pointer) is unaffected by
+#          that change -- every run discovered for the group is still a
+#          candidate, any depth (grouping by observed template value is a
+#          later stage of the same refactor, not this one).
 #      (b) literal/"*"/:name("...") path segments (same semantics as files
 #          -- see ReferenceFinder3._compile_path_pattern) PLUS its own
 #          trailing function chain -- narrows to runs whose own prefix
@@ -181,13 +186,31 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             )
 
         home = self.csvpaths.results_manager.get_named_results_home(root_major)
-        run_homes = self._discover_run_homes(root_major)
+        run_homes = [rh for rh, _ in self._discover_run_homes(root_major)]
+        calls = self._combined_name_one_calls(name_one)
 
         if self._is_bare_function_only(name_one):
-            # mirrors csvpaths: no literal path at all, e.g.
-            # "$acme.results.:all()"/"$acme.results.:last()" -- every run
-            # discovered for the group is a candidate, no prefix narrowing.
-            candidates = run_homes
+            is_grouped = any(
+                isinstance(c, FunctionCall3) and c.name == "all" for c in calls
+            )
+            if is_grouped:
+                # ':all()' present (bare, or bare + a pointer) -- every
+                # run discovered for the group is a candidate, any
+                # depth, no prefix narrowing. Grouping-by-observed-value
+                # (David's three-templates example) is a later stage of
+                # this same refactor, not built in this commit -- for
+                # now this just preserves the existing "every run"
+                # candidate set unreduced-per-group.
+                candidates = run_homes
+            else:
+                # a plain pointer alone, e.g. "$acme.results.:last()" --
+                # zero-level (direct children of the group's own root)
+                # only, NOT "ignore depth entirely" -- settled
+                # 2026-08-10. ':flatten()' is the new home for the any-
+                # depth case this used to cover; see that function.
+                candidates = [
+                    rh for rh in run_homes if self._matches_prefix(rh, home, [])
+                ]
         else:
             pattern = self._compile_path_pattern(name_one.path)
             candidates = [
@@ -195,7 +218,6 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             ]
         candidates = sorted(candidates, key=self._run_dir_sort_key)
 
-        calls = self._combined_name_one_calls(name_one)
         pointer = self._pointer_from_calls(calls)
         identity, match_all, accessor, _ = self._name_three_selector(
             reference.name_three
@@ -249,38 +271,50 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         """root_major == "*" -- query across every named-results group,
         not just one. Deliberately the narrowest '*' traversal of the
         three datatypes: only a bare pointer (:first()/:last()/
-        :index(n)), no path narrowing, no name_three, no ':all()', no
-        :manifest()/a field-accessor function. Two things make the
-        wider cases genuinely harder here, not just unbuilt yet (unlike
-        files/csvpaths, where the same shapes were straightforward
-        generalizations):
+        :index(n)), no literal/'*' path narrowing, no name_three, no
+        ':all()', no :manifest()/a field-accessor function. A bare
+        pointer here means the same zero-level-only ("direct children
+        of each run's own group's home") restriction the literal-root
+        query() case now applies -- settled 2026-08-10, see that
+        method's own comments and :flatten() for the any-depth case.
+        Two things make the wider cases genuinely harder here, not just
+        unbuilt yet (unlike files/csvpaths, where the same shapes were
+        straightforward generalizations):
 
         - RESULTS' own ':all()' already means something different --
           pooling every csvpath-statement instance WITHIN one already-
           selected run, at name_three (see _name_three_selector) -- so
           there is no existing syntactic home for a "group by named-
           results-group" trigger the way files/csvpaths both have via
-          a bare ':all()' in name_one.
-        - Path narrowing (_matches_prefix) needs a candidate's own
-          group's home directory to compute a relative match -- a bare
-          run_home string, once pooled from _discover_run_homes(), no
-          longer carries which group it came from. Generalizing that
-          safely needs real design work, not reuse.
+          a bare ':all()' in name_one. (Grouping by observed template
+          value WITHIN one already-literal group, David's three-
+          templates example, is a different, narrower thing and is
+          handled in the literal-root query() case, not here.)
+        - Literal/'*' path narrowing (_matches_prefix) needs a
+          candidate's own group's home directory to compute a relative
+          match -- a bare run_home string, once pooled from
+          _discover_run_homes(), no longer carries which group it came
+          from on its own. _discover_run_homes() now keeps each pair's
+          group name specifically so the zero-level check above can
+          compute the right home per candidate; genuine non-zero path
+          narrowing across every group still needs more design work
+          than reusing that, and stays out of scope here.
 
         So this only generalizes _discover_run_homes() (root_major=None
         skips its group filter -- it already reads the same archive-
         wide ledger Rule 1a/1b use, so no separate group-name
         enumeration is needed at all) and reuses _results_for_run()'s
-        existing no-name_three case unchanged. The one real design
-        decision: chronological order across every group cannot use a
-        full-path string sort the way one group's own query() case can
-        get away with (different groups' run directories live under
-        different prefixes, so a full-path sort would sort by group
-        name first, not by timestamp) -- _run_dir_sort_key() extracts
-        just the trailing directory-name segment, AND handles that
-        segment's own disambiguating "_N" suffix numerically rather
-        than as a string (see this module's own docstring for why that
-        suffix specifically cannot be sorted as a plain string).
+        existing no-name_three case unchanged. One real design
+        decision, independent of the zero-level change: chronological
+        order across every group cannot use a full-path string sort the
+        way one group's own query() case can get away with (different
+        groups' run directories live under different prefixes, so a
+        full-path sort would sort by group name first, not by
+        timestamp) -- _run_dir_sort_key() extracts just the trailing
+        directory-name segment, AND handles that segment's own
+        disambiguating "_N" suffix numerically rather than as a string
+        (see this module's own docstring for why that suffix
+        specifically cannot be sorted as a plain string).
         """
         name_one = reference.name_one
         if name_one.name_two is not None:
@@ -322,7 +356,19 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 "group with '*'."
             )
 
-        run_homes = self._discover_run_homes(None)
+        # zero-level (direct children of each run's own group's home)
+        # only -- same restriction the literal-root query() case now
+        # applies to a plain bare pointer, settled 2026-08-10. Each
+        # candidate's own group name (kept by _discover_run_homes since
+        # this is the traversal case) is needed to compute the right
+        # "home" per candidate -- different groups have different homes.
+        run_homes = [
+            rh
+            for rh, group in self._discover_run_homes(None)
+            if self._matches_prefix(
+                rh, self.csvpaths.results_manager.get_named_results_home(group), []
+            )
+        ]
         run_homes = sorted(run_homes, key=self._run_dir_sort_key)
         selected = self._apply_pointer(pointer, run_homes)
         if selected is None:
@@ -489,19 +535,25 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         path = Nos(instance_dir).join(accessor.arg)
         return cls._read_well_known_file(path)
 
-    def _discover_run_homes(self, root_major: str | None) -> list[str]:
-        """every distinct, still-existing run_home, read from the
-        archive-root manifest.json -- see this module's own docstring
-        for why this replaces directory-walking entirely (no need to
-        know/guess a group's template depth). root_major is a literal
-        group name to filter to (the ordinary, single-group case), or
-        None to skip the filter entirely and discover across every
-        group -- used by '*' traversal, which already has this same
-        archive-wide ledger in hand for Rule 1a/1b, so no separate
-        group-name enumeration is needed. Many entries can share the
-        same run_home (one entry per csvpath-statement execution,
-        several statements per run), so dedupe; a stale entry (the run
-        since deleted) is dropped via an existence check."""
+    def _discover_run_homes(self, root_major: str | None) -> list[tuple[str, str]]:
+        """every distinct, still-existing (run_home, named_paths_name)
+        pair, read from the archive-root manifest.json -- see this
+        module's own docstring for why this replaces directory-walking
+        entirely (no need to know/guess a group's template depth).
+        root_major is a literal group name to filter to (the ordinary,
+        single-group case), or None to skip the filter entirely and
+        discover across every group -- used by '*' traversal, which
+        already has this same archive-wide ledger in hand for Rule
+        1a/1b, so no separate group-name enumeration is needed. Each
+        pair's own group name is kept (not just the run_home) so '*'
+        traversal can tell whether a given run is a direct child of
+        *its own* group's home -- needed once a plain bare pointer
+        means zero-level-only (settled 2026-08-10, see :flatten() for
+        the any-depth case) rather than "ignore depth entirely." Many
+        entries can share the same run_home (one entry per csvpath-
+        statement execution, several statements per run), so dedupe; a
+        stale entry (the run since deleted) is dropped via an
+        existence check."""
         archive = self.csvpaths.config.get(section="results", name="archive")
         manifest_path = Nos(archive).join("manifest.json")
         if not Nos(manifest_path).exists():
@@ -509,13 +561,16 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         with DataFileReader(manifest_path) as reader:
             entries = json.load(reader.source)
         homes = []
+        seen = set()
         for entry in entries:
-            if root_major is not None and entry.get("named_paths_name") != root_major:
+            group = entry.get("named_paths_name")
+            if root_major is not None and group != root_major:
                 continue
             run_home = entry.get("run_home")
-            if run_home and run_home not in homes:
-                homes.append(run_home)
-        return [h for h in homes if Nos(h).exists()]
+            if run_home and run_home not in seen:
+                seen.add(run_home)
+                homes.append((run_home, group))
+        return [pair for pair in homes if Nos(pair[0]).exists()]
 
     def _results_for_run(
         self, run_dir: str, identity: str | None, match_all: bool

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -36,13 +36,14 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 #      (a) bare/function-only, no literal path at all (mirrors csvpaths --
 #          the sole path "segment" is itself a version-selecting function,
 #          e.g. :all()/:first()/:last()/:index(n)). A bare POINTER alone
-#          (no :all()) means zero-level only -- direct children of the
-#          group's own root, no template -- settled 2026-08-10; see
-#          :flatten() for the any-depth case this used to cover. A bare
-#          ':all()' (with or without a trailing pointer) is unaffected by
-#          that change -- every run discovered for the group is still a
-#          candidate, any depth (grouping by observed template value is a
-#          later stage of the same refactor, not this one).
+#          (no :all()/:flatten()) means zero-level only -- direct children
+#          of the group's own root, no template -- settled 2026-08-10. A
+#          bare ':all()' means exactly one level, wildcarded -- the same
+#          restriction '*' has, and unaffected by whether a pointer
+#          follows it (settled 2026-08-11, correcting an earlier version
+#          that let a pointer-less ':all()' fall through to any-depth
+#          behavior). ':flatten()' is the any-depth case -- see that
+#          function's own docstring.
 #      (b) literal/"*"/:name("...") path segments (same semantics as files
 #          -- see ReferenceFinder3._compile_path_pattern) PLUS its own
 #          trailing function chain -- narrows to runs whose own prefix
@@ -192,38 +193,50 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         is_grouped = any(
             isinstance(c, FunctionCall3) and c.name == "all" for c in calls
         )
-        # group_key_for: set only when ':all()' + a pointer together
-        # mean "partition by observed value, reduce each partition" --
-        # David's three-templates example (three different one-level
+        # group_key_for: set only when ':all()' partitions candidates by
+        # observed value AND a pointer exists to reduce each partition
+        # (David's three-templates example -- three different one-level
         # templates all group correctly by whatever directory each run
-        # actually landed in, not by which template produced it).
-        # Left None otherwise -- including ':all()' with NO pointer,
-        # which keeps its own separate, unchanged precedent (every run,
-        # any depth, unreduced, mirroring csvpaths' own bare ':all()').
+        # actually landed in, not by which template produced it). Left
+        # None when there is no pointer -- grouping only matters at the
+        # reduce step, so with no pointer the "grouped" and "pooled"
+        # candidate sets are identical anyway (every one-level match,
+        # unreduced).
         group_key_for = None
 
         if self._is_bare_function_only(name_one):
             is_flattened = any(
                 isinstance(c, FunctionCall3) and c.name == "flatten" for c in calls
             )
-            if is_grouped and pointer is not None:
-                # bare ':all()' + a pointer -- exactly one level,
-                # wildcarded, grouped by the run's own actual value
-                # there (peer of a bare '*', which is illegal on its
-                # own but this is the same one-level restriction).
+            if is_grouped and is_flattened:
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3 does not support combining "
+                    "':all()' and ':flatten()' -- one level, grouped, or "
+                    "any depth, pooled, but not both at once."
+                )
+            if is_grouped:
+                # bare ':all()' -- exactly one level, wildcarded, peer of
+                # a bare '*' (illegal on its own, but this is the same
+                # one-level restriction) -- settled 2026-08-11,
+                # regardless of whether a pointer follows. Corrected
+                # from an earlier version that let a pointer-less
+                # ':all()' fall through to ':flatten()'s any-depth
+                # candidate set by mistake, mirroring csvpaths' own
+                # depth-less ':all()' precedent -- which does not apply
+                # here, since csvpaths has no path dimension at all to
+                # be wrong about, but results does.
                 pattern = [Star3()]
                 candidates = [
                     rh for rh in run_homes if self._matches_prefix(rh, home, pattern)
                 ]
-                group_key_for = {
-                    rh: self._prefix_segments(rh, home)[-1] for rh in candidates
-                }
-            elif is_grouped or is_flattened:
-                # ':all()' with no pointer, or ':flatten()' (with or
-                # without one) -- every run discovered for the group is
-                # a candidate, any depth, no prefix narrowing. This is
-                # exactly what a bare pointer alone used to do before
-                # 2026-08-10 -- ':flatten()' is now its explicit name.
+                if pointer is not None:
+                    group_key_for = {
+                        rh: self._prefix_segments(rh, home)[-1] for rh in candidates
+                    }
+            elif is_flattened:
+                # ':flatten()', with or without a pointer -- every run
+                # discovered for the group is a candidate, any depth, no
+                # prefix narrowing.
                 candidates = run_homes
             else:
                 # a plain pointer alone, e.g. "$acme.results.:last()" --

--- a/tests/references/functions/selectors/test_flatten_3.py
+++ b/tests/references/functions/selectors/test_flatten_3.py
@@ -1,0 +1,22 @@
+import pytest
+
+from csvpath.references.functions.selectors.flatten_3 import Flatten3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Flatten3()
+    assert f.name == "flatten"
+    assert f.ROLE == Function3.CONTEXT_SETTER
+    assert f.DATATYPES == (Reference3.RESULTS,)
+
+
+def test_no_arg_is_valid():
+    Flatten3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Flatten3(arg="x").check_valid()

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -343,6 +343,17 @@ class TestGlobalLoadsLedgerOrdinalIndexing:
         assert results.files == ["inputs/named_paths/manifest.json"]
         assert results.results[0].uuid == "u-loads-3"
 
+    def test_manifest_then_pointer_order_also_works(self):
+        # order-insensitivity was missing on _pointer_before_manifest
+        # and fixed 2026-08-10.
+        finder = _finder(
+            "$*.csvpaths.:manifest():last()",
+            inputs_csvpaths_path="inputs/named_paths",
+            ledger=LOADS_LEDGER,
+        )
+        results = finder.query()
+        assert results.results[0].uuid == "u-loads-3"
+
 
 #
 # named-paths group alpha (2 versions) + beta (1 version). beta is

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -48,18 +48,35 @@ class _FakePathsDescriber:
 
 class _FakePathsManager:
     def __init__(
-        self, manifest, home=GROUP_HOME, definition: dict | None = None, ledger=None
+        self,
+        manifest,
+        home=GROUP_HOME,
+        definition: dict | None = None,
+        ledger=None,
+        by_name: dict | None = None,
     ):
         self._manifest = manifest
         self._home = home
         self._definition = definition or {}
         self._ledger = manifest if ledger is None else ledger
+        # by_name: {name: manifest} -- only used by '*' traversal tests,
+        # which need more than one distinct named-paths group. Every
+        # other test uses the single manifest above.
+        self._by_name = by_name
 
     def get_manifest_for_name(self, name):
+        if self._by_name is not None:
+            return self._by_name[name]
         return self._manifest
 
     def named_paths_home(self, name):
         return self._home
+
+    @property
+    def named_paths_names(self):
+        if self._by_name is not None:
+            return list(self._by_name.keys())
+        return []
 
     @property
     def paths_root_manifest(self):
@@ -87,9 +104,10 @@ def _finder(
     definition: dict | None = None,
     inputs_csvpaths_path: str | None = None,
     ledger: list | None = None,
+    by_name: dict | None = None,
 ) -> CsvpathsReferenceFinder3:
     csvpaths = _FakeCsvPaths(
-        _FakePathsManager(manifest, definition=definition, ledger=ledger),
+        _FakePathsManager(manifest, definition=definition, ledger=ledger, by_name=by_name),
         inputs_csvpaths_path=inputs_csvpaths_path,
     )
     ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
@@ -267,12 +285,14 @@ class TestGlobalLoadsLedger:
         with pytest.raises(ReferenceException3):
             finder.query()
 
-    def test_star_with_version_pointer_is_still_not_supported(self):
+    def test_star_root_major_with_no_named_paths_groups_gives_empty_results(self):
+        # '*' traversal is supported now (see TestStarTraversal below) --
+        # with zero named-paths groups to enumerate (no by_name given
+        # here), it correctly finds nothing rather than raising.
         finder = _finder(
             "$*.csvpaths.:last()", inputs_csvpaths_path="inputs/named_paths"
         )
-        with pytest.raises(ReferenceException3):
-            finder.query()
+        assert finder.query().results == []
 
 
 LOADS_LEDGER = [
@@ -322,6 +342,98 @@ class TestGlobalLoadsLedgerOrdinalIndexing:
         results = finder.query()
         assert results.files == ["inputs/named_paths/manifest.json"]
         assert results.results[0].uuid == "u-loads-3"
+
+
+#
+# named-paths group alpha (2 versions) + beta (1 version). beta is
+# listed FIRST in STAR_BY_NAME on purpose -- naive concatenation with no
+# time-sort would put alpha's own last entry last in the pooled list, so
+# a test asserting beta's true-latest entry wins would fail if the
+# flatten case's time-sort were ever removed/broken.
+#
+STAR_ALPHA_MANIFEST = [
+    {
+        "group_file_path": "named_paths/alpha/group.csvpath",
+        "uuid": "a-v1",
+        "time": "2026-01-01T00:00:00+00:00",
+    },
+    {
+        "group_file_path": "named_paths/alpha/group.csvpath",
+        "uuid": "a-v2",
+        "time": "2026-01-02T00:00:00+00:00",
+    },
+]
+STAR_BETA_MANIFEST = [
+    {
+        "group_file_path": "named_paths/beta/group.csvpath",
+        "uuid": "b-v1",
+        "time": "2026-01-03T00:00:00+00:00",
+    },
+]
+STAR_BY_NAME = {"beta": STAR_BETA_MANIFEST, "alpha": STAR_ALPHA_MANIFEST}
+
+
+def _star_finder(reference: str) -> CsvpathsReferenceFinder3:
+    return _finder(reference, by_name=STAR_BY_NAME)
+
+
+class TestStarTraversalFlatten:
+    # bare pointer, no ':all()' -- every named-paths group's whole
+    # manifest pools into one combined list, sorted by true
+    # chronological order (each entry's own "time"), reduced by one
+    # terminal pointer.
+    def test_last_across_every_group_is_the_true_most_recent(self):
+        # beta's only version (2026-01-03) is the global most-recent,
+        # not alpha's own last version (2026-01-02) -- proves pooling
+        # crosses groups and is truly time-sorted, not just
+        # concatenated in enumeration order.
+        results = _star_finder("$*.csvpaths.:last()").query()
+        assert results.uuids == ["b-v1"]
+
+    def test_first_across_every_group_is_the_true_earliest(self):
+        results = _star_finder("$*.csvpaths.:first()").query()
+        assert results.uuids == ["a-v1"]
+
+    def test_index_selects_by_chronological_position(self):
+        # chronological order: a-v1, a-v2, b-v1
+        results = _star_finder("$*.csvpaths.:index(1)").query()
+        assert results.uuids == ["a-v2"]
+
+    def test_combining_with_manifest_is_not_yet_supported(self):
+        # note: a plain pointer + :manifest() (e.g. ":last():manifest()")
+        # is intercepted earlier by Rule 1b (the global-ledger ordinal
+        # case, same structural shape) before ever reaching traversal --
+        # :all():manifest() is not a pointer-first shape, so it reaches
+        # _query_star_traversal's own combining-guard instead.
+        with pytest.raises(ReferenceException3):
+            _star_finder("$*.csvpaths.:all():manifest()").query()
+
+    def test_name_three_combined_with_traversal_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _star_finder("$*.csvpaths.:last().0").query()
+
+
+class TestStarTraversalGroup:
+    # ':all()' present in the combined name_one chain -- the pointer is
+    # applied independently within each group's own manifest, one
+    # result per group.
+    def test_all_with_last_gives_one_result_per_group(self):
+        results = _star_finder("$*.csvpaths.:all():last()").query()
+        assert len(results.results) == 2
+        assert set(results.uuids) == {"a-v2", "b-v1"}
+
+    def test_all_with_first_gives_each_groups_earliest_version(self):
+        results = _star_finder("$*.csvpaths.:all():first()").query()
+        assert len(results.results) == 2
+        assert set(results.uuids) == {"a-v1", "b-v1"}
+
+    def test_all_with_no_pointer_gives_every_version_unreduced(self):
+        # extends csvpaths' own existing single-group precedent (bare
+        # :all() with no pointer -- test_bare_all_returns_every_version
+        # above) across every group, rather than deduping to anything.
+        results = _star_finder("$*.csvpaths.:all()").query()
+        assert len(results.results) == 3
+        assert set(results.uuids) == {"a-v1", "a-v2", "b-v1"}
 
 
 class TestDefinitionFunction:

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -425,6 +425,20 @@ class TestGlobalArrivalsLedgerOrdinalIndexing:
         assert results.files == ["inputs/named_files/manifest.json"]
         assert results.results[0].uuid == "u-ledger-3"
 
+    def test_manifest_then_pointer_order_also_works(self):
+        # ":manifest():last()" means the same as ":last():manifest()" --
+        # order-insensitivity was missing on _pointer_before_manifest
+        # and fixed 2026-08-10.
+        finder = _finder(
+            "$*.files.:manifest():last()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+            ledger=LEDGER,
+        )
+        results = finder.query()
+        assert results.results[0].uuid == "u-ledger-3"
+
 
 #
 # matches the spec compendium's own EXAMPLE SCENARIO exactly ("Why a

--- a/tests/references/test_normative_examples_results.py
+++ b/tests/references/test_normative_examples_results.py
@@ -1,0 +1,386 @@
+"""Encodes the currently-buildable RESULTS examples from
+`references_notes/notes/normative_reference_examples.txt` as real, running
+assertions -- David's own agreed alternative to relying on manual code
+review against the doc: "rely on...the normative references" instead.
+
+Scope, deliberately narrow: RESULTS only, for now -- FILES/CSVPATHS get
+their own normative test files once their own doc sections are reviewed
+the same way this one was (2026-08-11). Within RESULTS, only examples using
+functions/mechanisms that are actually built today are included, per the
+doc's own note ("all functions may not be available at v3 launch"); each
+test below is commented with the exact doc line it encodes. When the doc
+gains new supported examples, or a currently-excluded one becomes
+supported, add/move the corresponding test here -- this file is meant to
+grow in lockstep with the doc, not be written once and left behind.
+
+Excluded doc lines and why (checked directly against the doc as of
+2026-08-11, not assumed):
+  - line 39 (:groups()) -- not built, explicitly deferred.
+  - lines 42/48/51 (:from()/:yesterday()/:hour()/:message()/:count()/
+    :above()) -- none of these functions are built yet. Lines 42/51 also
+    use a bare '*' in name_three, which is illegal (see
+    references_v3_compendium.md's "Why `*` is disallowed as name_three's
+    body").
+  - lines 69/72/75/78 (:name() with a regex/star/@var argument, :choice(),
+    :type()) -- Name3 is str-arg only today; :choice()/:type() do not
+    exist yet.
+  - lines 96-111 (:from(), :date(), :year(), :type()) -- none built yet.
+  - line 93 (.:all():data(), "data.csv output of each csvpath statement")
+    -- raises today: Rule 1 (settled, see manifest_field_functions_
+    proposal.md's "Entity resolution and pooling") forbids combining
+    ':all()' with any content accessor, since full content always
+    resolves to exactly one entity. David said this example was removed
+    from the doc during review -- it was still present as of this
+    writing, so this is flagged as an open discrepancy to reconcile, not
+    silently resolved either way.
+
+Known doc/code discrepancy, not yet reconciled (see test below): line 54's
+description ("every run having no template") does not match either the old
+or the corrected ':all()' behavior -- ':all()' is a one-level operator
+(peer of '*'), not a zero-level ("no template") one; "no template" is what
+line 30's bare pointer means. The test below asserts the actual, correct
+one-level behavior, not the doc's current wording.
+"""
+
+import json
+
+import pytest
+
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+from csvpath.references.reference_parser_3 import ReferenceParser3
+from csvpath.references.results_reference_finder_3 import ResultsReferenceFinder3
+
+
+class _FakeConfig:
+    def __init__(self, archive: str):
+        self._archive = archive
+
+    def get(self, *, section, name):
+        assert (section, name) == ("results", "archive")
+        return self._archive
+
+
+class _FakeResultsManager:
+    def __init__(self, archive: str):
+        self._archive = archive
+
+    def get_named_results_home(self, name):
+        import os
+
+        return os.path.join(self._archive, name)
+
+    @property
+    def results_root_manifest(self):
+        with open(f"{self._archive}/manifest.json") as f:
+            return json.load(f)
+
+
+class _FakeCsvPaths:
+    def __init__(self, archive: str):
+        self.results_manager = _FakeResultsManager(archive)
+        self.config = _FakeConfig(archive)
+
+
+def _write_json(path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def _make_run(base, run_name: str, run_uuid: str, instances: dict) -> str:
+    """instances: {identity: instance_uuid}. Returns the run's own full
+    path (for use as a "run_home" entry in the fake archive manifest)."""
+    run_dir = base / run_name
+    _write_json(run_dir / "manifest.json", {"run_uuid": run_uuid})
+    for identity, inst_uuid in instances.items():
+        _write_json(run_dir / identity / "manifest.json", {"uuid": inst_uuid})
+    return str(run_dir)
+
+
+def _write_archive_manifest(archive, group: str, run_homes: list) -> None:
+    entries = [{"named_paths_name": group, "run_home": rh} for rh in run_homes]
+    _write_json(archive / "manifest.json", entries)
+
+
+def _finder(reference: str, archive: str) -> ResultsReferenceFinder3:
+    csvpaths = _FakeCsvPaths(archive)
+    ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
+    return ResultsReferenceFinder3(csvpaths=csvpaths, ref=ref)
+
+
+class TestFindingTheLastRun:
+    # doc lines 30-38: "Finding the 'last' run or runs of a type of
+    # information" -- one named-results group ("alpha") with runs at
+    # every depth the doc's examples need: no template, one 1-level
+    # template ("zero/"), and two 2-level templates both starting "beta"
+    # ("beta/x/", "beta/y/").
+    @pytest.fixture
+    def alpha_archive(self, tmp_path):
+        base = tmp_path / "alpha"
+        flat = _make_run(base, "2026-01-01_00-00-00", "flat-uuid", {})
+        zero = _make_run(base / "zero", "2026-01-02_00-00-00", "zero-uuid", {})
+        beta_x = _make_run(base / "beta" / "x", "2026-01-03_00-00-00", "beta-x-uuid", {})
+        beta_y = _make_run(base / "beta" / "y", "2026-01-04_00-00-00", "beta-y-uuid", {})
+        _write_archive_manifest(tmp_path, "alpha", [flat, zero, beta_x, beta_y])
+        return str(tmp_path)
+
+    def test_line_30_bare_pointer_is_zero_level(self, alpha_archive):
+        # $alpha.results.:last() >> run with no template
+        results = _finder("$alpha.results.:last()", alpha_archive).query()
+        assert results.uuids == ["flat-uuid"]
+
+    def test_line_31_star_is_one_level(self, alpha_archive):
+        # $alpha.results.*:last() >> run with a 1-level template
+        results = _finder("$alpha.results.*:last()", alpha_archive).query()
+        assert results.uuids == ["zero-uuid"]
+
+    def test_line_32_all_groups_one_level_templates(self, tmp_path):
+        # $alpha.results.:all():last() >> runs for each 1-level template
+        # -- needs at least two distinct 1-level templates to prove
+        # grouping (not just pooling); alpha_archive only has one.
+        base = tmp_path / "alpha"
+        zero1 = _make_run(base / "zero", "2026-01-01_00-00-00", "zero-1", {})
+        zero2 = _make_run(base / "zero", "2026-01-02_00-00-00", "zero-2", {})
+        one1 = _make_run(base / "one", "2026-01-03_00-00-00", "one-1", {})
+        _write_archive_manifest(tmp_path, "alpha", [zero1, zero2, one1])
+        results = _finder("$alpha.results.:all():last()", str(tmp_path)).query()
+        assert set(results.uuids) == {"zero-2", "one-1"}
+
+    def test_line_33_flatten_pools_any_depth(self, alpha_archive):
+        # $alpha.results.:flatten():last() >> run (single, any depth)
+        # beta/y is the true chronological latest across every depth.
+        results = _finder("$alpha.results.:flatten():last()", alpha_archive).query()
+        assert results.uuids == ["beta-y-uuid"]
+
+    def test_line_34_prefixed_flatten_any_depth_beyond_prefix(self, alpha_archive):
+        # $alpha.results.beta/:flatten():last() >> run of all templates
+        # starting `beta`
+        results = _finder(
+            "$alpha.results.beta/:flatten():last()", alpha_archive
+        ).query()
+        assert results.uuids == ["beta-y-uuid"]
+
+    def test_line_35_prefixed_all_groups_by_next_level(self, alpha_archive):
+        # $alpha.results.beta/:all():last() >> runs of all 2-level
+        # templates starting `beta` -- one per distinct 2nd-level value.
+        results = _finder(
+            "$alpha.results.beta/:all():last()", alpha_archive
+        ).query()
+        assert set(results.uuids) == {"beta-x-uuid", "beta-y-uuid"}
+
+    def test_line_36_prefixed_star_pools_next_level(self, alpha_archive):
+        # $alpha.results.beta/*:last() >> run of all 2-level templates
+        # starting `beta` -- single, pooled (contrast with line 35).
+        results = _finder("$alpha.results.beta/*:last()", alpha_archive).query()
+        assert results.uuids == ["beta-y-uuid"]
+
+    def test_line_37_manifest_at_literal_root_is_zero_level(self, alpha_archive):
+        # $alpha.results.:manifest():last() >> manifest entry of the
+        # most recent run with no template
+        results = _finder(
+            "$alpha.results.:manifest():last()", alpha_archive
+        ).resolve()
+        assert results.results[0].data["run_uuid"] == "flat-uuid"
+
+    def test_line_38_global_manifest_is_unrestricted(self, tmp_path):
+        # $*.results.:manifest():last() >> manifest entry of the most
+        # recent run, period -- reads the archive-wide ledger directly,
+        # bypassing the zero-level restriction entirely (Rule 1b is
+        # checked before the zero-level logic ever runs). The archive
+        # ledger's own entries carry "run_uuid" (not "uuid"), unlike
+        # alpha_archive's fixture -- a dedicated, minimal ledger is used
+        # here rather than _write_archive_manifest, same as the ordinal-
+        # indexing tests in test_results_reference_finder_3.py.
+        ledger = [
+            {"named_paths_name": "alpha", "run_uuid": "run-1"},
+            {"named_paths_name": "alpha", "run_uuid": "run-2"},
+        ]
+        _write_json(tmp_path / "manifest.json", ledger)
+        results = _finder("$*.results.:manifest():last()", str(tmp_path)).resolve()
+        assert results.results[0].data["run_uuid"] == "run-2"
+
+
+class TestAllIsAOneLevelOperator:
+    # doc line 54: $acme.results.:all() -- the doc's own description
+    # ("every run having no template") does not match ':all()'s actual,
+    # correct behavior (one level, peer of '*') -- see this file's own
+    # module docstring. This test asserts the CORRECT behavior, not the
+    # doc's current wording, which is flagged as needing a fix.
+    def test_line_54_all_with_no_pointer_is_still_one_level_only(self, tmp_path):
+        base = tmp_path / "acme"
+        flat = _make_run(base, "2026-01-01_00-00-00", "flat-uuid", {})
+        one_level = _make_run(base / "customers", "2026-01-02_00-00-00", "one-uuid", {})
+        two_level = _make_run(
+            base / "customers" / "2025", "2026-01-03_00-00-00", "two-uuid", {}
+        )
+        _write_archive_manifest(tmp_path, "acme", [flat, one_level, two_level])
+        results = _finder("$acme.results.:all()", str(tmp_path)).query()
+        assert results.uuids == ["one-uuid"]
+
+
+class TestPathNarrowingAndInstanceSelection:
+    # doc lines 57-90: literal/wildcard path narrowing down to a run,
+    # then a literal statement identity ("invoices") and its well-known
+    # output files.
+    @pytest.fixture
+    def acme_archive(self, tmp_path):
+        base = tmp_path / "acme"
+        cust2025_1 = _make_run(
+            base / "customers" / "2025",
+            "2026-01-01_00-00-00",
+            "cust2025-1-uuid",
+            {"invoices": "invoices-1-uuid"},
+        )
+        cust2025_2 = _make_run(
+            base / "customers" / "2025",
+            "2026-01-02_00-00-00",
+            "cust2025-2-uuid",
+            {"invoices": "invoices-2-uuid"},
+        )
+        region2025 = _make_run(
+            base / "region" / "office" / "2025",
+            "2026-01-03_00-00-00",
+            "region2025-uuid",
+            {"invoices": "invoices-region-uuid"},
+        )
+        one_level_customers = _make_run(
+            base / "customers", "2026-01-04_00-00-00", "one-level-uuid", {}
+        )
+        _write_archive_manifest(
+            tmp_path,
+            "acme",
+            [cust2025_1, cust2025_2, region2025, one_level_customers],
+        )
+        return str(tmp_path)
+
+    def test_line_57_literal_two_level_path(self, acme_archive):
+        # $acme.results.customers/2025:first() >> first run with
+        # template customers/2025
+        results = _finder(
+            "$acme.results.customers/2025:first()", acme_archive
+        ).query()
+        assert results.uuids == ["cust2025-1-uuid"]
+
+    def test_line_60_identity_lookup_on_the_selected_run(self, acme_archive):
+        # $acme.results.customers/2025:first().invoices
+        results = _finder(
+            "$acme.results.customers/2025:first().invoices", acme_archive
+        ).query()
+        assert results.uuids == ["invoices-1-uuid"]
+
+    def test_line_63_wildcard_prefix_ending_in_a_literal(self, acme_archive):
+        # $acme.results.*/2025:first().invoices >> ending `2025`,
+        # 2-level only -- matches customers/2025, not region/office/2025.
+        results = _finder(
+            "$acme.results.*/2025:first().invoices", acme_archive
+        ).query()
+        assert results.uuids == ["invoices-1-uuid"]
+
+    def test_line_66_two_wildcards_ending_in_a_literal(self, acme_archive):
+        # $acme.results.*/*/2025:first().invoices >> 3-level ending
+        # `2025` -- matches region/office/2025, not customers/2025.
+        results = _finder(
+            "$acme.results.*/*/2025:first().invoices", acme_archive
+        ).query()
+        assert results.uuids == ["invoices-region-uuid"]
+
+    def test_line_81_file_accessor_on_a_wildcard_matched_instance(
+        self, acme_archive
+    ):
+        # $acme.results.*/2025:first().invoices:file("report.txt")
+        import os
+
+        instance_dir = os.path.join(
+            acme_archive, "acme", "customers", "2025", "2026-01-01_00-00-00", "invoices"
+        )
+        os.makedirs(instance_dir, exist_ok=True)
+        with open(os.path.join(instance_dir, "report.txt"), "w") as f:
+            f.write("report content")
+        results = _finder(
+            '$acme.results.*/2025:first().invoices:file("report.txt")',
+            acme_archive,
+        ).resolve()
+        assert results.results[0].data == b"report content"
+
+    def test_line_84_data_accessor(self, acme_archive):
+        # $acme.results.customers/2025:first().invoices:data()
+        import os
+
+        instance_dir = os.path.join(
+            acme_archive, "acme", "customers", "2025", "2026-01-01_00-00-00", "invoices"
+        )
+        os.makedirs(instance_dir, exist_ok=True)
+        with open(os.path.join(instance_dir, "data.csv"), "wb") as f:
+            f.write(b"a,b\n1,2\n")
+        results = _finder(
+            "$acme.results.customers/2025:first().invoices:data()", acme_archive
+        ).resolve()
+        assert results.results[0].data == b"a,b\n1,2\n"
+
+    def test_line_87_vars_accessor(self, acme_archive):
+        # $acme.results.customers/2025:first().invoices:vars()
+        import os
+
+        instance_dir = os.path.join(
+            acme_archive, "acme", "customers", "2025", "2026-01-01_00-00-00", "invoices"
+        )
+        os.makedirs(instance_dir, exist_ok=True)
+        with open(os.path.join(instance_dir, "vars.json"), "w") as f:
+            json.dump({"count": 3}, f)
+        results = _finder(
+            "$acme.results.customers/2025:first().invoices:vars()", acme_archive
+        ).resolve()
+        assert results.results[0].data == {"count": 3}
+
+    def test_line_90_meta_accessor(self, acme_archive):
+        # $acme.results.customers/2025:first().invoices:meta()
+        import os
+
+        instance_dir = os.path.join(
+            acme_archive, "acme", "customers", "2025", "2026-01-01_00-00-00", "invoices"
+        )
+        os.makedirs(instance_dir, exist_ok=True)
+        with open(os.path.join(instance_dir, "meta.json"), "w") as f:
+            json.dump({"identity": "invoices"}, f)
+        results = _finder(
+            "$acme.results.customers/2025:first().invoices:meta()", acme_archive
+        ).resolve()
+        assert results.results[0].data == {"identity": "invoices"}
+
+    def test_line_114_manifest_before_pointer_at_a_one_level_template(
+        self, acme_archive
+    ):
+        # $acme.results.customers:manifest():first() >> manifest of
+        # first run with 1-level template `customers`
+        results = _finder(
+            "$acme.results.customers:manifest():first()", acme_archive
+        ).resolve()
+        assert results.results[0].data["run_uuid"] == "one-level-uuid"
+
+    def test_line_117_pointer_before_manifest_same_result(self, acme_archive):
+        # $acme.results.customers:first():manifest() -- same as line
+        # 114, order does not matter.
+        results = _finder(
+            "$acme.results.customers:first():manifest()", acme_archive
+        ).resolve()
+        assert results.results[0].data["run_uuid"] == "one-level-uuid"
+
+
+class TestKnownExcludedOrContestedExamples:
+    # locks in the CURRENT, real limitation for line 93 so this test
+    # file notices if/when that changes (either by Rule 1 being
+    # revisited, or the doc line being removed/rewritten) -- not a
+    # statement that this is desired, permanent behavior.
+    def test_line_93_all_combined_with_data_still_raises(self, tmp_path):
+        base = tmp_path / "acme"
+        run1 = _make_run(
+            base / "customers" / "2025",
+            "2026-01-01_00-00-00",
+            "run1-uuid",
+            {"invoices": "invoices-uuid", "receipts": "receipts-uuid"},
+        )
+        _write_archive_manifest(tmp_path, "acme", [run1])
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$acme.results.customers/2025:first().:all():data()",
+                str(tmp_path),
+            ).resolve()

--- a/tests/references/test_normative_examples_results.py
+++ b/tests/references/test_normative_examples_results.py
@@ -25,21 +25,16 @@ Excluded doc lines and why (checked directly against the doc as of
     :type()) -- Name3 is str-arg only today; :choice()/:type() do not
     exist yet.
   - lines 96-111 (:from(), :date(), :year(), :type()) -- none built yet.
-  - line 93 (.:all():data(), "data.csv output of each csvpath statement")
-    -- raises today: Rule 1 (settled, see manifest_field_functions_
-    proposal.md's "Entity resolution and pooling") forbids combining
-    ':all()' with any content accessor, since full content always
-    resolves to exactly one entity. David said this example was removed
-    from the doc during review -- it was still present as of this
-    writing, so this is flagged as an open discrepancy to reconcile, not
-    silently resolved either way.
 
-Known doc/code discrepancy, not yet reconciled (see test below): line 54's
-description ("every run having no template") does not match either the old
-or the corrected ':all()' behavior -- ':all()' is a one-level operator
-(peer of '*'), not a zero-level ("no template") one; "no template" is what
-line 30's bare pointer means. The test below asserts the actual, correct
-one-level behavior, not the doc's current wording.
+Both discrepancies flagged in an earlier version of this docstring are now
+resolved directly in the doc itself (confirmed 2026-08-11, not assumed):
+line 54's description now correctly says "1-level template" (':all()' is
+a one-level operator, peer of '*', not zero-level/"no template"); the
+`.:all():data()` example (which raised, since Rule 1 forbids combining
+':all()' with any content accessor) has been removed from the doc
+entirely. No corresponding test lives here for either -- there is nothing
+left to encode for the removed example, and line 54 is covered by
+TestAllIsAOneLevelOperator below using the doc's own, now-correct wording.
 """
 
 import json
@@ -200,11 +195,9 @@ class TestFindingTheLastRun:
 
 
 class TestAllIsAOneLevelOperator:
-    # doc line 54: $acme.results.:all() -- the doc's own description
-    # ("every run having no template") does not match ':all()'s actual,
-    # correct behavior (one level, peer of '*') -- see this file's own
-    # module docstring. This test asserts the CORRECT behavior, not the
-    # doc's current wording, which is flagged as needing a fix.
+    # doc line 54: $acme.results.:all() >> every run having a 1-level
+    # template -- description fixed by David 2026-08-11 (was "no
+    # template", which is bare :last()'s job, not ':all()'s).
     def test_line_54_all_with_no_pointer_is_still_one_level_only(self, tmp_path):
         base = tmp_path / "acme"
         flat = _make_run(base, "2026-01-01_00-00-00", "flat-uuid", {})
@@ -365,22 +358,58 @@ class TestPathNarrowingAndInstanceSelection:
         assert results.results[0].data["run_uuid"] == "one-level-uuid"
 
 
-class TestKnownExcludedOrContestedExamples:
-    # locks in the CURRENT, real limitation for line 93 so this test
-    # file notices if/when that changes (either by Rule 1 being
-    # revisited, or the doc line being removed/rewritten) -- not a
-    # statement that this is desired, permanent behavior.
-    def test_line_93_all_combined_with_data_still_raises(self, tmp_path):
-        base = tmp_path / "acme"
-        run1 = _make_run(
-            base / "customers" / "2025",
-            "2026-01-01_00-00-00",
-            "run1-uuid",
-            {"invoices": "invoices-uuid", "receipts": "receipts-uuid"},
+class TestHomeAsAZeroLevelSelector:
+    # decided jointly 2026-08-11, added to the doc under its own new
+    # "## :home() as a zero-level selector" heading -- fills the one
+    # real gap in the depth model: no existing mechanism returned
+    # "every zero-level run, unreduced" (bare pointer always reduces to
+    # one; ':all()' is one-level not zero; ':flatten()' is any depth
+    # not zero). Works because ':home()' is VALUE-role, never a
+    # POINTER -- when it is the only function present, nothing reduces
+    # the candidate set.
+    def test_bare_home_lists_every_no_template_run(self, tmp_path):
+        base = tmp_path / "alpha"
+        flat1 = _make_run(base, "2026-01-01_00-00-00", "flat-1", {})
+        flat2 = _make_run(base, "2026-01-02_00-00-00", "flat-2", {})
+        one_level = _make_run(
+            base / "zero", "2026-01-03_00-00-00", "one-level", {}
         )
-        _write_archive_manifest(tmp_path, "acme", [run1])
-        with pytest.raises(ReferenceException3):
-            _finder(
-                "$acme.results.customers/2025:first().:all():data()",
-                str(tmp_path),
-            ).resolve()
+        _write_archive_manifest(tmp_path, "alpha", [flat1, flat2, one_level])
+        results = _finder("$alpha.results.:home()", str(tmp_path)).query()
+        assert set(results.uuids) == {"flat-1", "flat-2"}
+
+    def test_home_then_pointer_order_independent(self, tmp_path):
+        base = tmp_path / "alpha"
+        flat1 = _make_run(base, "2026-01-01_00-00-00", "flat-1", {})
+        flat2 = _make_run(base, "2026-01-02_00-00-00", "flat-2", {})
+        _write_archive_manifest(tmp_path, "alpha", [flat1, flat2])
+        home_first = _finder(
+            "$alpha.results.:home():last()", str(tmp_path)
+        ).query()
+        pointer_first = _finder(
+            "$alpha.results.:last():home()", str(tmp_path)
+        ).query()
+        assert home_first.uuids == pointer_first.uuids == ["flat-2"]
+
+    def test_prefixed_home_lists_every_run_directly_under_the_prefix(
+        self, tmp_path
+    ):
+        base = tmp_path / "acme"
+        beta1 = _make_run(base / "beta", "2026-01-01_00-00-00", "beta-1", {})
+        beta2 = _make_run(base / "beta", "2026-01-02_00-00-00", "beta-2", {})
+        deeper = _make_run(
+            base / "beta" / "x", "2026-01-03_00-00-00", "deeper", {}
+        )
+        _write_archive_manifest(tmp_path, "acme", [beta1, beta2, deeper])
+        results = _finder("$acme.results.beta/:home()", str(tmp_path)).query()
+        assert set(results.uuids) == {"beta-1", "beta-2"}
+
+    def test_prefixed_home_then_pointer(self, tmp_path):
+        base = tmp_path / "acme"
+        beta1 = _make_run(base / "beta", "2026-01-01_00-00-00", "beta-1", {})
+        beta2 = _make_run(base / "beta", "2026-01-02_00-00-00", "beta-2", {})
+        _write_archive_manifest(tmp_path, "acme", [beta1, beta2])
+        results = _finder(
+            "$acme.results.beta/:home():last()", str(tmp_path)
+        ).query()
+        assert results.uuids == ["beta-2"]

--- a/tests/references/test_normative_examples_results.py
+++ b/tests/references/test_normative_examples_results.py
@@ -391,25 +391,18 @@ class TestHomeAsAZeroLevelSelector:
         ).query()
         assert home_first.uuids == pointer_first.uuids == ["flat-2"]
 
-    def test_prefixed_home_lists_every_run_directly_under_the_prefix(
+    # NOTE: there is no prefixed equivalent ("beta/:home()") -- a plain
+    # literal prefix with nothing trailing already means "every run
+    # under this exact prefix, unreduced" (confirmed identical results
+    # in every case tested), so ':home()' is root-only.
+    def test_prefixed_home_is_not_a_thing_use_the_literal_prefix_alone(
         self, tmp_path
     ):
         base = tmp_path / "acme"
         beta1 = _make_run(base / "beta", "2026-01-01_00-00-00", "beta-1", {})
         beta2 = _make_run(base / "beta", "2026-01-02_00-00-00", "beta-2", {})
-        deeper = _make_run(
-            base / "beta" / "x", "2026-01-03_00-00-00", "deeper", {}
-        )
-        _write_archive_manifest(tmp_path, "acme", [beta1, beta2, deeper])
-        results = _finder("$acme.results.beta/:home()", str(tmp_path)).query()
-        assert set(results.uuids) == {"beta-1", "beta-2"}
-
-    def test_prefixed_home_then_pointer(self, tmp_path):
-        base = tmp_path / "acme"
-        beta1 = _make_run(base / "beta", "2026-01-01_00-00-00", "beta-1", {})
-        beta2 = _make_run(base / "beta", "2026-01-02_00-00-00", "beta-2", {})
         _write_archive_manifest(tmp_path, "acme", [beta1, beta2])
-        results = _finder(
-            "$acme.results.beta/:home():last()", str(tmp_path)
-        ).query()
-        assert results.uuids == ["beta-2"]
+        plain_prefix = _finder("$acme.results.beta", str(tmp_path)).query()
+        assert set(plain_prefix.uuids) == {"beta-1", "beta-2"}
+        with pytest.raises(ReferenceException3):
+            _finder("$acme.results.beta/:home()", str(tmp_path)).query()

--- a/tests/references/test_reference_finder_3.py
+++ b/tests/references/test_reference_finder_3.py
@@ -147,10 +147,12 @@ class TestIsBarePointerReference:
 class TestPointerBeforeManifest:
     # shared by every finder that supports ordinal indexing into a
     # global ledger (Rule 1b) -- files/csvpaths/results all read a flat
-    # array in arrival order, so a pointer riding before the bare
+    # array in arrival order, so a pointer riding alongside the bare
     # :manifest() (e.g. ":last():manifest()", parsed as name_one.path
     # == [:last()], name_one.functions == [:manifest()]) means the same
-    # thing everywhere.
+    # thing everywhere -- in either order (see
+    # test_true_for_manifest_then_pointer below; order-insensitivity
+    # was missing and fixed 2026-08-10).
     @staticmethod
     def _ref(name_one, name_three=None) -> Reference3:
         return Reference3(
@@ -184,6 +186,29 @@ class TestPointerBeforeManifest:
 
     def test_none_when_no_trailing_function(self):
         r = self._ref(NameOne3(path=[FunctionCall3(name="last")]))
+        assert ReferenceFinder3._pointer_before_manifest(r, "manifest") is None
+
+    def test_true_for_manifest_then_pointer(self):
+        # the reverse order -- ":manifest():last()" -- means the same
+        # thing as ":last():manifest()". Confirmed missing 2026-08-10:
+        # this used to only recognize pointer-first.
+        r = self._ref(
+            NameOne3(
+                path=[FunctionCall3(name="manifest")],
+                functions=[FunctionCall3(name="last")],
+            )
+        )
+        pointer = ReferenceFinder3._pointer_before_manifest(r, "manifest")
+        assert pointer is not None
+        assert pointer.name == "last"
+
+    def test_none_when_both_positions_are_pointers(self):
+        r = self._ref(
+            NameOne3(
+                path=[FunctionCall3(name="last")],
+                functions=[FunctionCall3(name="first")],
+            )
+        )
         assert ReferenceFinder3._pointer_before_manifest(r, "manifest") is None
 
     def test_none_when_path_segment_is_not_a_pointer(self):

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -373,6 +373,81 @@ class TestFlatten:
             _finder("$*.results.:flatten():last()", two_group_archive).query()
 
 
+class TestAllGrouping:
+    # ':all()' and '*' stay depth peers (exactly one level) --
+    # ':all()' additionally groups by whatever value actually occupies
+    # that one wildcarded position, unlike '*' (which pools). Settled
+    # 2026-08-10, directly from David's own example: three different
+    # one-level templates, each nesting runs one level deep via a
+    # different substitution source, still group correctly by whatever
+    # directory each run actually landed in -- not by which template
+    # produced it.
+    def test_davids_three_templates_example(self, tmp_path):
+        base = tmp_path / "alpha"
+        zero_run1 = _make_run(base / "zero", "2026-01-01_00-00-00", "zero-1", {})
+        zero_run2 = _make_run(base / "zero", "2026-01-02_00-00-00", "zero-2", {})
+        one_run1 = _make_run(base / "one", "2026-01-03_00-00-00", "one-1", {})
+        one_run2 = _make_run(base / "one", "2026-01-04_00-00-00", "one-2", {})
+        two_run1 = _make_run(base / "two", "2026-01-05_00-00-00", "two-1", {})
+        two_run2 = _make_run(base / "two", "2026-01-06_00-00-00", "two-2", {})
+        _write_archive_manifest(
+            tmp_path,
+            "alpha",
+            [zero_run1, zero_run2, one_run1, one_run2, two_run1, two_run2],
+        )
+        results = _finder("$alpha.results.:all():last()", str(tmp_path)).query()
+        assert len(results.results) == 3
+        assert set(results.uuids) == {"zero-2", "one-2", "two-2"}
+
+    def test_all_with_first_gives_each_groups_earliest(self, tmp_path):
+        base = tmp_path / "alpha"
+        zero_run1 = _make_run(base / "zero", "2026-01-01_00-00-00", "zero-1", {})
+        zero_run2 = _make_run(base / "zero", "2026-01-02_00-00-00", "zero-2", {})
+        one_run1 = _make_run(base / "one", "2026-01-03_00-00-00", "one-1", {})
+        _write_archive_manifest(tmp_path, "alpha", [zero_run1, zero_run2, one_run1])
+        results = _finder("$alpha.results.:all():first()", str(tmp_path)).query()
+        assert set(results.uuids) == {"zero-1", "one-1"}
+
+    def test_all_with_no_pointer_keeps_its_own_unchanged_precedent(
+        self, tmp_path
+    ):
+        # ':all()' alone (no pointer) is unaffected by grouping -- still
+        # every run for the group, any depth, unreduced, mirroring
+        # csvpaths' own bare ':all()' precedent.
+        base = tmp_path / "alpha"
+        zero_run = _make_run(base / "zero", "2026-01-01_00-00-00", "zero-1", {})
+        flat_run = _make_run(base, "2026-01-02_00-00-00", "flat-1", {})
+        _write_archive_manifest(tmp_path, "alpha", [zero_run, flat_run])
+        results = _finder("$alpha.results.:all()", str(tmp_path)).query()
+        assert set(results.uuids) == {"zero-1", "flat-1"}
+
+    def test_prefixed_all_groups_by_the_next_level(self, tmp_path):
+        base = tmp_path / "acme"
+        x_run1 = _make_run(base / "beta" / "x", "2026-01-01_00-00-00", "x-1", {})
+        x_run2 = _make_run(base / "beta" / "x", "2026-01-02_00-00-00", "x-2", {})
+        y_run1 = _make_run(base / "beta" / "y", "2026-01-03_00-00-00", "y-1", {})
+        other_run = _make_run(base / "gamma" / "z", "2026-01-04_00-00-00", "z-1", {})
+        _write_archive_manifest(
+            tmp_path, "acme", [x_run1, x_run2, y_run1, other_run]
+        )
+        results = _finder(
+            "$acme.results.beta/:all():last()", str(tmp_path)
+        ).query()
+        assert len(results.results) == 2
+        assert set(results.uuids) == {"x-2", "y-1"}
+
+    def test_all_grouping_combined_with_manifest_is_not_yet_supported(
+        self, tmp_path
+    ):
+        base = tmp_path / "alpha"
+        run1 = _make_run(base / "zero", "2026-01-01_00-00-00", "zero-1", {})
+        _write_archive_manifest(tmp_path, "alpha", [run1])
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$alpha.results.:all():last():manifest()", str(tmp_path)
+            ).query()
+
+
 class TestDiscoveryFromArchiveManifest:
     def test_dedupes_multiple_entries_sharing_one_run_home(self, tmp_path):
         # a real run_home is written once per csvpath-statement

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -102,13 +102,18 @@ def acme_archive(tmp_path):
 
 @pytest.fixture
 def two_group_archive(tmp_path):
-    # acme (2 runs) + widgets (1 run, chronologically LATEST overall).
+    # acme (2 runs) + widgets (1 run, chronologically LATEST overall) --
+    # both groups' runs are flat (zero-level, direct children of their
+    # own group's home), since a bare pointer now only considers
+    # zero-level runs (settled 2026-08-10) -- a nested group here would
+    # be silently excluded from traversal entirely, defeating this
+    # fixture's whole point (proving pooling crosses groups correctly).
     # widgets is written FIRST in the merged manifest on purpose -- a
     # naive (unsorted) "last" would give acme's own last run
     # (2026-01-02) instead of the true global-latest (widgets',
     # 2026-01-03), so this fails if the '*' traversal sort-by-trailing-
     # segment logic is ever removed/broken.
-    acme_base = tmp_path / "acme" / "customers" / "2025"
+    acme_base = tmp_path / "acme"
     acme_run1 = _make_run(acme_base, "2026-01-01_00-00-00", "acme-run1-uuid", {})
     acme_run2 = _make_run(acme_base, "2026-01-02_00-00-00", "acme-run2-uuid", {})
     widgets_base = tmp_path / "widgets"
@@ -233,10 +238,11 @@ class TestPathMatching:
 
 class TestBareFunctionOnlyNameOne:
     # mirrors csvpaths: no literal path at all -- the sole path
-    # "segment" is itself a version-selecting function. Every run
-    # discovered for the group is a candidate, regardless of how deep
-    # its own prefix happens to be (unlike the literal-path shape, which
-    # requires an exact segment-count match).
+    # "segment" is itself a version-selecting function. A bare pointer
+    # alone (no ':all()') means zero-level only -- direct children of
+    # the group's own root -- settled 2026-08-10; see :flatten() for
+    # the any-depth case this used to cover. A bare ':all()' is
+    # unaffected: still every run for the group, any depth.
     @pytest.fixture
     def flat_archive(self, tmp_path):
         base = tmp_path / "flat"
@@ -257,13 +263,35 @@ class TestBareFunctionOnlyNameOne:
         results = _finder("$flat.results.:all()", flat_archive).query()
         assert set(results.uuids) == {"run1-uuid", "run2-uuid"}
 
-    def test_bare_pointer_still_finds_a_run_under_a_deep_template(
+    def test_bare_pointer_does_not_find_a_run_under_a_deep_template(
         self, acme_archive
     ):
-        # bare :last() ignores prefix depth entirely -- it still finds
-        # the group's runs even though they sit under "customers/2025".
+        # bare :last() means zero-level only -- acme_archive's runs sit
+        # under "customers/2025", two levels deep, so a bare pointer no
+        # longer finds them at all (settled 2026-08-10). Reaching them
+        # needs an explicit path prefix (customers/2025:last(), already
+        # covered by TestVersionPointer) or :flatten().
         results = _finder("$acme.results.:last()", acme_archive).query()
-        assert results.uuids == ["run2-uuid"]
+        assert results.uuids == []
+
+    def test_bare_pointer_finds_a_flat_run_alongside_a_deep_one(
+        self, tmp_path
+    ):
+        # confirms the new restriction is specifically "zero levels",
+        # not "broken entirely" -- a genuinely flat run for the same
+        # group as a deep one is still found, and correctly preferred
+        # over it even when the deep one is chronologically later.
+        flat_base = tmp_path / "mixed"
+        flat_run = _make_run(flat_base, "2026-01-01_00-00-00", "flat-uuid", {})
+        deep_run = _make_run(
+            flat_base / "customers" / "2025",
+            "2026-01-02_00-00-00",
+            "deep-uuid",
+            {},
+        )
+        _write_archive_manifest(tmp_path, "mixed", [flat_run, deep_run])
+        results = _finder("$mixed.results.:last()", str(tmp_path)).query()
+        assert results.uuids == ["flat-uuid"]
 
 
 class TestDiscoveryFromArchiveManifest:
@@ -383,9 +411,17 @@ class TestManifestOnNameOne:
         ).resolve()
         assert results.results[0].data == {"run_uuid": "run1-uuid"}
 
-    def test_manifest_beside_a_pointer_in_the_bare_shape(self, acme_archive):
+    def test_manifest_beside_a_pointer_in_the_bare_shape(self, tmp_path):
+        # a bare pointer now means zero-level only (settled 2026-08-10)
+        # -- acme_archive's runs are nested under "customers/2025", so
+        # this needs its own flat fixture rather than reusing acme_archive
+        # the way the literal-path sibling test above does.
+        base = tmp_path / "flatgroup"
+        run1 = _make_run(base, "2026-01-01_00-00-00", "run1-uuid", {})
+        run2 = _make_run(base, "2026-01-02_00-00-00", "run2-uuid", {})
+        _write_archive_manifest(tmp_path, "flatgroup", [run1, run2])
         results = _finder(
-            "$acme.results.:last():manifest()", acme_archive
+            "$flatgroup.results.:last():manifest()", str(tmp_path)
         ).resolve()
         assert results.results[0].data == {"run_uuid": "run2-uuid"}
 
@@ -447,7 +483,7 @@ class TestFieldAccessorFunctions:
         # _make_run's default fixture instance manifests only carry
         # "uuid" -- run_uuid at instance scope needs its own manifest
         # data with a "run_uuid" field actually present.
-        base = tmp_path / "acme" / "widgets"
+        base = tmp_path / "widgets"  # direct child of the groups own home
         run_dir = base / "2026-01-01_00-00-00"
         _write_json(run_dir / "manifest.json", {"run_uuid": "run1-uuid"})
         _write_json(
@@ -519,7 +555,7 @@ class TestFieldAccessorFunctions:
         # different keys (all_valid at run scope, valid at instance
         # scope) -- the case Reference3.RESULT/RESULTS actually exists
         # for.
-        base = tmp_path / "acme" / "widgets"
+        base = tmp_path / "widgets"  # direct child of the groups own home
         run_dir = base / "2026-01-01_00-00-00"
         _write_json(
             run_dir / "manifest.json",
@@ -555,7 +591,7 @@ class TestFieldAccessorFunctions:
         # status/method/hostname/username/time_completed/manifest_path/
         # named_paths_name -- run scope only, confirmed real keys in
         # results_registrar.py.
-        base = tmp_path / "acme" / "widgets"
+        base = tmp_path / "widgets"  # direct child of the groups own home
         run_dir = base / "2026-01-01_00-00-00"
         _write_json(
             run_dir / "manifest.json",
@@ -586,7 +622,7 @@ class TestFieldAccessorFunctions:
         assert resolve("named_paths_name") == "widgets"
 
     def test_completed_and_files_complete_scope_dependent_keys(self, tmp_path):
-        base = tmp_path / "acme" / "widgets"
+        base = tmp_path / "widgets"  # direct child of the groups own home
         run_dir = base / "2026-01-01_00-00-00"
         _write_json(
             run_dir / "manifest.json",
@@ -624,7 +660,7 @@ class TestFieldAccessorFunctions:
         assert instance_files_complete.results[0].data is True
 
     def test_named_file_name_shared_key_both_scopes(self, tmp_path):
-        base = tmp_path / "acme" / "widgets"
+        base = tmp_path / "widgets"  # direct child of the groups own home
         run_dir = base / "2026-01-01_00-00-00"
         _write_json(
             run_dir / "manifest.json",
@@ -677,7 +713,7 @@ class TestFieldAccessorFunctions:
         # confirmed present in the real Result Instance Manifest despite
         # manifest_field_functions_proposal.md flagging it as a gap when
         # that doc was written.
-        base = tmp_path / "acme" / "widgets"
+        base = tmp_path / "widgets"  # direct child of the groups own home
         run_dir = base / "2026-01-01_00-00-00"
         instance_manifest_path = str(run_dir / "company_names" / "manifest.json")
         _write_json(run_dir / "manifest.json", {"run_uuid": "run-uuid"})
@@ -895,15 +931,30 @@ class TestGlobalArchiveLedger:
         assert isinstance(data, list)
         assert {e["named_paths_name"] for e in data} == {"acme"}
 
-    def test_star_with_a_bare_pointer_is_supported(self, acme_archive):
+    def test_star_with_a_bare_pointer_is_supported(self, tmp_path):
         # '*' traversal is supported now for the bare-pointer case (see
-        # TestStarTraversal below) -- with only one named-results group
-        # in this fixture, this just confirms it resolves to that
-        # group's own last run rather than raising.
-        finder = _finder("$*.results.:last()", acme_archive)
+        # TestStarTraversal below) -- with only one named-results group,
+        # its runs flat (zero-level, per the 2026-08-10 semantics),
+        # this confirms it resolves to that group's own last run rather
+        # than raising.
+        base = tmp_path / "acme"
+        run1 = _make_run(base, "2026-01-01_00-00-00", "run1-uuid", {})
+        run2 = _make_run(base, "2026-01-02_00-00-00", "run2-uuid", {})
+        _write_archive_manifest(tmp_path, "acme", [run1, run2])
+        finder = _finder("$*.results.:last()", str(tmp_path))
         results = finder.query()
         assert len(results.results) == 1
         assert results.results[0].uuid == "run2-uuid"
+
+    def test_star_with_a_bare_pointer_excludes_a_deep_templated_run(
+        self, acme_archive
+    ):
+        # acme_archive's only group has its runs nested under
+        # "customers/2025" -- with no zero-level runs anywhere, '*'
+        # traversal correctly finds nothing, same restriction the
+        # single-group case now applies.
+        results = _finder("$*.results.:last()", acme_archive).query()
+        assert results.results == []
 
     def test_star_with_path_narrowing_is_still_not_supported(self, acme_archive):
         finder = _finder("$*.results.customers/2025:last()", acme_archive)

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -294,6 +294,85 @@ class TestBareFunctionOnlyNameOne:
         assert results.uuids == ["flat-uuid"]
 
 
+class TestFlatten:
+    # ':flatten()' is the any-depth pooling counterpart of what a bare
+    # pointer used to do before it was redefined to zero-level-only
+    # (settled 2026-08-10) -- unlike a bare pointer (zero levels) or
+    # '*' (exactly one level), ':flatten()' matches any remaining depth.
+    def test_bare_flatten_finds_the_true_latest_regardless_of_depth(
+        self, tmp_path
+    ):
+        base = tmp_path / "mixed"
+        flat_run = _make_run(base, "2026-01-01_00-00-00", "flat-uuid", {})
+        deep_run = _make_run(
+            base / "customers" / "2025", "2026-01-02_00-00-00", "deep-uuid", {}
+        )
+        _write_archive_manifest(tmp_path, "mixed", [flat_run, deep_run])
+        results = _finder(
+            "$mixed.results.:flatten():last()", str(tmp_path)
+        ).query()
+        assert results.uuids == ["deep-uuid"]
+
+    def test_bare_flatten_still_finds_a_flat_run_when_it_is_latest(
+        self, tmp_path
+    ):
+        base = tmp_path / "mixed2"
+        flat_run = _make_run(base, "2026-01-02_00-00-00", "flat-uuid", {})
+        deep_run = _make_run(
+            base / "customers" / "2025", "2026-01-01_00-00-00", "deep-uuid", {}
+        )
+        _write_archive_manifest(tmp_path, "mixed2", [flat_run, deep_run])
+        results = _finder(
+            "$mixed2.results.:flatten():last()", str(tmp_path)
+        ).query()
+        assert results.uuids == ["flat-uuid"]
+
+    def test_prefixed_flatten_matches_any_depth_beyond_the_prefix(
+        self, tmp_path
+    ):
+        base = tmp_path / "beta_group"
+        shallow_run = _make_run(
+            base / "beta" / "x", "2026-01-01_00-00-00", "shallow-uuid", {}
+        )
+        deep_run = _make_run(
+            base / "beta" / "y" / "z", "2026-01-02_00-00-00", "deep-uuid", {}
+        )
+        other_run = _make_run(
+            base / "gamma", "2026-01-03_00-00-00", "other-uuid", {}
+        )
+        _write_archive_manifest(
+            tmp_path, "beta_group", [shallow_run, deep_run, other_run]
+        )
+        results = _finder(
+            "$beta_group.results.beta/:flatten():last()", str(tmp_path)
+        ).query()
+        assert results.uuids == ["deep-uuid"]
+
+    def test_bare_flatten_rejects_an_argument(self, tmp_path):
+        base = tmp_path / "acme"
+        run1 = _make_run(base, "2026-01-01_00-00-00", "run1-uuid", {})
+        _write_archive_manifest(tmp_path, "acme", [run1])
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$acme.results.:flatten("x"):last()', str(tmp_path)
+            ).query()
+
+    def test_prefixed_flatten_rejects_an_argument(self, tmp_path):
+        base = tmp_path / "acme"
+        run1 = _make_run(base / "beta", "2026-01-01_00-00-00", "run1-uuid", {})
+        _write_archive_manifest(tmp_path, "acme", [run1])
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$acme.results.beta/:flatten("x"):last()', str(tmp_path)
+            ).query()
+
+    def test_flatten_combined_with_traversal_is_not_yet_supported(
+        self, two_group_archive
+    ):
+        with pytest.raises(ReferenceException3):
+            _finder("$*.results.:flatten():last()", two_group_archive).query()
+
+
 class TestDiscoveryFromArchiveManifest:
     def test_dedupes_multiple_entries_sharing_one_run_home(self, tmp_path):
         # a real run_home is written once per csvpath-statement

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -463,11 +463,20 @@ class TestHomeAsAZeroLevelSelector:
     # "everything that has its home here") fills the one real gap left
     # in the depth model -- there was no way to ask for "every zero-
     # level run, unreduced" (bare pointer always reduces to one, ':all()'
-    # is one-level not zero, ':flatten()' is any depth not zero). Works
-    # at both the root (no code change needed -- ':home()' is VALUE-
-    # role, never a pointer, so it naturally falls through to the
-    # existing zero-level, no-pointer candidate set) and prefixed
-    # (new code, mirrors :all()/:flatten()'s own prefixed branches).
+    # is one-level not zero, ':flatten()' is any depth not zero). Needed
+    # no code change at all -- ':home()' is VALUE-role, never a pointer,
+    # so when it is the only function in the bare chain, nothing reduces
+    # the candidate set and every zero-level run comes back unreduced
+    # for free.
+    #
+    # settled 2026-08-12: there is NO prefixed equivalent
+    # ("beta/:home()") -- a plain literal prefix segment with nothing
+    # trailing already means "every run under this exact prefix,
+    # unreduced" (confirmed identical results to a prefixed ':home()'
+    # in every case tested), so a prefixed ':home()' would just be a
+    # second, more confusing spelling of something that already has
+    # one. ':home()' is only load-bearing at the bare/root position,
+    # where the grammar has no other way to say "zero segments."
     def test_bare_home_lists_every_zero_level_run_unreduced(self, tmp_path):
         base = tmp_path / "alpha"
         flat1 = _make_run(base, "2026-01-01_00-00-00", "flat-1", {})
@@ -503,32 +512,6 @@ class TestHomeAsAZeroLevelSelector:
         ).query()
         assert home_then_pointer.uuids == pointer_then_home.uuids == ["flat-2"]
 
-    def test_prefixed_home_lists_every_run_directly_under_the_prefix(
-        self, tmp_path
-    ):
-        base = tmp_path / "acme"
-        beta1 = _make_run(base / "beta", "2026-01-01_00-00-00", "beta-1", {})
-        beta2 = _make_run(base / "beta", "2026-01-02_00-00-00", "beta-2", {})
-        beta_deep = _make_run(
-            base / "beta" / "x", "2026-01-03_00-00-00", "beta-deep", {}
-        )
-        other = _make_run(base / "gamma", "2026-01-04_00-00-00", "other", {})
-        _write_archive_manifest(
-            tmp_path, "acme", [beta1, beta2, beta_deep, other]
-        )
-        results = _finder("$acme.results.beta/:home()", str(tmp_path)).query()
-        assert set(results.uuids) == {"beta-1", "beta-2"}
-
-    def test_prefixed_home_then_pointer_reduces_to_one(self, tmp_path):
-        base = tmp_path / "acme"
-        beta1 = _make_run(base / "beta", "2026-01-01_00-00-00", "beta-1", {})
-        beta2 = _make_run(base / "beta", "2026-01-02_00-00-00", "beta-2", {})
-        _write_archive_manifest(tmp_path, "acme", [beta1, beta2])
-        results = _finder(
-            "$acme.results.beta/:home():last()", str(tmp_path)
-        ).query()
-        assert results.uuids == ["beta-2"]
-
     def test_bare_home_rejects_an_argument(self, tmp_path):
         base = tmp_path / "alpha"
         run1 = _make_run(base, "2026-01-01_00-00-00", "run1", {})
@@ -536,12 +519,23 @@ class TestHomeAsAZeroLevelSelector:
         with pytest.raises(ReferenceException3):
             _finder('$alpha.results.:home("x")', str(tmp_path)).query()
 
-    def test_prefixed_home_rejects_an_argument(self, tmp_path):
+    def test_prefixed_home_is_not_a_thing_use_the_literal_prefix_alone(
+        self, tmp_path
+    ):
+        # a literal prefix segment with nothing trailing already means
+        # "every run under this exact prefix, unreduced" -- confirmed
+        # this gives identical results to a would-be prefixed ':home()'
+        # in every case tested, so ':home()' was never wired up as a
+        # legal non-first path segment. This locks in that "beta/
+        # :home()" is simply unsupported syntax, not a silent no-op.
         base = tmp_path / "acme"
-        run1 = _make_run(base / "beta", "2026-01-01_00-00-00", "run1", {})
-        _write_archive_manifest(tmp_path, "acme", [run1])
+        beta1 = _make_run(base / "beta", "2026-01-01_00-00-00", "beta-1", {})
+        beta2 = _make_run(base / "beta", "2026-01-02_00-00-00", "beta-2", {})
+        _write_archive_manifest(tmp_path, "acme", [beta1, beta2])
+        plain_prefix = _finder("$acme.results.beta", str(tmp_path)).query()
+        assert set(plain_prefix.uuids) == {"beta-1", "beta-2"}
         with pytest.raises(ReferenceException3):
-            _finder('$acme.results.beta/:home("x")', str(tmp_path)).query()
+            _finder("$acme.results.beta/:home()", str(tmp_path)).query()
 
 
 class TestDiscoveryFromArchiveManifest:

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -125,6 +125,46 @@ def two_group_archive(tmp_path):
     return str(tmp_path)
 
 
+class TestRunDirSortKey:
+    # run directories collide within the same group+prefix+second more
+    # often than you would expect during test suite runs (confirmed by
+    # David) -- RunHomeMaker disambiguates with a plain, unpadded "_N"
+    # suffix starting at "_0". A naive lexicographic sort of the full
+    # directory name breaks once a collision count reaches double
+    # digits ("_10" sorts before "_9" as strings) -- these tests use
+    # "_9"/"_10" specifically to catch that, not just "does sorting
+    # work at all".
+    def test_double_digit_suffix_sorts_after_single_digit_within_one_group(
+        self, tmp_path
+    ):
+        base = tmp_path / "acme"
+        run_base = _make_run(base, "2026-01-01_00-00-00", "run-base-uuid", {})
+        run_9 = _make_run(base, "2026-01-01_00-00-00_9", "run-9-uuid", {})
+        run_10 = _make_run(base, "2026-01-01_00-00-00_10", "run-10-uuid", {})
+        _write_archive_manifest(tmp_path, "acme", [run_10, run_9, run_base])
+        results = _finder("$acme.results.:last()", str(tmp_path)).query()
+        assert results.uuids == ["run-10-uuid"]
+
+    def test_double_digit_suffix_sorts_after_single_digit_across_groups(
+        self, tmp_path
+    ):
+        base = tmp_path / "acme"
+        run_base = _make_run(base, "2026-01-01_00-00-00", "run-base-uuid", {})
+        run_9 = _make_run(base, "2026-01-01_00-00-00_9", "run-9-uuid", {})
+        run_10 = _make_run(base, "2026-01-01_00-00-00_10", "run-10-uuid", {})
+        _write_archive_manifest(tmp_path, "acme", [run_10, run_9, run_base])
+        results = _finder("$*.results.:last()", str(tmp_path)).query()
+        assert results.uuids == ["run-10-uuid"]
+
+    def test_unsuffixed_run_sorts_before_any_suffixed_collision(self, tmp_path):
+        base = tmp_path / "acme"
+        run_base = _make_run(base, "2026-01-01_00-00-00", "run-base-uuid", {})
+        run_0 = _make_run(base, "2026-01-01_00-00-00_0", "run-0-uuid", {})
+        _write_archive_manifest(tmp_path, "acme", [run_0, run_base])
+        results = _finder("$acme.results.:first()", str(tmp_path)).query()
+        assert results.uuids == ["run-base-uuid"]
+
+
 class TestVersionPointer:
     def test_last(self, acme_archive):
         results = _finder(

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -259,9 +259,18 @@ class TestBareFunctionOnlyNameOne:
         results = _finder("$flat.results.:first()", flat_archive).query()
         assert results.uuids == ["run1-uuid"]
 
-    def test_bare_all_returns_every_run(self, flat_archive):
-        results = _finder("$flat.results.:all()", flat_archive).query()
+    def test_bare_flatten_returns_every_run(self, flat_archive):
+        # ':all()' now requires exactly one level (settled 2026-08-11,
+        # same restriction '*' has) -- ':flatten()' is the right tool
+        # for "every run regardless of depth", including flat ones.
+        results = _finder("$flat.results.:flatten()", flat_archive).query()
         assert set(results.uuids) == {"run1-uuid", "run2-uuid"}
+
+    def test_bare_all_excludes_flat_runs(self, flat_archive):
+        # both of flat_archive's runs are zero-level (direct children) --
+        # ':all()' requires exactly one level, so it finds neither.
+        results = _finder("$flat.results.:all()", flat_archive).query()
+        assert results.uuids == []
 
     def test_bare_pointer_does_not_find_a_run_under_a_deep_template(
         self, acme_archive
@@ -408,18 +417,19 @@ class TestAllGrouping:
         results = _finder("$alpha.results.:all():first()", str(tmp_path)).query()
         assert set(results.uuids) == {"zero-1", "one-1"}
 
-    def test_all_with_no_pointer_keeps_its_own_unchanged_precedent(
+    def test_all_with_no_pointer_still_requires_exactly_one_level(
         self, tmp_path
     ):
-        # ':all()' alone (no pointer) is unaffected by grouping -- still
-        # every run for the group, any depth, unreduced, mirroring
-        # csvpaths' own bare ':all()' precedent.
+        # settled 2026-08-11: ':all()' stays '*'s one-level peer whether
+        # or not a pointer follows it -- the flat run is excluded here,
+        # same as it would be for "*" (illegal on its own, but this is
+        # the same restriction), unreduced since there is no pointer.
         base = tmp_path / "alpha"
         zero_run = _make_run(base / "zero", "2026-01-01_00-00-00", "zero-1", {})
         flat_run = _make_run(base, "2026-01-02_00-00-00", "flat-1", {})
         _write_archive_manifest(tmp_path, "alpha", [zero_run, flat_run])
         results = _finder("$alpha.results.:all()", str(tmp_path)).query()
-        assert set(results.uuids) == {"zero-1", "flat-1"}
+        assert results.uuids == ["zero-1"]
 
     def test_prefixed_all_groups_by_the_next_level(self, tmp_path):
         base = tmp_path / "acme"
@@ -452,11 +462,14 @@ class TestDiscoveryFromArchiveManifest:
     def test_dedupes_multiple_entries_sharing_one_run_home(self, tmp_path):
         # a real run_home is written once per csvpath-statement
         # execution -- several entries in the archive manifest can share
-        # the same run_home for one run with multiple statements.
+        # the same run_home for one run with multiple statements. Uses
+        # ':flatten()' rather than ':all()' -- run1 here is flat/zero-
+        # level, and this test is about discovery/dedup, not depth
+        # semantics.
         base = tmp_path / "acme"
         run1 = _make_run(base, "2026-01-01_00-00-00", "run1-uuid", {})
         _write_archive_manifest(tmp_path, "acme", [run1, run1, run1])
-        results = _finder("$acme.results.:all()", str(tmp_path)).query()
+        results = _finder("$acme.results.:flatten()", str(tmp_path)).query()
         assert results.uuids == ["run1-uuid"]
 
     def test_stale_entry_for_a_deleted_run_is_dropped(self, tmp_path):
@@ -464,7 +477,7 @@ class TestDiscoveryFromArchiveManifest:
         run1 = _make_run(base, "2026-01-01_00-00-00", "run1-uuid", {})
         deleted_run_home = str(base / "2025-06-06_00-00-00")
         _write_archive_manifest(tmp_path, "acme", [run1, deleted_run_home])
-        results = _finder("$acme.results.:all()", str(tmp_path)).query()
+        results = _finder("$acme.results.:flatten()", str(tmp_path)).query()
         assert results.uuids == ["run1-uuid"]
 
     def test_other_groups_entries_are_ignored(self, tmp_path):
@@ -481,7 +494,7 @@ class TestDiscoveryFromArchiveManifest:
                 {"named_paths_name": "other", "run_home": other_run},
             ],
         )
-        results = _finder("$acme.results.:all()", str(tmp_path)).query()
+        results = _finder("$acme.results.:flatten()", str(tmp_path)).query()
         assert results.uuids == ["acme-run-uuid"]
 
     def test_no_archive_manifest_yet_returns_empty_not_an_error(self, tmp_path):

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -69,6 +69,17 @@ def _write_archive_manifest(archive, group: str, run_homes: list[str]) -> None:
     _write_json(archive / "manifest.json", entries)
 
 
+def _write_archive_manifest_multi(archive, groups: dict) -> None:
+    """like _write_archive_manifest, but merges more than one group's
+    entries into a single archive manifest.json write -- needed for '*'
+    traversal tests, since _write_archive_manifest overwrites rather
+    than appends. groups: {group_name: [run_home, ...]}."""
+    entries = []
+    for group, run_homes in groups.items():
+        entries.extend({"named_paths_name": group, "run_home": rh} for rh in run_homes)
+    _write_json(archive / "manifest.json", entries)
+
+
 def _finder(reference: str, archive: str) -> ResultsReferenceFinder3:
     csvpaths = _FakeCsvPaths(archive)
     ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
@@ -86,6 +97,31 @@ def acme_archive(tmp_path):
     )
     run2 = _make_run(base, "2026-01-02_00-00-00", "run2-uuid", {"0": "inst3-uuid"})
     _write_archive_manifest(tmp_path, "acme", [run1, run2])
+    return str(tmp_path)
+
+
+@pytest.fixture
+def two_group_archive(tmp_path):
+    # acme (2 runs) + widgets (1 run, chronologically LATEST overall).
+    # widgets is written FIRST in the merged manifest on purpose -- a
+    # naive (unsorted) "last" would give acme's own last run
+    # (2026-01-02) instead of the true global-latest (widgets',
+    # 2026-01-03), so this fails if the '*' traversal sort-by-trailing-
+    # segment logic is ever removed/broken.
+    acme_base = tmp_path / "acme" / "customers" / "2025"
+    acme_run1 = _make_run(acme_base, "2026-01-01_00-00-00", "acme-run1-uuid", {})
+    acme_run2 = _make_run(acme_base, "2026-01-02_00-00-00", "acme-run2-uuid", {})
+    widgets_base = tmp_path / "widgets"
+    widgets_run1 = _make_run(
+        widgets_base, "2026-01-03_00-00-00", "widgets-run1-uuid", {}
+    )
+    _write_archive_manifest_multi(
+        tmp_path,
+        {
+            "widgets": [widgets_run1],
+            "acme": [acme_run1, acme_run2],
+        },
+    )
     return str(tmp_path)
 
 
@@ -819,10 +855,15 @@ class TestGlobalArchiveLedger:
         assert isinstance(data, list)
         assert {e["named_paths_name"] for e in data} == {"acme"}
 
-    def test_star_with_a_pointer_is_still_not_supported(self, acme_archive):
+    def test_star_with_a_bare_pointer_is_supported(self, acme_archive):
+        # '*' traversal is supported now for the bare-pointer case (see
+        # TestStarTraversal below) -- with only one named-results group
+        # in this fixture, this just confirms it resolves to that
+        # group's own last run rather than raising.
         finder = _finder("$*.results.:last()", acme_archive)
-        with pytest.raises(ReferenceException3):
-            finder.query()
+        results = finder.query()
+        assert len(results.results) == 1
+        assert results.results[0].uuid == "run2-uuid"
 
     def test_star_with_path_narrowing_is_still_not_supported(self, acme_archive):
         finder = _finder("$*.results.customers/2025:last()", acme_archive)
@@ -870,6 +911,45 @@ class TestGlobalArchiveLedgerOrdinalIndexing:
         results = _finder("$*.results.:last():manifest()", archive).query()
         assert results.files == [f"{archive}/manifest.json"]
         assert results.results[0].uuid == "run-3"
+
+
+class TestStarTraversal:
+    # only the bare-pointer flatten case is supported for results (see
+    # _query_star_traversal's own docstring for why) -- every named-
+    # results group's discovered runs pool into one combined list,
+    # sorted by each run directory's own trailing timestamp segment
+    # (not the full path, which would sort by group name first when
+    # pooling across groups), reduced by one terminal pointer.
+    def test_last_across_every_group_is_the_true_most_recent(self, two_group_archive):
+        # widgets' only run (2026-01-03) is the global most-recent, not
+        # acme's own last run (2026-01-02) -- proves pooling crosses
+        # groups and is truly sorted by timestamp, not enumeration
+        # order (widgets is written first in the merged manifest).
+        results = _finder("$*.results.:last()", two_group_archive).query()
+        assert len(results.results) == 1
+        assert results.results[0].uuid == "widgets-run1-uuid"
+
+    def test_first_across_every_group_is_the_true_earliest(self, two_group_archive):
+        results = _finder("$*.results.:first()", two_group_archive).query()
+        assert results.results[0].uuid == "acme-run1-uuid"
+
+    def test_index_selects_by_chronological_position(self, two_group_archive):
+        # chronological order: acme-run1, acme-run2, widgets-run1
+        results = _finder("$*.results.:index(1)", two_group_archive).query()
+        assert results.results[0].uuid == "acme-run2-uuid"
+
+    def test_all_is_not_yet_supported(self, two_group_archive):
+        # results' own :all() already means "every instance within one
+        # run" (name_three) -- no syntactic home for group-by-group
+        # traversal semantics exists yet, unlike files/csvpaths.
+        with pytest.raises(ReferenceException3):
+            _finder("$*.results.:all()", two_group_archive).query()
+
+    def test_name_three_combined_with_traversal_is_not_yet_supported(
+        self, two_group_archive
+    ):
+        with pytest.raises(ReferenceException3):
+            _finder("$*.results.:last().0", two_group_archive).query()
 
 
 class TestScopeLimits:

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -952,6 +952,15 @@ class TestGlobalArchiveLedgerOrdinalIndexing:
         assert results.files == [f"{archive}/manifest.json"]
         assert results.results[0].uuid == "run-3"
 
+    def test_manifest_then_pointer_order_also_works(self, tmp_path):
+        # order-insensitivity was missing on _pointer_before_manifest
+        # and fixed 2026-08-10 -- this exact shape previously fell
+        # through to _query_star_traversal's own "not yet supported"
+        # raise instead of being recognized as Rule 1b.
+        archive = self._archive(tmp_path)
+        results = _finder("$*.results.:manifest():last()", archive).query()
+        assert results.results[0].uuid == "run-3"
+
 
 class TestStarTraversal:
     # only the bare-pointer flatten case is supported for results (see

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -458,6 +458,92 @@ class TestAllGrouping:
             ).query()
 
 
+class TestHomeAsAZeroLevelSelector:
+    # settled 2026-08-11: bare ':home()' (David's own framing --
+    # "everything that has its home here") fills the one real gap left
+    # in the depth model -- there was no way to ask for "every zero-
+    # level run, unreduced" (bare pointer always reduces to one, ':all()'
+    # is one-level not zero, ':flatten()' is any depth not zero). Works
+    # at both the root (no code change needed -- ':home()' is VALUE-
+    # role, never a pointer, so it naturally falls through to the
+    # existing zero-level, no-pointer candidate set) and prefixed
+    # (new code, mirrors :all()/:flatten()'s own prefixed branches).
+    def test_bare_home_lists_every_zero_level_run_unreduced(self, tmp_path):
+        base = tmp_path / "alpha"
+        flat1 = _make_run(base, "2026-01-01_00-00-00", "flat-1", {})
+        flat2 = _make_run(base, "2026-01-02_00-00-00", "flat-2", {})
+        one_level = _make_run(base / "zero", "2026-01-03_00-00-00", "one-level", {})
+        _write_archive_manifest(tmp_path, "alpha", [flat1, flat2, one_level])
+        results = _finder("$alpha.results.:home()", str(tmp_path)).query()
+        assert set(results.uuids) == {"flat-1", "flat-2"}
+
+    def test_home_then_pointer_reduces_to_one(self, tmp_path):
+        base = tmp_path / "alpha"
+        flat1 = _make_run(base, "2026-01-01_00-00-00", "flat-1", {})
+        flat2 = _make_run(base, "2026-01-02_00-00-00", "flat-2", {})
+        _write_archive_manifest(tmp_path, "alpha", [flat1, flat2])
+        results = _finder("$alpha.results.:home():last()", str(tmp_path)).query()
+        assert results.uuids == ["flat-2"]
+
+    def test_pointer_then_home_gives_the_same_result_either_order(
+        self, tmp_path
+    ):
+        # order-independence: ':home()' is not a pointer, so its own
+        # presence never competes with a real pointer for which one
+        # "wins" -- both orders mean the same thing.
+        base = tmp_path / "alpha"
+        flat1 = _make_run(base, "2026-01-01_00-00-00", "flat-1", {})
+        flat2 = _make_run(base, "2026-01-02_00-00-00", "flat-2", {})
+        _write_archive_manifest(tmp_path, "alpha", [flat1, flat2])
+        home_then_pointer = _finder(
+            "$alpha.results.:home():last()", str(tmp_path)
+        ).query()
+        pointer_then_home = _finder(
+            "$alpha.results.:last():home()", str(tmp_path)
+        ).query()
+        assert home_then_pointer.uuids == pointer_then_home.uuids == ["flat-2"]
+
+    def test_prefixed_home_lists_every_run_directly_under_the_prefix(
+        self, tmp_path
+    ):
+        base = tmp_path / "acme"
+        beta1 = _make_run(base / "beta", "2026-01-01_00-00-00", "beta-1", {})
+        beta2 = _make_run(base / "beta", "2026-01-02_00-00-00", "beta-2", {})
+        beta_deep = _make_run(
+            base / "beta" / "x", "2026-01-03_00-00-00", "beta-deep", {}
+        )
+        other = _make_run(base / "gamma", "2026-01-04_00-00-00", "other", {})
+        _write_archive_manifest(
+            tmp_path, "acme", [beta1, beta2, beta_deep, other]
+        )
+        results = _finder("$acme.results.beta/:home()", str(tmp_path)).query()
+        assert set(results.uuids) == {"beta-1", "beta-2"}
+
+    def test_prefixed_home_then_pointer_reduces_to_one(self, tmp_path):
+        base = tmp_path / "acme"
+        beta1 = _make_run(base / "beta", "2026-01-01_00-00-00", "beta-1", {})
+        beta2 = _make_run(base / "beta", "2026-01-02_00-00-00", "beta-2", {})
+        _write_archive_manifest(tmp_path, "acme", [beta1, beta2])
+        results = _finder(
+            "$acme.results.beta/:home():last()", str(tmp_path)
+        ).query()
+        assert results.uuids == ["beta-2"]
+
+    def test_bare_home_rejects_an_argument(self, tmp_path):
+        base = tmp_path / "alpha"
+        run1 = _make_run(base, "2026-01-01_00-00-00", "run1", {})
+        _write_archive_manifest(tmp_path, "alpha", [run1])
+        with pytest.raises(ReferenceException3):
+            _finder('$alpha.results.:home("x")', str(tmp_path)).query()
+
+    def test_prefixed_home_rejects_an_argument(self, tmp_path):
+        base = tmp_path / "acme"
+        run1 = _make_run(base / "beta", "2026-01-01_00-00-00", "run1", {})
+        _write_archive_manifest(tmp_path, "acme", [run1])
+        with pytest.raises(ReferenceException3):
+            _finder('$acme.results.beta/:home("x")', str(tmp_path)).query()
+
+
 class TestDiscoveryFromArchiveManifest:
     def test_dedupes_multiple_entries_sharing_one_run_home(self, tmp_path):
         # a real run_home is written once per csvpath-statement


### PR DESCRIPTION
## Summary

Follow-up to #240 (root_major == "*" traversal, flatten+group, for FILES). Expands the same capability to CSVPATHS and RESULTS -- confirmed via research first that neither datatype could reuse the FILES shape verbatim, so each generalizes its own already-established single-entity precedent instead of copying #240's code.

**CSVPATHS**: the version-selecting pointer and `:all()` both already live in name_one's own combined chain (`_resolve_versions`), not name_three the way files uses.
- Flatten (bare pointer, no `:all()`): every named-paths group's whole manifest pools into one combined list, sorted by each entry's own "time" for true chronological order, one pointer reduces it.
- Group (`:all()` present in the chain, e.g. `:all():last()`): the pointer is applied independently within each group's own manifest -- one result per group. With `:all()` and no pointer, extends csvpaths' own existing single-group precedent (every version, unreduced) across every group, since there is no path dimension to dedupe to.

**RESULTS**: deliberately the narrowest of the three. Its own `:all()` already means something different (pooling every csvpath-statement instance within one run, at name_three) -- there is no existing syntactic home for group-by-group traversal semantics. Path narrowing across groups would need per-entry group tracking that does not exist today. So this PR supports only the bare-pointer flatten case (`$*.results.:last()`/`:first()`/`:index(n)`) -- "the most recent run, period, across every group." Generalized `_discover_run_homes()` with an optional group filter (it already reads the same archive-wide ledger Rule 1a/1b use, so no new enumeration primitive was needed) and reused `_results_for_run()`'s existing no-name_three case unchanged. One real design point: pooled run_homes are sorted by their own trailing directory-name segment, not the full path -- a full-path sort would incorrectly sort by group name first when pooling across groups.

Both stay deliberately narrow past their supported shapes, same discipline as #240: combining traversal with `:manifest()`/field-accessors/name_three raises clearly rather than guessing.

## Test plan

- [x] New tests prove real cross-group behavior (not single-entity coincidence): fixtures deliberately order groups so a broken/removed sort would fail rather than pass by enumeration-order coincidence
- [x] Stale "not yet supported" tests updated to reflect newly-supported shapes; the deliberately-deferred shapes (RESULTS path narrowing, `:all()`/name_three combined with traversal for both) still raise, with updated reasons
- [x] Live check against real `Builder()`-registered named-paths groups and real runs for both datatypes
- [x] Full suite: 2313 passed, same known 11-failure SFTP/S3/Nos baseline

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
