### PR TITLE
Make :uuid() mirror :run_uuid() at RESULTS run scope

### DIFF
--- a/csvpath/references/functions/fields/uuid_3.py
+++ b/csvpath/references/functions/fields/uuid_3.py
@@ -11,22 +11,27 @@ class Uuid3(Function3):
     # :manifest() itself rides alongside a pointer, except this pulls one
     # field out instead of handing back the whole entry.
     #
-    # RESULTS is instance-only (Reference3.RESULT, not Reference3.
-    # RESULTS): a run's own bare "uuid" field (table 5) is the excluded,
-    # vestigial one (see project_manifest_field_review_issues) -- an
-    # instance's own "uuid" (table 6) is the real, meaningful one. No
-    # Reference3.RESULTS entry means :uuid() used at run scope correctly
-    # resolves to None (_extract_field_value's tolerant missing-key
-    # behavior) rather than accidentally surfacing the deprecated field.
-    # See run_uuid_3.py for "which run this belongs to" instead.
+    # RESULTS run scope reads "run_uuid", not the run's own bare "uuid"
+    # field (table 5) -- that field is deprecated/vestigial (see
+    # project_manifest_field_review_issues) and its setter already
+    # mirrors run_uuid's value (PR #231), so reading run_uuid here gives
+    # the identical value without resurrecting any dependency on the
+    # field slated for eventual removal. Settled 2026-08-11: "this
+    # entity's own id" and "which run this belongs to" trivially
+    # coincide AT run scope (the run has no further container above it
+    # to diverge from) -- the caution that is genuinely needed at
+    # instance scope (an instance's own id really is different from its
+    # containing run's) does not apply at run scope, so :uuid() should
+    # not withhold a value there the way it used to. See run_uuid_3.py
+    # for the same value under its own, always-available name.
     #
     NAME = "uuid"
     SUMMARY = (
         "The uuid of the resolved named-file/named-paths version, or "
-        "results instance -- the registration/load/instance event's own "
-        "identifier, read straight off its manifest entry. Not "
-        "available at RESULTS run scope -- that field is deprecated; "
-        "see :run_uuid()."
+        "results run/instance -- the registration/load/run/instance "
+        "event's own identifier. At RESULTS run scope this is the same "
+        "value as :run_uuid() (the run's own bare 'uuid' field is "
+        "deprecated and not read here)."
     )
     ROLE = Function3.VALUE
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
@@ -36,5 +41,6 @@ class Uuid3(Function3):
     KEY = {
         Reference3.FILES: "uuid",
         Reference3.CSVPATHS: "uuid",
+        Reference3.RESULTS: "run_uuid",
         Reference3.RESULT: "uuid",
     }

--- a/tests/references/functions/fields/test_uuid_3.py
+++ b/tests/references/functions/fields/test_uuid_3.py
@@ -19,6 +19,7 @@ def test_metadata():
     assert f.KEY == {
         Reference3.FILES: "uuid",
         Reference3.CSVPATHS: "uuid",
+        Reference3.RESULTS: "run_uuid",
         Reference3.RESULT: "uuid",
     }
 

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -393,16 +393,17 @@ class TestFieldAccessorFunctions:
         ).resolve()
         assert results.results[0].data == "inst1-uuid"
 
-    def test_uuid_at_run_scope_gives_none_not_the_deprecated_field(
+    def test_uuid_at_run_scope_mirrors_run_uuid_not_the_deprecated_field(
         self, acme_archive
     ):
-        # :uuid()'s KEY has no Reference3.RESULTS entry at all -- run
-        # scope's own bare "uuid" is the deprecated field (see #225-
-        # adjacent findings) -- this must not accidentally surface it.
+        # settled 2026-08-11: :uuid()'s KEY reads "run_uuid" at RESULTS
+        # run scope, not the run's own bare "uuid" field (deprecated,
+        # see #225-adjacent findings) -- this must give the same value
+        # :run_uuid() gives, not None and not the deprecated field.
         results = _finder(
             "$acme.results.customers/2025:first():uuid()", acme_archive
         ).resolve()
-        assert results.results[0].data is None
+        assert results.results[0].data == "run1-uuid"
 
     def test_run_level_field_accessor_combined_with_name_three_raises(
         self, acme_archive


### PR DESCRIPTION
## Summary

David caught this while reviewing the new normative_reference_examples.txt doc: :uuid() previously had no KEY entry for RESULTS run scope at all, deliberately withholding a value to avoid surfacing the deprecated run-scope "uuid" manifest field. That caution was right for the field itself, but went further than necessary -- it forced anyone asking for a run's own identifier to remember a RESULTS-specific exception and reach for :run_uuid() instead of the otherwise-universal :uuid().

At run scope, "this entitys own id" and "which run this belongs to" trivially coincide -- the run has no further container above it to diverge from, unlike instance scope, where an instance genuinely has its own separate identity from the run it lives in. The caution instance scope needs does not apply at run scope.

Fixed by pointing Uuid3s RESULTS KEY entry at "run_uuid" instead of leaving it unset -- reads the exact same, already-mirrored value :run_uuid() reads (the ResultsMetadata setter mirroring from PR #231), without resurrecting any dependency on the deprecated "uuid" field itself, which stays untouched and free to be removed later.

## Test plan

- [x] Updated the existing test that asserted None to assert the new mirrored value instead (its own stated purpose -- do not surface the deprecated field -- is unchanged, it is just pointed at the correct source field now)
- [x] Updated Uuid3s own metadata unit test for the new KEY entry
- [x] Live check against a real registered run: :uuid() and :run_uuid() now give the identical value
- [x] Full suite: 2300 passed, same known 11-failure SFTP/S3/Nos baseline

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
