### PR TITLE
FILES: :all() for one named-file + normative examples test

### DIFF
--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -60,7 +60,14 @@ class FilesReferenceFinder3(ReferenceFinder3):
     #    the matched version's own manifest entry) or appear alone with
     #    no pointer at all (e.g. ":manifest()" alone -- every matching
     #    version's entry, unreduced) -- it never narrows/selects itself,
-    #    see functions/manifest_3.py. name_three is
+    #    see functions/manifest_3.py. ":all()" is also legal in
+    #    name_three -- settled 2026-08-12, mirroring CSVPATHS' own
+    #    ":all()" precedent exactly (it is not a POINTER, so its whole
+    #    effect is simply NOT reducing -- "$alpha.files.:name(...).
+    #    :all()" gives every matched version, unreduced, with real
+    #    paths/uuids -- unlike name_three being absent entirely, which
+    #    dedupes to directory-level results with uuid=None instead).
+    #    name_three is
     #    optional: when absent, name_one alone is a prefix search that
     #    returns zero or more paths to file-home directories (one per
     #    distinct file matched, deduplicated across versions) -- per
@@ -170,6 +177,27 @@ class FilesReferenceFinder3(ReferenceFinder3):
             candidates = self._candidates_for_name(root_major, [Star3()])
         elif is_flattened or is_deep_grouped:
             candidates = self._all_candidates_for_name(root_major)
+        elif self._is_bare_home_reference(name_one):
+            # ':home()' as name_one's entire content -- a zero-level
+            # selector, added 2026-08-12, mirroring RESULTS' own
+            # ':home()' (David: keep functions meaning the same thing
+            # across datatypes). Unlike RESULTS, this does NOT fall out
+            # for free -- name_one can never be empty for FILES (the
+            # grammar requires something after the last "."), so there
+            # is no pre-existing "no pattern" code path for a bare
+            # pointer to piggyback on the way RESULTS' bare pointer did.
+            # Reuses the existing exact-length _matches machinery with
+            # an EMPTY pattern (already correctly requires zero
+            # intermediate segments, i.e. file_home == root_major's own
+            # home directory exactly) -- no new matching primitive
+            # needed. Does not collide with ':home()'s ordinary job as
+            # a field accessor in name_three (SOURCE == "manifest",
+            # reading the "file_home" key off a matched candidate) --
+            # different position, different code path, and bare
+            # ':home()' in name_one was previously unreachable/
+            # undefined (only SOURCE == "definition" functions get bare
+            # treatment via _bare_definition_field_call).
+            candidates = self._candidates_for_name(root_major, [])
         elif self._is_flatten_prefixed_reference(name_one):
             # ':flatten()' as name_one's FIRST segment, followed by more
             # path -- settled 2026-08-12, David: "the last version of
@@ -230,12 +258,19 @@ class FilesReferenceFinder3(ReferenceFinder3):
         has_manifest = any(f.name == "manifest" for f in built)
         has_field_function = self._find_field_function_call(built) is not None
         has_path = self._find_path_call(built) is not None
-        if not pointers and not has_manifest and not has_field_function and not has_path:
+        has_all = any(f.name == "all" for f in built)
+        if (
+            not pointers
+            and not has_manifest
+            and not has_field_function
+            and not has_path
+            and not has_all
+        ):
             raise ReferenceException3(
                 "FilesReferenceFinder3 requires name_three to resolve to "
                 "exactly one pointer function (:first()/:last()/:index(n)), "
-                "optionally combined with :manifest(), :path(), or a "
-                "registered field-accessor function (e.g. :uuid())."
+                "optionally combined with :manifest(), :path(), :all(), or "
+                "a registered field-accessor function (e.g. :uuid())."
             )
 
         if partitioned and pointers and (has_manifest or has_field_function or has_path):
@@ -520,6 +555,20 @@ class FilesReferenceFinder3(ReferenceFinder3):
             and len(name_one.path) == 1
             and isinstance(name_one.path[0], FunctionCall3)
             and name_one.path[0].name == "groups"
+            and name_one.path[0].arg is None
+        )
+
+    @staticmethod
+    def _is_bare_home_reference(name_one) -> bool:
+        """same shape as _is_bare_all_reference/_is_bare_flatten_
+        reference/_is_bare_groups_reference, for ':home()' -- a zero-
+        level selector when it is name_one's entire content (settled
+        2026-08-12). Structurally exclusive with all three siblings."""
+        return (
+            not name_one.functions
+            and len(name_one.path) == 1
+            and isinstance(name_one.path[0], FunctionCall3)
+            and name_one.path[0].name == "home"
             and name_one.path[0].arg is None
         )
 

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -26,29 +26,31 @@ class FilesReferenceFinder3(ReferenceFinder3):
     #  - name_one is "*", a literal path segment, :name("...") (for a
     #    literal name containing characters -- e.g. a real filename's
     #    "." -- that cannot appear in a bare PATH_SEGMENT), a bare
-    #    ':all()', or a bare ':flatten()' -- these last two settled/
-    #    corrected 2026-08-12, kept deliberately in lockstep with
-    #    ResultsReferenceFinder3's own depth vocabulary (David: keep
-    #    functions meaning the same thing across datatypes wherever the
-    #    underlying structure supports it -- FILES has the same
-    #    "variable, not-known-in-advance path depth" structure RESULTS
-    #    does): ':all()' is a one-level GROUP, an exact peer of '*'
-    #    (same [Star3()] pattern, but partitioned by file_home and
-    #    reduced independently per partition instead of pooled) --
-    #    reaches each distinct one-level path's own latest version.
-    #    ':flatten()' is the any-depth POOL peer -- every distinct
-    #    file_home under this name, at any depth, into ONE pooled
-    #    answer. Any-depth GROUPED (reaching a mixed-depth name's every
-    #    distinct path independently) is deliberately NOT built --
-    #    that would be a ':groups()' analog, deferred here exactly like
-    #    ResultsReferenceFinder3 defers it. ':all()' combined with
-    #    :manifest()/:path()/a field-accessor function is not yet
+    #    ':all()', a bare ':flatten()', or a bare ':groups()' -- the
+    #    last three settled/corrected 2026-08-12, kept deliberately in
+    #    lockstep with ResultsReferenceFinder3's own depth vocabulary
+    #    (David: keep functions meaning the same thing across datatypes
+    #    wherever the underlying structure supports it -- FILES has the
+    #    same "variable, not-known-in-advance path depth" structure
+    #    RESULTS does). Full 2x2 depth matrix: ':all()' is a one-level
+    #    GROUP, an exact peer of '*' (one-level POOL) -- same [Star3()]
+    #    pattern, partitioned by file_home and reduced independently per
+    #    partition instead of pooled. ':flatten()' is the any-depth POOL
+    #    peer -- every distinct file_home under this name, at any depth,
+    #    into ONE pooled answer. ':groups()' is the any-depth GROUP peer
+    #    -- same any-depth candidate set as ':flatten()', but partitioned
+    #    by file_home like ':all()', reaching each distinct path's own
+    #    latest version even when a name's paths do not all sit at the
+    #    same depth (the case that originally motivated this whole
+    #    depth-matrix pass). ':all()'/':groups()' (both GROUP) combined
+    #    with :manifest()/:path()/a field-accessor function is not yet
     #    supported (same under-specified-interaction reasoning as
     #    ResultsReferenceFinder3's own ':all()' restriction) --
-    #    ':flatten()' has no such restriction here, since root_major is
-    #    always known at this position (unlike '*' traversal below).
-    #    Any other function-valued segment (e.g. :quarter()) and the
-    #    "#worksheet" marker (name_two) are not yet supported.
+    #    ':flatten()' (POOL) has no such restriction here, since
+    #    root_major is always known at this position (unlike '*'
+    #    traversal below). Any other function-valued segment (e.g.
+    #    :quarter()) and the "#worksheet" marker (name_two) are not yet
+    #    supported.
     #  - name_three, if present, must resolve to exactly one pointer
     #    function (:first()/:last()/:index(n)) -- matching the
     #    STRUCTURE table: name_one picks *which file*, name_three picks
@@ -132,19 +134,23 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "directly to name_one -- put the version-selecting function in "
                 "name_three instead."
             )
-        # bare ':all()'/':flatten()' for ONE named-file -- see the class
-        # docstring's 2026-08-12 note. ':all()' is a one-level GROUP,
-        # exactly the pattern '*' already matches, just partitioned by
-        # file_home and reduced per-partition below instead of pooled.
-        # ':flatten()' is the any-depth POOL peer, filling the real gap
-        # a literal/'*' pattern cannot (an exact segment count) without
-        # over-reaching into "group at any depth too," which stays
-        # deferred (':groups()', not built).
+        # bare ':all()'/':flatten()'/':groups()' for ONE named-file --
+        # see the class docstring's 2026-08-12 note. ':all()' is a
+        # one-level GROUP, exactly the pattern '*' already matches, just
+        # partitioned by file_home and reduced per-partition below
+        # instead of pooled. ':flatten()'/':groups()' both match at ANY
+        # depth (the real gap a literal/'*' pattern cannot reach, an
+        # exact segment count) -- ':flatten()' pools that any-depth set
+        # into one answer, ':groups()' partitions it by file_home like
+        # ':all()' does, just over the any-depth set instead of the
+        # one-level one.
         is_grouped = self._is_bare_all_reference(name_one)
         is_flattened = self._is_bare_flatten_reference(name_one)
+        is_deep_grouped = self._is_bare_groups_reference(name_one)
+        partitioned = is_grouped or is_deep_grouped
         if is_grouped:
             candidates = self._candidates_for_name(root_major, [Star3()])
-        elif is_flattened:
+        elif is_flattened or is_deep_grouped:
             candidates = self._all_candidates_for_name(root_major)
         else:
             pattern = self._compile_path_pattern(name_one.path)
@@ -182,28 +188,29 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "registered field-accessor function (e.g. :uuid())."
             )
 
-        if is_grouped and pointers and (has_manifest or has_field_function or has_path):
+        if partitioned and pointers and (has_manifest or has_field_function or has_path):
             # mirrors ResultsReferenceFinder3's own ':all()'-grouping
-            # restriction (settled 2026-08-11 there): grouping plus
-            # :manifest()/:path()/a field-accessor is an under-specified
-            # interaction, not decided -- resolve the grouped versions
-            # on their own first, rather than guessing what "the
-            # manifest entry of every group's own latest version, all at
-            # once" should even resolve to.
+            # restriction (settled 2026-08-11 there): grouping (one-
+            # level ':all()' or any-depth ':groups()') plus :manifest()/
+            # :path()/a field-accessor is an under-specified interaction,
+            # not decided -- resolve the grouped versions on their own
+            # first, rather than guessing what "the manifest entry of
+            # every group's own latest version, all at once" should even
+            # resolve to.
             raise ReferenceException3(
                 "FilesReferenceFinder3 does not yet support combining "
-                "':all()' grouping with :manifest(), :path(), or a "
-                "field-accessor function -- resolve the grouped versions "
-                "on their own first."
+                "':all()'/':groups()' grouping with :manifest(), :path(), "
+                "or a field-accessor function -- resolve the grouped "
+                "versions on their own first."
             )
 
         if pointers:
-            if is_grouped:
+            if partitioned:
                 # one independent reduction per distinct file_home, not
                 # one pooled answer across all of them -- mirrors
-                # _query_star_traversal's own is_grouped branch, scoped
-                # to this one named-file's own candidates instead of
-                # every named-file's.
+                # _query_star_traversal's own is_grouped/is_deep_grouped
+                # branch, scoped to this one named-file's own candidates
+                # instead of every named-file's.
                 by_file_home = {}
                 for entry in candidates:
                     by_file_home.setdefault(entry["file_home"], []).append(entry)
@@ -248,7 +255,7 @@ class FilesReferenceFinder3(ReferenceFinder3):
 
     def _query_star_traversal(self, reference: Reference3) -> ReferenceResults3:
         """root_major == "*" -- query across every named-file, not just
-        one. Three distinct semantics, corrected/extended 2026-08-12 to
+        one. Four distinct semantics, corrected/extended 2026-08-12 to
         match ResultsReferenceFinder3's own depth vocabulary exactly
         (David: keep functions meaning the same thing across datatypes):
 
@@ -271,16 +278,20 @@ class FilesReferenceFinder3(ReferenceFinder3):
           depth): every named-file's candidates AT ANY DEPTH pool into
           one combined list, time-sorted and reduced exactly like the
           '*' case above -- the any-depth counterpart '*' cannot reach
-          (an exact segment count). Any-depth GROUPED stays deferred
-          (a ':groups()' analog, not built), matching
-          ResultsReferenceFinder3's own deferral.
+          (an exact segment count).
+        - bare ':groups()' as name_one's entire content (GROUP, any
+          depth): same any-depth candidate gathering as ':flatten()',
+          but partitioned by file_home like ':all()' instead of pooled
+          -- one result per (named-file, path) pair regardless of how
+          deep that pair's own path happens to be.
 
         Deliberately narrow for now, matching only the spec's own worked
-        examples: combining '*'/':flatten()' traversal with :manifest()/
-        :path()/a field-accessor function in name_three is not yet
-        supported -- those all assume exactly one already-known manifest
-        to re-read in _extract_data(), which does not hold when a result
-        could have come from any of several named-files' manifests.
+        examples: combining '*'/':flatten()'/':groups()' traversal with
+        :manifest()/:path()/a field-accessor function in name_three is
+        not yet supported -- those all assume exactly one already-known
+        manifest to re-read in _extract_data(), which does not hold when
+        a result could have come from any of several named-files'
+        manifests.
         """
         name_one = reference.name_one
         if name_one.name_two is not None:
@@ -290,11 +301,13 @@ class FilesReferenceFinder3(ReferenceFinder3):
             )
         is_grouped = self._is_bare_all_reference(name_one)
         is_flattened = self._is_bare_flatten_reference(name_one)
+        is_deep_grouped = self._is_bare_groups_reference(name_one)
+        partitioned = is_grouped or is_deep_grouped
         if is_grouped:
             candidates = []
             for name in self.csvpaths.file_manager.named_file_names:
                 candidates.extend(self._candidates_for_name(name, [Star3()]))
-        elif is_flattened:
+        elif is_flattened or is_deep_grouped:
             candidates = []
             for name in self.csvpaths.file_manager.named_file_names:
                 candidates.extend(self._all_candidates_for_name(name))
@@ -351,7 +364,7 @@ class FilesReferenceFinder3(ReferenceFinder3):
             )
         pointer = pointers[0]
 
-        if is_grouped:
+        if partitioned:
             by_file_home = {}
             for entry in candidates:
                 by_file_home.setdefault(entry["file_home"], []).append(entry)
@@ -385,11 +398,14 @@ class FilesReferenceFinder3(ReferenceFinder3):
 
     def _all_candidates_for_name(self, name: str) -> list:
         """every manifest entry for one named-file, at any path depth --
-        ':flatten()' matches unconditionally, unlike a pattern (which
-        must match an exact segment count), so this skips _matches
-        entirely. Shared by '*' traversal's own is_flattened branch
-        (every named-file) and query()'s literal-root_major is_flattened
-        branch (this one named-file only)."""
+        ':flatten()'/':groups()' both match unconditionally, unlike a
+        pattern (which must match an exact segment count), so this skips
+        _matches entirely. Shared by '*' traversal's own is_flattened/
+        is_deep_grouped branch (every named-file) and query()'s
+        literal-root_major is_flattened/is_deep_grouped branch (this one
+        named-file only) -- ':groups()' differs from ':flatten()' only in
+        what happens AFTER gathering (partitioned vs. pooled), not in
+        which candidates are gathered."""
         manifest = self.csvpaths.file_manager.get_manifest(name)
         home = self.csvpaths.file_manager.named_file_home(name).rstrip("/")
         return [
@@ -423,6 +439,21 @@ class FilesReferenceFinder3(ReferenceFinder3):
             and len(name_one.path) == 1
             and isinstance(name_one.path[0], FunctionCall3)
             and name_one.path[0].name == "flatten"
+            and name_one.path[0].arg is None
+        )
+
+    @staticmethod
+    def _is_bare_groups_reference(name_one) -> bool:
+        """same shape as _is_bare_all_reference/_is_bare_flatten_
+        reference, for ':groups()' -- structurally exclusive with both
+        (a single FunctionCall3 cannot be named "all"/"flatten"/"groups"
+        at once), so callers never need to guard against more than one
+        being true together."""
+        return (
+            not name_one.functions
+            and len(name_one.path) == 1
+            and isinstance(name_one.path[0], FunctionCall3)
+            and name_one.path[0].name == "groups"
             and name_one.path[0].arg is None
         )
 

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -170,6 +170,38 @@ class FilesReferenceFinder3(ReferenceFinder3):
             candidates = self._candidates_for_name(root_major, [Star3()])
         elif is_flattened or is_deep_grouped:
             candidates = self._all_candidates_for_name(root_major)
+        elif self._is_flatten_prefixed_reference(name_one):
+            # ':flatten()' as name_one's FIRST segment, followed by more
+            # path -- settled 2026-08-12, David: "the last version of
+            # all orders.csv no matter how many template levels from 0
+            # to n" ($alpha.files.:flatten()/:name("orders.csv").:last()).
+            # The mirror image of RESULTS' own prefixed ':flatten()'
+            # (literal-prefix, THEN any depth) -- here the any-depth
+            # part comes first and a fixed literal/'*'/:name(...) suffix
+            # pattern (everything after it) anchors the end. Matches ANY
+            # number of segments, including zero, before that suffix --
+            # same "any depth, including a direct/zero-level match"
+            # convention bare ':flatten()' already uses.
+            if name_one.path[0].arg is not None:
+                raise ReferenceException3(
+                    "FilesReferenceFinder3's ':flatten()' does not take an "
+                    "argument."
+                )
+            suffix_pattern = self._compile_path_pattern(name_one.path[1:])
+            candidates = self._candidates_for_name_by_suffix(root_major, suffix_pattern)
+        # NOT YET BUILT, deferred 2026-08-12 (David wants it eventually,
+        # not now): a literal prefix BEFORE ':flatten()', e.g.
+        # "2025/:flatten()/:name('orders.csv')" -- "any orders.csv
+        # below 2025, at any depth in between." Falls through to the
+        # ordinary _compile_path_pattern branch below today, which
+        # raises cleanly (":flatten() as a name_one path segment" is
+        # unsupported there) rather than matching silently wrong -- see
+        # TestFlattenPrefixedWithSuffix::
+        # test_a_literal_prefix_before_flatten_is_not_yet_supported.
+        # Expected to be additive when built (a new elif keyed on
+        # ':flatten()' appearing at some position other than first),
+        # not a change to this bare-":flatten()"-first shape or to any
+        # non-prefixed path.
         else:
             pattern = self._compile_path_pattern(name_one.path)
             candidates = self._candidates_for_name(root_major, pattern)
@@ -414,6 +446,22 @@ class FilesReferenceFinder3(ReferenceFinder3):
         home = self.csvpaths.file_manager.named_file_home(name).rstrip("/")
         return [entry for entry in manifest if self._matches(entry, home, pattern)]
 
+    def _candidates_for_name_by_suffix(self, name: str, suffix_pattern: list) -> list:
+        """every manifest entry for one named-file whose file_home's
+        TRAILING segments match `suffix_pattern` position-by-position
+        (Star3 as wildcard), with any number of additional segments
+        (including zero) allowed before them -- the suffix-anchored
+        counterpart to _candidates_for_name's exact-length match, used
+        by the ':flatten()/...' prefixed shape (any depth, THEN a fixed
+        literal/'*'/:name(...) anchor at the end)."""
+        manifest = self.csvpaths.file_manager.get_manifest(name)
+        home = self.csvpaths.file_manager.named_file_home(name).rstrip("/")
+        return [
+            entry
+            for entry in manifest
+            if self._matches_suffix(entry, home, suffix_pattern)
+        ]
+
     def _all_candidates_for_name(self, name: str) -> list:
         """every manifest entry for one named-file, at any path depth --
         ':flatten()'/':groups()' both match unconditionally, unlike a
@@ -473,6 +521,22 @@ class FilesReferenceFinder3(ReferenceFinder3):
             and isinstance(name_one.path[0], FunctionCall3)
             and name_one.path[0].name == "groups"
             and name_one.path[0].arg is None
+        )
+
+    @staticmethod
+    def _is_flatten_prefixed_reference(name_one) -> bool:
+        """true when name_one's path STARTS with a bare ':flatten()'
+        followed by at least one more segment -- the mirror image of
+        _is_bare_flatten_reference (which requires ':flatten()' to be
+        the ONLY segment). Does not check the arg here -- query() raises
+        its own clear error for that, mirroring how the bare-shape
+        checks fold the arg check into the boolean instead (this one
+        needs to distinguish "wrong arg" from "not this shape at all"
+        for a better error message, so it is checked by the caller)."""
+        return (
+            len(name_one.path) > 1
+            and isinstance(name_one.path[0], FunctionCall3)
+            and name_one.path[0].name == "flatten"
         )
 
     @staticmethod
@@ -616,6 +680,31 @@ class FilesReferenceFinder3(ReferenceFinder3):
         if len(segments) != len(pattern):
             return False
         for actual, expected in zip(segments, pattern):
+            if isinstance(expected, Star3):
+                continue
+            if actual != expected:
+                return False
+        return True
+
+    @staticmethod
+    def _matches_suffix(entry: dict, home: str, pattern: list) -> bool:
+        """like _matches, but matches when file_home's own relative
+        segments END WITH `pattern` position-by-position (Star3 as
+        wildcard), with any number of additional segments (including
+        zero) allowed BEFORE them -- the ':flatten()/...' prefixed
+        shape's own matcher: any depth, then a fixed literal/'*'/
+        :name(...) anchor at the end. `pattern` is never empty here (the
+        caller only reaches this with at least one segment after the
+        leading ':flatten()')."""
+        file_home = entry["file_home"].rstrip("/")
+        if not file_home.startswith(home):
+            return False
+        rel = file_home[len(home) :].lstrip("/")
+        segments = rel.split("/") if rel else []
+        if len(segments) < len(pattern):
+            return False
+        trailing = segments[len(segments) - len(pattern) :]
+        for actual, expected in zip(trailing, pattern):
             if isinstance(expected, Star3):
                 continue
             if actual != expected:

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -25,19 +25,30 @@ class FilesReferenceFinder3(ReferenceFinder3):
     #    method's own docstring.
     #  - name_one is "*", a literal path segment, :name("...") (for a
     #    literal name containing characters -- e.g. a real filename's
-    #    "." -- that cannot appear in a bare PATH_SEGMENT), or a bare
-    #    ':all()' -- settled 2026-08-12: every distinct file_home under
-    #    this ONE named-file, at any depth, each independently reduced
-    #    by name_three's own pointer (mirrors _query_star_traversal's
-    #    own is_grouped branch, just scoped to one name instead of
-    #    every named-file). A literal/'*' pattern always requires an
-    #    EXACT segment count, so ':all()' is the only way to reach a
-    #    file whose depth is not known/uniform in advance. Combining it
-    #    with :manifest()/:path()/a field-accessor function is not yet
+    #    "." -- that cannot appear in a bare PATH_SEGMENT), a bare
+    #    ':all()', or a bare ':flatten()' -- these last two settled/
+    #    corrected 2026-08-12, kept deliberately in lockstep with
+    #    ResultsReferenceFinder3's own depth vocabulary (David: keep
+    #    functions meaning the same thing across datatypes wherever the
+    #    underlying structure supports it -- FILES has the same
+    #    "variable, not-known-in-advance path depth" structure RESULTS
+    #    does): ':all()' is a one-level GROUP, an exact peer of '*'
+    #    (same [Star3()] pattern, but partitioned by file_home and
+    #    reduced independently per partition instead of pooled) --
+    #    reaches each distinct one-level path's own latest version.
+    #    ':flatten()' is the any-depth POOL peer -- every distinct
+    #    file_home under this name, at any depth, into ONE pooled
+    #    answer. Any-depth GROUPED (reaching a mixed-depth name's every
+    #    distinct path independently) is deliberately NOT built --
+    #    that would be a ':groups()' analog, deferred here exactly like
+    #    ResultsReferenceFinder3 defers it. ':all()' combined with
+    #    :manifest()/:path()/a field-accessor function is not yet
     #    supported (same under-specified-interaction reasoning as
-    #    ResultsReferenceFinder3's own ':all()' restriction). Any other
-    #    function-valued segment (e.g. :quarter()) and the "#worksheet"
-    #    marker (name_two) are not yet supported.
+    #    ResultsReferenceFinder3's own ':all()' restriction) --
+    #    ':flatten()' has no such restriction here, since root_major is
+    #    always known at this position (unlike '*' traversal below).
+    #    Any other function-valued segment (e.g. :quarter()) and the
+    #    "#worksheet" marker (name_two) are not yet supported.
     #  - name_three, if present, must resolve to exactly one pointer
     #    function (:first()/:last()/:index(n)) -- matching the
     #    STRUCTURE table: name_one picks *which file*, name_three picks
@@ -121,18 +132,19 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "directly to name_one -- put the version-selecting function in "
                 "name_three instead."
             )
-        # bare ':all()' for ONE named-file (settled 2026-08-12) -- every
-        # distinct file_home under root_major, at ANY depth, each
-        # reduced independently by name_three's own pointer (if any).
-        # Fills the same real gap '*' traversal's own is_grouped branch
-        # already fills across every named-file: a literal/'*' pattern
-        # here always requires an EXACT segment count (via _matches), so
-        # there was no way to ask for "each distinct path's own latest
-        # version" for a single named-file whose files do not all sit at
-        # the same depth. Mirrors _query_star_traversal's grouping
-        # exactly, just scoped to one name instead of every name.
+        # bare ':all()'/':flatten()' for ONE named-file -- see the class
+        # docstring's 2026-08-12 note. ':all()' is a one-level GROUP,
+        # exactly the pattern '*' already matches, just partitioned by
+        # file_home and reduced per-partition below instead of pooled.
+        # ':flatten()' is the any-depth POOL peer, filling the real gap
+        # a literal/'*' pattern cannot (an exact segment count) without
+        # over-reaching into "group at any depth too," which stays
+        # deferred (':groups()', not built).
         is_grouped = self._is_bare_all_reference(name_one)
+        is_flattened = self._is_bare_flatten_reference(name_one)
         if is_grouped:
+            candidates = self._candidates_for_name(root_major, [Star3()])
+        elif is_flattened:
             candidates = self._all_candidates_for_name(root_major)
         else:
             pattern = self._compile_path_pattern(name_one.path)
@@ -236,14 +248,18 @@ class FilesReferenceFinder3(ReferenceFinder3):
 
     def _query_star_traversal(self, reference: Reference3) -> ReferenceResults3:
         """root_major == "*" -- query across every named-file, not just
-        one. Two distinct semantics (per "Why a trailing bare '*' is
-        illegal but bare ':all()' is fine" in the spec compendium):
+        one. Three distinct semantics, corrected/extended 2026-08-12 to
+        match ResultsReferenceFinder3's own depth vocabulary exactly
+        (David: keep functions meaning the same thing across datatypes):
 
-        - bare '*'/literal path narrowing (FLATTEN): every named-file's
-          matching candidates pool into one combined list, sorted by
-          each entry's own "time" so a terminal pointer means true
-          chronological order across everything, not enumeration order.
-        - bare ':all()' as name_one's entire content (GROUP): every
+        - bare '*'/literal path narrowing (POOL, exactly one level):
+          every named-file's matching candidates pool into one combined
+          list, sorted by each entry's own "time" so a terminal pointer
+          means true chronological order across everything, not
+          enumeration order.
+        - bare ':all()' as name_one's entire content (GROUP, exactly one
+          level -- matches the SAME [Star3()] pattern '*' does, NOT any
+          depth as an earlier version of this method did): every
           matching candidate across every named-file is partitioned by
           its own "file_home" (already unique per named-file+path, since
           file_home embeds the named-file's name as a path prefix), and
@@ -251,13 +267,20 @@ class FilesReferenceFinder3(ReferenceFinder3):
           group -- one result per (named-file, path) pair, each that
           pair's own last/first/nth version in its own array order (no
           time-sort needed within one already-single-manifest group).
+        - bare ':flatten()' as name_one's entire content (POOL, any
+          depth): every named-file's candidates AT ANY DEPTH pool into
+          one combined list, time-sorted and reduced exactly like the
+          '*' case above -- the any-depth counterpart '*' cannot reach
+          (an exact segment count). Any-depth GROUPED stays deferred
+          (a ':groups()' analog, not built), matching
+          ResultsReferenceFinder3's own deferral.
 
         Deliberately narrow for now, matching only the spec's own worked
-        examples: combining '*' traversal with :manifest()/:path()/a
-        field-accessor function in name_three is not yet supported --
-        those all assume exactly one already-known manifest to re-read
-        in _extract_data(), which does not hold when a result could have
-        come from any of several named-files' manifests.
+        examples: combining '*'/':flatten()' traversal with :manifest()/
+        :path()/a field-accessor function in name_three is not yet
+        supported -- those all assume exactly one already-known manifest
+        to re-read in _extract_data(), which does not hold when a result
+        could have come from any of several named-files' manifests.
         """
         name_one = reference.name_one
         if name_one.name_two is not None:
@@ -266,7 +289,12 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "marker (name_two)."
             )
         is_grouped = self._is_bare_all_reference(name_one)
+        is_flattened = self._is_bare_flatten_reference(name_one)
         if is_grouped:
+            candidates = []
+            for name in self.csvpaths.file_manager.named_file_names:
+                candidates.extend(self._candidates_for_name(name, [Star3()]))
+        elif is_flattened:
             candidates = []
             for name in self.csvpaths.file_manager.named_file_names:
                 candidates.extend(self._all_candidates_for_name(name))
@@ -347,19 +375,21 @@ class FilesReferenceFinder3(ReferenceFinder3):
     def _candidates_for_name(self, name: str, pattern: list) -> list:
         """every manifest entry for one named-file whose file_home
         matches `pattern` relative to that name's own home directory --
-        the per-name-file work shared by both the literal-root_major
-        path and '*' traversal's flatten mode."""
+        the per-name-file work shared by the literal-root_major path,
+        '*' traversal's pool mode, and both ':all()' branches (which
+        also match this exact-one-level pattern, just with the results
+        partitioned rather than pooled afterward)."""
         manifest = self.csvpaths.file_manager.get_manifest(name)
         home = self.csvpaths.file_manager.named_file_home(name).rstrip("/")
         return [entry for entry in manifest if self._matches(entry, home, pattern)]
 
     def _all_candidates_for_name(self, name: str) -> list:
         """every manifest entry for one named-file, at any path depth --
-        ':all()' matches unconditionally, unlike a pattern (which must
-        match an exact segment count), so this skips _matches entirely.
-        Shared by '*' traversal's own is_grouped branch (every named-
-        file) and query()'s literal-root_major is_grouped branch (this
-        one named-file only)."""
+        ':flatten()' matches unconditionally, unlike a pattern (which
+        must match an exact segment count), so this skips _matches
+        entirely. Shared by '*' traversal's own is_flattened branch
+        (every named-file) and query()'s literal-root_major is_flattened
+        branch (this one named-file only)."""
         manifest = self.csvpaths.file_manager.get_manifest(name)
         home = self.csvpaths.file_manager.named_file_home(name).rstrip("/")
         return [
@@ -379,6 +409,20 @@ class FilesReferenceFinder3(ReferenceFinder3):
             and len(name_one.path) == 1
             and isinstance(name_one.path[0], FunctionCall3)
             and name_one.path[0].name == "all"
+            and name_one.path[0].arg is None
+        )
+
+    @staticmethod
+    def _is_bare_flatten_reference(name_one) -> bool:
+        """same shape as _is_bare_all_reference, for ':flatten()'
+        instead of ':all()' -- the two are structurally exclusive (a
+        single FunctionCall3 cannot be named both at once), so callers
+        never need to guard against both being true together."""
+        return (
+            not name_one.functions
+            and len(name_one.path) == 1
+            and isinstance(name_one.path[0], FunctionCall3)
+            and name_one.path[0].name == "flatten"
             and name_one.path[0].arg is None
         )
 

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -128,6 +128,24 @@ class FilesReferenceFinder3(ReferenceFinder3):
             filename = f"{name_one.path[0].name}.json"
             return self._query_well_known_file(home, filename)
 
+        bare_field_call = self._bare_definition_field_call(name_one)
+        if bare_field_call is not None:
+            # ":on_arrival()"/":sources()" bare -- settled 2026-08-12,
+            # David: an arrival activation lives in the named-file's own
+            # definition.json, it "doesn't go to the version level" --
+            # confirmed by direct testing that the value is identical
+            # regardless of which version a :name(...)+pointer combo
+            # narrowed to (SOURCE == "definition" means _extract_data()
+            # never reads result.uuid for these), so requiring either
+            # was a real inconsistency with :definition() itself, which
+            # already gets this same bare treatment. No :name(...)/
+            # version needed at all -- matches :definition()'s own
+            # precedent exactly, this just extracts one key from it
+            # instead of returning the whole file.
+            home = self.csvpaths.file_manager.named_file_home(root_major)
+            path = Nos(home).join("definition.json")
+            return ReferenceResults3(results=[ReferenceResult3(path=path, uuid=None)])
+
         if name_one.functions:
             raise ReferenceException3(
                 "FilesReferenceFinder3 does not yet support functions attached "
@@ -457,6 +475,28 @@ class FilesReferenceFinder3(ReferenceFinder3):
             and name_one.path[0].arg is None
         )
 
+    @staticmethod
+    def _bare_definition_field_call(name_one) -> "FunctionCall3 | None":
+        """returns the field-accessor FunctionCall3 when name_one's
+        entire content is a single, argument-less function whose
+        registered class is SOURCE == "definition" (":on_arrival()"/
+        ":sources()" today) -- these values live in the named-file's own
+        definition.json, not any particular file/version's manifest
+        entry, so (like ":definition()" itself) they need no
+        :name(...)/matched-version context to resolve. None for every
+        other shape, including SOURCE == "manifest" field accessors
+        (":uuid()"/":time()"/etc.), which DO vary by which version
+        matched and still need a real candidate."""
+        if name_one.functions or len(name_one.path) != 1:
+            return None
+        segment = name_one.path[0]
+        if not isinstance(segment, FunctionCall3) or segment.arg is not None:
+            return None
+        function_cls = ReferenceFunctionFactory.get_registered_class(segment.name)
+        if function_cls is not None and function_cls.SOURCE == "definition":
+            return segment
+        return None
+
     def _extract_data(self, result: ReferenceResult3):
         reference = self.ref.parsed
         # :path(...) is checked before resolve_kind's content-oriented
@@ -508,10 +548,19 @@ class FilesReferenceFinder3(ReferenceFinder3):
                     reference.root_major
                 )
                 return self._find_manifest_entry_by_uuid(manifest, result.uuid)
-        if kind == Reference3.METADATA_FIELD and reference.name_three is not None:
-            field_call = self._find_field_function_call(
-                reference.name_three.functions
-            )
+        if kind == Reference3.METADATA_FIELD:
+            if reference.name_three is not None:
+                field_call = self._find_field_function_call(
+                    reference.name_three.functions
+                )
+            else:
+                # a bare, SOURCE == "definition" field accessor occupying
+                # name_one's entire content (":on_arrival()"/":sources()")
+                # -- settled 2026-08-12, see query()'s own comment. Never
+                # reads result.uuid below (function_cls.SOURCE is always
+                # "definition" for anything _bare_definition_field_call
+                # returns), so result.uuid being None here is fine.
+                field_call = self._bare_definition_field_call(reference.name_one)
             if field_call is not None:
                 function_cls = ReferenceFunctionFactory.get_registered_class(
                     field_call.name

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -23,9 +23,19 @@ class FilesReferenceFinder3(ReferenceFinder3):
     #    narrow itself: combining '*' traversal with :manifest()/:path()/
     #    a field-accessor function is not yet supported, see that
     #    method's own docstring.
-    #  - name_one is "*", a literal path segment, or :name("...") (for a
+    #  - name_one is "*", a literal path segment, :name("...") (for a
     #    literal name containing characters -- e.g. a real filename's
-    #    "." -- that cannot appear in a bare PATH_SEGMENT). any other
+    #    "." -- that cannot appear in a bare PATH_SEGMENT), or a bare
+    #    ':all()' -- settled 2026-08-12: every distinct file_home under
+    #    this ONE named-file, at any depth, each independently reduced
+    #    by name_three's own pointer (mirrors _query_star_traversal's
+    #    own is_grouped branch, just scoped to one name instead of
+    #    every named-file). A literal/'*' pattern always requires an
+    #    EXACT segment count, so ':all()' is the only way to reach a
+    #    file whose depth is not known/uniform in advance. Combining it
+    #    with :manifest()/:path()/a field-accessor function is not yet
+    #    supported (same under-specified-interaction reasoning as
+    #    ResultsReferenceFinder3's own ':all()' restriction). Any other
     #    function-valued segment (e.g. :quarter()) and the "#worksheet"
     #    marker (name_two) are not yet supported.
     #  - name_three, if present, must resolve to exactly one pointer
@@ -111,8 +121,22 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "directly to name_one -- put the version-selecting function in "
                 "name_three instead."
             )
-        pattern = self._compile_path_pattern(name_one.path)
-        candidates = self._candidates_for_name(root_major, pattern)
+        # bare ':all()' for ONE named-file (settled 2026-08-12) -- every
+        # distinct file_home under root_major, at ANY depth, each
+        # reduced independently by name_three's own pointer (if any).
+        # Fills the same real gap '*' traversal's own is_grouped branch
+        # already fills across every named-file: a literal/'*' pattern
+        # here always requires an EXACT segment count (via _matches), so
+        # there was no way to ask for "each distinct path's own latest
+        # version" for a single named-file whose files do not all sit at
+        # the same depth. Mirrors _query_star_traversal's grouping
+        # exactly, just scoped to one name instead of every name.
+        is_grouped = self._is_bare_all_reference(name_one)
+        if is_grouped:
+            candidates = self._all_candidates_for_name(root_major)
+        else:
+            pattern = self._compile_path_pattern(name_one.path)
+            candidates = self._candidates_for_name(root_major, pattern)
 
         name_three = reference.name_three
         if name_three is None:
@@ -146,11 +170,41 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "registered field-accessor function (e.g. :uuid())."
             )
 
+        if is_grouped and pointers and (has_manifest or has_field_function or has_path):
+            # mirrors ResultsReferenceFinder3's own ':all()'-grouping
+            # restriction (settled 2026-08-11 there): grouping plus
+            # :manifest()/:path()/a field-accessor is an under-specified
+            # interaction, not decided -- resolve the grouped versions
+            # on their own first, rather than guessing what "the
+            # manifest entry of every group's own latest version, all at
+            # once" should even resolve to.
+            raise ReferenceException3(
+                "FilesReferenceFinder3 does not yet support combining "
+                "':all()' grouping with :manifest(), :path(), or a "
+                "field-accessor function -- resolve the grouped versions "
+                "on their own first."
+            )
+
         if pointers:
-            # a pointer (with or without :manifest() riding alongside it)
-            # reduces to one specific version, same as before.
-            selected = self._apply_pointer(pointers[0], candidates)
-            selected_candidates = [selected] if selected is not None else []
+            if is_grouped:
+                # one independent reduction per distinct file_home, not
+                # one pooled answer across all of them -- mirrors
+                # _query_star_traversal's own is_grouped branch, scoped
+                # to this one named-file's own candidates instead of
+                # every named-file's.
+                by_file_home = {}
+                for entry in candidates:
+                    by_file_home.setdefault(entry["file_home"], []).append(entry)
+                selected_candidates = []
+                for file_home in sorted(by_file_home):
+                    selected = self._apply_pointer(pointers[0], by_file_home[file_home])
+                    if selected is not None:
+                        selected_candidates.append(selected)
+            else:
+                # a pointer (with or without :manifest() riding alongside
+                # it) reduces to one specific version, same as before.
+                selected = self._apply_pointer(pointers[0], candidates)
+                selected_candidates = [selected] if selected is not None else []
         else:
             # :manifest() alone, no pointer -- legal only when name_one's
             # own path narrowing already resolves to at most one version.
@@ -302,7 +356,10 @@ class FilesReferenceFinder3(ReferenceFinder3):
     def _all_candidates_for_name(self, name: str) -> list:
         """every manifest entry for one named-file, at any path depth --
         ':all()' matches unconditionally, unlike a pattern (which must
-        match an exact segment count), so this skips _matches entirely."""
+        match an exact segment count), so this skips _matches entirely.
+        Shared by '*' traversal's own is_grouped branch (every named-
+        file) and query()'s literal-root_major is_grouped branch (this
+        one named-file only)."""
         manifest = self.csvpaths.file_manager.get_manifest(name)
         home = self.csvpaths.file_manager.named_file_home(name).rstrip("/")
         return [

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -19,6 +19,7 @@ class ReferenceFunctionFactory:
         from .selectors.all_3 import All3
         from .selectors.first_3 import First3
         from .selectors.flatten_3 import Flatten3
+        from .selectors.groups_3 import Groups3
         from .selectors.index_3 import Index3
         from .selectors.last_3 import Last3
         from .selectors.name_3 import Name3
@@ -81,6 +82,7 @@ class ReferenceFunctionFactory:
             Name3.NAME: Name3,
             All3.NAME: All3,
             Flatten3.NAME: Flatten3,
+            Groups3.NAME: Groups3,
             Manifest3.NAME: Manifest3,
             Definition3.NAME: Definition3,
             Errors3.NAME: Errors3,

--- a/csvpath/references/functions/selectors/flatten_3.py
+++ b/csvpath/references/functions/selectors/flatten_3.py
@@ -4,28 +4,36 @@ from ..function_3 import Function3
 
 class Flatten3(Function3):
     #
-    # RESULTS-only. Settled 2026-08-10, alongside redefining a bare
-    # pointer to mean zero-level-only (see ResultsReferenceFinder3's
-    # module docstring and _query_star_traversal). Once bare stopped
-    # meaning "any depth, pooled," that capability needed a new,
-    # explicit name -- :flatten() is it. Unlike "*"/:all() (which are
-    # depth PEERS, both requiring exactly one level), :flatten() pools
-    # every run matching its own position (bare, or after a literal
-    # prefix) at ANY remaining depth into one combined list, the same
-    # way a bare pointer used to. A deferred peer, :groups(), would do
-    # the same any-depth matching but partition instead of pool --
-    # ResultsReferenceFinder3 keeps candidate-gathering and pool-vs-
-    # reduce as separate steps specifically so that peer is a small
-    # addition later, not a rework, when/if it is needed.
+    # Originally RESULTS-only. Settled 2026-08-10, alongside redefining
+    # a bare pointer to mean zero-level-only (see
+    # ResultsReferenceFinder3's module docstring and
+    # _query_star_traversal). Once bare stopped meaning "any depth,
+    # pooled," that capability needed a new, explicit name -- :flatten()
+    # is it. Unlike "*"/:all() (which are depth PEERS, both requiring
+    # exactly one level), :flatten() pools every match at its own
+    # position (bare, or after a literal prefix) at ANY remaining depth
+    # into one combined list, the same way a bare pointer used to. A
+    # deferred peer, :groups(), would do the same any-depth matching but
+    # partition instead of pool -- both finders keep candidate-gathering
+    # and pool-vs-reduce as separate steps specifically so that peer is
+    # a small addition later, not a rework, when/if it is needed.
+    #
+    # Extended to FILES 2026-08-12: FILES also has variable, unknown-in-
+    # advance path depth (a named-file's distinct files need not all sit
+    # at the same depth), the same structural reason RESULTS needed this
+    # -- David's own principle: keep functions meaning the same thing
+    # across datatypes wherever the underlying structure supports it.
+    # CSVPATHS has no path dimension at all, so it stays excluded, same
+    # as :all()'s own grouping is a no-op there.
     #
     NAME = "flatten"
     SUMMARY = (
-        "Pools every run matching this position at any remaining depth "
-        "into one combined list, reduced by a pointer riding alongside "
-        "it -- the any-depth counterpart to '*'/':all()', which are "
-        "both restricted to exactly one level."
+        "Pools every match at this position at any remaining depth into "
+        "one combined list, reduced by a pointer riding alongside it -- "
+        "the any-depth counterpart to '*'/':all()', which are both "
+        "restricted to exactly one level."
     )
     ROLE = Function3.CONTEXT_SETTER
-    DATATYPES = (Reference3.RESULTS,)
+    DATATYPES = (Reference3.FILES, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False

--- a/csvpath/references/functions/selectors/groups_3.py
+++ b/csvpath/references/functions/selectors/groups_3.py
@@ -1,0 +1,37 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class Groups3(Function3):
+    #
+    # the any-depth GROUP peer of ':flatten()' (any-depth POOL) --
+    # completes the 2x2 depth matrix alongside '*'/':all()' (both
+    # restricted to exactly one level): '*'/':flatten()' pool into one
+    # answer, ':all()'/':groups()' partition into one answer per
+    # distinct value. Added 2026-08-12, together with FILES/RESULTS
+    # both getting it in the same pass -- David's own principle (see
+    # feedback_cross_datatype_function_consistency): keep functions
+    # meaning the same thing across datatypes wherever the underlying
+    # structure supports it. Deliberately deferred through the whole
+    # ':all()'/':flatten()' work leading up to this -- David judged it
+    # no longer deferrable once a concrete need surfaced for FILES (a
+    # named-file's distinct paths are not always uniformly one level
+    # deep) and confirmed RESULTS should get it in the same pass rather
+    # than drift out of sync again the way ':all()' already had once.
+    #
+    # CSVPATHS has no path dimension at all to group by, so it is
+    # excluded here -- same reasoning that already excludes it from
+    # ':flatten()'.
+    #
+    NAME = "groups"
+    SUMMARY = (
+        "Partitions every match at this position, at any remaining "
+        "depth, by its own distinguishing path, reducing each "
+        "partition independently by a pointer riding alongside it -- "
+        "the any-depth counterpart to ':all()', which is restricted to "
+        "exactly one level."
+    )
+    ROLE = Function3.CONTEXT_SETTER
+    DATATYPES = (Reference3.FILES, Reference3.RESULTS)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -36,14 +36,17 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 #      (a) bare/function-only, no literal path at all (mirrors csvpaths --
 #          the sole path "segment" is itself a version-selecting function,
 #          e.g. :all()/:first()/:last()/:index(n)). A bare POINTER alone
-#          (no :all()/:flatten()) means zero-level only -- direct children
-#          of the group's own root, no template -- settled 2026-08-10. A
-#          bare ':all()' means exactly one level, wildcarded -- the same
-#          restriction '*' has, and unaffected by whether a pointer
-#          follows it (settled 2026-08-11, correcting an earlier version
-#          that let a pointer-less ':all()' fall through to any-depth
-#          behavior). ':flatten()' is the any-depth case -- see that
-#          function's own docstring.
+#          (no :all()/:flatten()/:groups()) means zero-level only -- direct
+#          children of the group's own root, no template -- settled
+#          2026-08-10. A bare ':all()' means exactly one level, wildcarded
+#          -- the same restriction '*' has, and unaffected by whether a
+#          pointer follows it (settled 2026-08-11, correcting an earlier
+#          version that let a pointer-less ':all()' fall through to
+#          any-depth behavior). ':flatten()' pools any depth into one
+#          answer; ':groups()' partitions any depth into one answer per
+#          distinct value observed (added 2026-08-12, alongside FILES'
+#          own ':groups()' -- David: keep functions meaning the same
+#          thing across datatypes) -- see each function's own docstring.
 #      (b) literal/"*"/:name("...") path segments (same semantics as files
 #          -- see ReferenceFinder3._compile_path_pattern) PLUS its own
 #          trailing function chain -- narrows to runs whose own prefix
@@ -193,26 +196,29 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         is_grouped = any(
             isinstance(c, FunctionCall3) and c.name == "all" for c in calls
         )
-        # group_key_for: set only when ':all()' partitions candidates by
-        # observed value AND a pointer exists to reduce each partition
-        # (David's three-templates example -- three different one-level
-        # templates all group correctly by whatever directory each run
-        # actually landed in, not by which template produced it). Left
-        # None when there is no pointer -- grouping only matters at the
-        # reduce step, so with no pointer the "grouped" and "pooled"
-        # candidate sets are identical anyway (every one-level match,
-        # unreduced).
+        # group_key_for: set only when ':all()'/':groups()' partitions
+        # candidates by observed value AND a pointer exists to reduce
+        # each partition (David's three-templates example -- three
+        # different one-level templates all group correctly by whatever
+        # directory each run actually landed in, not by which template
+        # produced it -- ':groups()' extends this to any depth, see
+        # _group_key). Left None when there is no pointer -- grouping
+        # only matters at the reduce step, so with no pointer the
+        # "grouped" and "pooled" candidate sets are identical anyway.
         group_key_for = None
 
         if self._is_bare_function_only(name_one):
             is_flattened = any(
                 isinstance(c, FunctionCall3) and c.name == "flatten" for c in calls
             )
-            if is_grouped and is_flattened:
+            is_deep_grouped = any(
+                isinstance(c, FunctionCall3) and c.name == "groups" for c in calls
+            )
+            if sum([is_grouped, is_flattened, is_deep_grouped]) > 1:
                 raise ReferenceException3(
                     "ResultsReferenceFinder3 does not support combining "
-                    "':all()' and ':flatten()' -- one level, grouped, or "
-                    "any depth, pooled, but not both at once."
+                    "':all()'/':flatten()'/':groups()' -- each is its own "
+                    "depth/grouping choice, not to be combined with another."
                 )
             if is_grouped:
                 # bare ':all()' -- exactly one level, wildcarded, peer of
@@ -231,13 +237,31 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 ]
                 if pointer is not None:
                     group_key_for = {
-                        rh: self._prefix_segments(rh, home)[-1] for rh in candidates
+                        rh: self._group_key(rh, home) for rh in candidates
                     }
             elif is_flattened:
                 # ':flatten()', with or without a pointer -- every run
                 # discovered for the group is a candidate, any depth, no
                 # prefix narrowing.
                 candidates = run_homes
+            elif is_deep_grouped:
+                # ':groups()' -- added 2026-08-12, the any-depth GROUP
+                # peer of ':all()' (one-level GROUP)/':flatten()' (any-
+                # depth POOL), built alongside FILES' own ':groups()' in
+                # the same pass (David: keep functions meaning the same
+                # thing across datatypes). Same any-depth candidate set
+                # as ':flatten()' (no prefix-length restriction), but
+                # partitioned by _group_key -- each run's FULL relative
+                # path (not just its last segment, since two runs at
+                # different depths could otherwise share a trailing
+                # segment by coincidence and be wrongly conflated). A
+                # zero-level (no-template) run gets the empty-tuple key
+                # -- its own valid, distinct group, not a special case.
+                candidates = run_homes
+                if pointer is not None:
+                    group_key_for = {
+                        rh: self._group_key(rh, home) for rh in candidates
+                    }
             else:
                 # a plain pointer alone, e.g. "$acme.results.:last()" --
                 # zero-level (direct children of the group's own root)
@@ -314,7 +338,34 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             ]
             if pointer is not None:
                 group_key_for = {
-                    rh: self._prefix_segments(rh, home)[-1] for rh in candidates
+                    rh: self._group_key(rh, home, prefix_len=len(pattern) - 1)
+                    for rh in candidates
+                }
+        elif isinstance(name_one.path[-1], FunctionCall3) and name_one.path[
+            -1
+        ].name == "groups":
+            # a literal/wildcard prefix, then ':groups()' as the last
+            # segment, e.g. "beta/:groups():last()" -- added 2026-08-12,
+            # matches this prefix, then anything, at any remaining depth
+            # (same candidate set as the prefixed ':flatten()' branch
+            # above), grouped by everything beyond the fixed prefix
+            # instead of pooled -- one result per distinct value observed
+            # there, even when that remaining depth varies per run.
+            if name_one.path[-1].arg is not None:
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3's ':groups()' does not take "
+                    "an argument."
+                )
+            prefix_pattern = self._compile_path_pattern(name_one.path[:-1])
+            candidates = [
+                rh
+                for rh in run_homes
+                if self._matches_prefix_at_least(rh, home, prefix_pattern)
+            ]
+            if pointer is not None:
+                group_key_for = {
+                    rh: self._group_key(rh, home, prefix_len=len(prefix_pattern))
+                    for rh in candidates
                 }
         else:
             pattern = self._compile_path_pattern(name_one.path)
@@ -337,8 +388,9 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         ):
             raise ReferenceException3(
                 "ResultsReferenceFinder3 does not yet support combining "
-                "':all()' grouping with :manifest() or a run-level field "
-                "accessor -- resolve the grouped runs on their own first."
+                "':all()'/':groups()' grouping with :manifest() or a "
+                "run-level field accessor -- resolve the grouped runs on "
+                "their own first."
             )
 
         if group_key_for:
@@ -831,6 +883,27 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 "instance(s) a well-known-file function applies to."
             )
         return body, match_all, accessor, field_call
+
+    @classmethod
+    def _group_key(cls, run_home: str, home: str, prefix_len: int = 0) -> tuple:
+        """group key for ':all()'/':groups()' partitioning -- every
+        segment after the first `prefix_len` (the fixed literal/'*'
+        prefix, if any) and before the run's own trailing name, as a
+        TUPLE -- not just the last segment. Matters for ':groups()'
+        specifically (any depth, so the remaining length varies per
+        candidate): two runs sharing a common trailing segment under
+        DIFFERENT earlier templates (e.g. "beta/x" vs. "gamma/x") must
+        never be conflated into one group just because both end in "x".
+        For ':all()', every candidate's remaining length is always
+        exactly 1 by construction (the pattern already fixes every
+        other position), so a 1-tuple here behaves identically to using
+        the bare last-segment string -- this is purely a shared
+        implementation, not a behavior change for ':all()'. An empty
+        tuple (zero additional segments -- a direct/zero-level run,
+        only reachable through ':groups()', never ':all()') is itself a
+        valid, distinct group, not a special case needing a guard."""
+        segments = cls._prefix_segments(run_home, home)
+        return tuple(segments[prefix_len:])
 
     @staticmethod
     def _prefix_segments(run_home: str, home: str) -> "list[str] | None":

--- a/tests/references/functions/selectors/test_flatten_3.py
+++ b/tests/references/functions/selectors/test_flatten_3.py
@@ -10,7 +10,7 @@ def test_metadata():
     f = Flatten3()
     assert f.name == "flatten"
     assert f.ROLE == Function3.CONTEXT_SETTER
-    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.DATATYPES == (Reference3.FILES, Reference3.RESULTS)
 
 
 def test_no_arg_is_valid():

--- a/tests/references/functions/selectors/test_groups_3.py
+++ b/tests/references/functions/selectors/test_groups_3.py
@@ -1,0 +1,22 @@
+import pytest
+
+from csvpath.references.functions.selectors.groups_3 import Groups3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Groups3()
+    assert f.name == "groups"
+    assert f.ROLE == Function3.CONTEXT_SETTER
+    assert f.DATATYPES == (Reference3.FILES, Reference3.RESULTS)
+
+
+def test_no_arg_is_valid():
+    Groups3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Groups3(arg="x").check_valid()

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -566,9 +566,15 @@ class TestStarTraversalFlatten:
 
 class TestStarTraversalGroup:
     # bare ':all()' as name_one's entire content partitions every
-    # named-file's matches by file_home (already unique per named-file+
-    # path), applying the terminal pointer independently within each
-    # group -- one result per (named-file, path) pair.
+    # named-file's EXACTLY-one-level matches (corrected 2026-08-12 to
+    # require the same [Star3()] pattern '*' does -- an earlier version
+    # matched any depth, which diverged from ResultsReferenceFinder3's
+    # own ':all()'/'*' depth-peer vocabulary) by file_home (already
+    # unique per named-file+path), applying the terminal pointer
+    # independently within each group -- one result per (named-file,
+    # path) pair. STAR_ALPHA/STAR_BETA are already all one level deep,
+    # so these assertions are unaffected by the correction -- see
+    # TestStarTraversalFlattenAnyDepth below for the any-depth case.
     def test_all_with_last_gives_one_result_per_named_file_and_path(self):
         results = _star_finder("$*.files.:all().:last()").query()
         assert len(results.results) == 3
@@ -592,56 +598,161 @@ class TestStarTraversalGroup:
             _star_finder("$*.files.:all().:last():manifest()").query()
 
 
+#
+# adds one named-file ("gamma") with a TWO-level entry, chronologically
+# latest of everything, to STAR_ALPHA/STAR_BETA's existing one-level
+# fixtures -- '*'/':all()' (both restricted to exactly one level) never
+# see it; ':flatten()' (any depth, pooled across every named-file) does.
+#
+FLATTEN_GAMMA_HOME = "inputs/named_files/gamma"
+FLATTEN_GAMMA_MANIFEST = [
+    {
+        "file": "inputs/named_files/gamma/nested/deep.csv/fff.csv",
+        "file_home": "inputs/named_files/gamma/nested/deep.csv",
+        "uuid": "u-gamma-deep-1",
+        "time": "2026-01-06T00:00:00+00:00",
+    },
+]
+FLATTEN_BY_NAME = dict(STAR_BY_NAME, gamma=(FLATTEN_GAMMA_HOME, FLATTEN_GAMMA_MANIFEST))
+
+
+def _flatten_star_finder(reference: str) -> FilesReferenceFinder3:
+    csvpaths = _FakeCsvPaths(_FakeFileManager(None, None, by_name=FLATTEN_BY_NAME))
+    ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
+    return FilesReferenceFinder3(csvpaths=csvpaths, ref=ref)
+
+
+class TestStarTraversalFlattenAnyDepth:
+    # bare ':flatten()' as name_one's entire content -- added 2026-08-12,
+    # the any-depth POOL peer of '*' (one-level POOL)/':all()' (one-level
+    # GROUP) across every named-file, mirroring ResultsReferenceFinder3's
+    # own ':flatten()'. Pools every named-file's candidates at any depth
+    # into one combined list, time-sorted, same as '*' traversal's own
+    # pool branch -- just without the exact-one-level restriction.
+    def test_last_reaches_a_two_level_entry_star_cannot(self):
+        star_results = _flatten_star_finder("$*.files.*.:last()").query()
+        assert star_results.uuids == ["u-two-2"]
+        flatten_results = _flatten_star_finder("$*.files.:flatten().:last()").query()
+        assert flatten_results.uuids == ["u-gamma-deep-1"]
+
+    def test_first_across_every_named_file_and_depth(self):
+        results = _flatten_star_finder("$*.files.:flatten().:first()").query()
+        assert results.uuids == ["u-zero-1"]
+
+    def test_with_no_name_three_dedupes_to_file_home_directories_any_depth(self):
+        results = _flatten_star_finder("$*.files.:flatten()").query()
+        assert set(results.files) == {
+            "inputs/named_files/alpha/zero.csv",
+            "inputs/named_files/alpha/one.csv",
+            "inputs/named_files/beta/two.csv",
+            "inputs/named_files/gamma/nested/deep.csv",
+        }
+
+    def test_combining_with_manifest_is_not_yet_supported(self):
+        # same structural reason '*' traversal has this restriction --
+        # root_major is "*" here, so _extract_data() cannot know which
+        # named-file's manifest to re-read.
+        with pytest.raises(ReferenceException3):
+            _flatten_star_finder("$*.files.:flatten().:last():manifest()").query()
+
+
 class TestAllForOneNamedFile:
     # bare ':all()' as name_one's entire content, for a LITERAL (non-'*')
-    # root_major -- settled 2026-08-12. Mirrors TestStarTraversalGroup's
-    # own semantics exactly, just scoped to one named-file: every
-    # distinct file_home under this name, at ANY depth (not the exact
-    # one-level match a literal/'*' pattern always requires), each
-    # independently reduced by name_three's own pointer.
-    def test_all_with_last_gives_each_distinct_paths_own_latest(self):
+    # root_major -- settled 2026-08-12, CORRECTED same day: ':all()' is
+    # a one-level GROUP, an exact peer of '*' (same [Star3()] pattern),
+    # not an any-depth match -- kept in lockstep with
+    # ResultsReferenceFinder3's own ':all()'/'*' depth-peer vocabulary.
+    # ALPHA_MANIFEST has two distinct one-level paths (zero.csv x1
+    # version, one.csv x2) -- exactly what ':all()' groups by.
+    def test_all_with_last_gives_each_paths_own_latest(self):
+        results = _finder("$alpha.files.:all().:last()", ALPHA_HOME, ALPHA_MANIFEST)
+        r = results.query()
+        assert set(r.uuids) == {"u-zero-1", "u-one-2"}
+
+    def test_all_with_first_gives_each_paths_own_earliest(self):
+        results = _finder("$alpha.files.:all().:first()", ALPHA_HOME, ALPHA_MANIFEST)
+        r = results.query()
+        assert set(r.uuids) == {"u-zero-1", "u-one-1"}
+
+    def test_all_with_no_name_three_dedupes_to_file_home_directories(self):
+        results = _finder("$alpha.files.:all()", ALPHA_HOME, ALPHA_MANIFEST)
+        r = results.query()
+        assert set(r.files) == {
+            "inputs/named_files/alpha/zero.csv",
+            "inputs/named_files/alpha/one.csv",
+        }
+
+    def test_all_does_not_reach_a_two_level_entry(self):
+        # ':all()' is now restricted to exactly one level, same as '*'
+        # -- a two-level path is invisible to it, same as to '*'. Use
+        # ':flatten()' (TestFlattenForOneNamedFile below) to reach it.
         results = _finder("$mixed.files.:all().:last()", MIXED_HOME, MIXED_MANIFEST)
         r = results.query()
-        assert len(r.results) == 2
-        assert set(r.uuids) == {"u-zero-2", "u-deep-2"}
+        assert set(r.uuids) == {"u-zero-2"}
 
-    def test_all_with_first_gives_each_distinct_paths_own_earliest(self):
-        results = _finder("$mixed.files.:all().:first()", MIXED_HOME, MIXED_MANIFEST)
+    def test_all_combined_with_manifest_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$alpha.files.:all().:last():manifest()", ALPHA_HOME, ALPHA_MANIFEST
+            ).query()
+
+    def test_all_combined_with_a_field_accessor_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$alpha.files.:all().:last():uuid()", ALPHA_HOME, ALPHA_MANIFEST
+            ).query()
+
+
+class TestFlattenForOneNamedFile:
+    # bare ':flatten()' as name_one's entire content, for a LITERAL
+    # (non-'*') root_major -- added 2026-08-12, the any-depth POOL peer
+    # of ':all()' (one-level GROUP)/'*' (one-level POOL). MIXED_MANIFEST
+    # has two distinct file_homes at DIFFERENT depths (zero.csv one
+    # level, nested/deep.csv two levels) -- exactly what '*' cannot
+    # reach (an exact segment count) and ':flatten()' pools into one
+    # answer, in manifest-array order (arrival order for FILES, not a
+    # "time" field -- this is one already-known manifest, same as any
+    # other single-name pooled reduction).
+    def test_flatten_last_pools_across_every_depth(self):
+        results = _finder("$mixed.files.:flatten().:last()", MIXED_HOME, MIXED_MANIFEST)
         r = results.query()
-        assert len(r.results) == 2
-        assert set(r.uuids) == {"u-zero-1", "u-deep-1"}
+        assert r.uuids == ["u-deep-2"]
 
-    def test_all_with_no_name_three_dedupes_to_file_home_directories_any_depth(self):
-        results = _finder("$mixed.files.:all()", MIXED_HOME, MIXED_MANIFEST)
+    def test_flatten_first_pools_across_every_depth(self):
+        results = _finder(
+            "$mixed.files.:flatten().:first()", MIXED_HOME, MIXED_MANIFEST
+        )
+        r = results.query()
+        assert r.uuids == ["u-zero-1"]
+
+    def test_flatten_with_no_name_three_dedupes_to_file_homes_any_depth(self):
+        results = _finder("$mixed.files.:flatten()", MIXED_HOME, MIXED_MANIFEST)
         r = results.query()
         assert set(r.files) == {
             "inputs/named_files/mixed/zero.csv",
             "inputs/named_files/mixed/nested/deep.csv",
         }
 
-    def test_a_literal_star_misses_the_two_level_entry_all_does_not(self):
-        # proves ':all()' is genuinely reaching further than '*' can --
-        # '*' requires exactly one level, so it only ever sees zero.csv.
+    def test_a_literal_star_misses_the_two_level_entry_flatten_does_not(self):
         star_results = _finder(
             "$mixed.files.*.:last()", MIXED_HOME, MIXED_MANIFEST
         ).query()
         assert star_results.uuids == ["u-zero-2"]
-        all_results = _finder(
-            "$mixed.files.:all().:last()", MIXED_HOME, MIXED_MANIFEST
+        flatten_results = _finder(
+            "$mixed.files.:flatten().:last()", MIXED_HOME, MIXED_MANIFEST
         ).query()
-        assert set(all_results.uuids) == {"u-zero-2", "u-deep-2"}
+        assert flatten_results.uuids == ["u-deep-2"]
 
-    def test_all_combined_with_manifest_is_not_yet_supported(self):
-        with pytest.raises(ReferenceException3):
-            _finder(
-                "$mixed.files.:all().:last():manifest()", MIXED_HOME, MIXED_MANIFEST
-            ).query()
-
-    def test_all_combined_with_a_field_accessor_is_not_yet_supported(self):
-        with pytest.raises(ReferenceException3):
-            _finder(
-                "$mixed.files.:all().:last():uuid()", MIXED_HOME, MIXED_MANIFEST
-            ).query()
+    def test_flatten_combined_with_manifest_is_supported(self):
+        # unlike ':all()' grouping, ':flatten()' pooling has no
+        # under-specified-interaction restriction -- root_major is
+        # always known here (unlike '*' traversal), so it reduces to
+        # one entity same as an ordinary pointer would.
+        results = _finder(
+            "$mixed.files.:flatten().:last():manifest()", MIXED_HOME, MIXED_MANIFEST
+        )
+        r = results.resolve()
+        assert r.results[0].data == MIXED_MANIFEST[3]
 
 
 class TestManifestCombinedWithNameThree:

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -885,6 +885,113 @@ class TestFlattenPrefixedWithSuffix:
             ).query()
 
 
+HOME_TEST_HOME = "inputs/named_files/homer"
+HOME_TEST_MANIFEST = [
+    {
+        "file": "inputs/named_files/homer/aaa.csv",
+        "file_home": "inputs/named_files/homer",
+        "uuid": "u-zero-1",
+    },
+    {
+        "file": "inputs/named_files/homer/bbb.csv",
+        "file_home": "inputs/named_files/homer",
+        "uuid": "u-zero-2",
+    },
+    {
+        "file": "inputs/named_files/homer/orders.csv/ccc.csv",
+        "file_home": "inputs/named_files/homer/orders.csv",
+        "uuid": "u-one-level",
+    },
+]
+
+
+class TestHomeAsAZeroLevelSelector:
+    # bare ':home()' as name_one's entire content -- added 2026-08-12,
+    # a zero-level selector mirroring ResultsReferenceFinder3's own
+    # ':home()' (David: keep functions meaning the same thing across
+    # datatypes). Unlike RESULTS, this needed real new code -- FILES'
+    # name_one can never be empty, so there is no pre-existing "no
+    # pattern" path for a bare pointer to fall into the way RESULTS'
+    # did. HOME_TEST_MANIFEST has both zero-level entries (directly at
+    # homer's own home) and a one-level "orders.csv" entry that must be
+    # excluded.
+    def test_home_then_pointer_gives_the_latest_zero_level_entry(self):
+        results = _finder(
+            "$homer.files.:home().:last()", HOME_TEST_HOME, HOME_TEST_MANIFEST
+        ).query()
+        assert results.uuids == ["u-zero-2"]
+
+    def test_bare_home_dedupes_to_the_named_files_own_home_directory(self):
+        results = _finder(
+            "$homer.files.:home()", HOME_TEST_HOME, HOME_TEST_MANIFEST
+        ).query()
+        assert results.files == [HOME_TEST_HOME]
+        assert results.results[0].uuid is None
+
+    def test_home_excludes_the_one_level_entry(self):
+        results = _finder(
+            "$homer.files.:home()", HOME_TEST_HOME, HOME_TEST_MANIFEST
+        ).query()
+        assert "u-one-level" not in results.uuids
+
+    def test_home_rejects_an_argument(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$homer.files.:home("x").:last()', HOME_TEST_HOME, HOME_TEST_MANIFEST
+            ).query()
+
+    def test_home_in_name_three_position_is_unaffected(self):
+        # ':home()' keeps its ordinary field-accessor job (SOURCE ==
+        # "manifest", reading "file_home") when it appears in name_three
+        # instead of bare in name_one -- different position, no collision.
+        results = _finder(
+            '$homer.files.:name("orders.csv").:first():home()',
+            HOME_TEST_HOME,
+            HOME_TEST_MANIFEST,
+        ).resolve()
+        assert results.results[0].data == "inputs/named_files/homer/orders.csv"
+
+
+class TestAllOnNameThree:
+    # ':all()' as (part of) name_three's function chain -- added
+    # 2026-08-12, mirroring CsvpathsReferenceFinder3's own ':all()'
+    # precedent exactly: it is not a POINTER, so its whole effect is
+    # simply NOT reducing -- every matched candidate comes back with its
+    # own real path/uuid, unlike name_three being absent entirely (which
+    # dedupes to directory-level results with uuid=None instead).
+    def test_all_gives_every_matched_version_with_real_uuids(self):
+        results = _finder(
+            '$alpha.files.:name("one.csv").:all()', ALPHA_HOME, ALPHA_MANIFEST
+        ).query()
+        assert set(results.uuids) == {"u-one-1", "u-one-2"}
+        assert None not in results.uuids
+
+    def test_all_differs_from_no_name_three_at_all(self):
+        # no name_three: deduped to ONE directory-level result, uuid=None.
+        no_name_three = _finder(
+            '$alpha.files.:name("one.csv")', ALPHA_HOME, ALPHA_MANIFEST
+        ).query()
+        assert len(no_name_three.results) == 1
+        assert no_name_three.results[0].uuid is None
+        # :all(): every version, unreduced, real uuids.
+        with_all = _finder(
+            '$alpha.files.:name("one.csv").:all()', ALPHA_HOME, ALPHA_MANIFEST
+        ).query()
+        assert len(with_all.results) == 2
+        assert all(u is not None for u in with_all.uuids)
+
+    def test_all_combined_with_a_pointer_is_redundant_pointer_wins(self):
+        # mirrors CSVPATHS' own "the same outcome as writing no pointer
+        # at all" framing -- :all() alongside a real pointer does not
+        # error, the pointer just reduces as normal.
+        results = _finder(
+            '$alpha.files.:name("one.csv").:all():last()',
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+        ).query()
+        assert results.uuids == ["u-one-2"]
+
+
 class TestGroupsForOneNamedFile:
     # bare ':groups()' as name_one's entire content, for a LITERAL
     # (non-'*') root_major -- added 2026-08-12, the any-depth GROUP peer

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -656,6 +656,29 @@ class TestStarTraversalFlattenAnyDepth:
             _flatten_star_finder("$*.files.:flatten().:last():manifest()").query()
 
 
+class TestStarTraversalGroupsAnyDepth:
+    # bare ':groups()' as name_one's entire content -- added 2026-08-12,
+    # the any-depth GROUP peer of ':all()' (one-level GROUP)/':flatten()'
+    # (any-depth POOL) across every named-file. Same any-depth candidate
+    # gathering as ':flatten()' (reaches gamma's two-level entry, which
+    # ':all()' cannot), partitioned by file_home like ':all()' instead of
+    # pooled into one answer.
+    def test_last_gives_one_result_per_named_file_and_path_any_depth(self):
+        all_results = _flatten_star_finder("$*.files.:all().:last()").query()
+        assert set(all_results.uuids) == {"u-zero-1", "u-one-2", "u-two-2"}
+        groups_results = _flatten_star_finder("$*.files.:groups().:last()").query()
+        assert set(groups_results.uuids) == {
+            "u-zero-1",
+            "u-one-2",
+            "u-two-2",
+            "u-gamma-deep-1",
+        }
+
+    def test_combining_with_manifest_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _flatten_star_finder("$*.files.:groups().:last():manifest()").query()
+
+
 class TestAllForOneNamedFile:
     # bare ':all()' as name_one's entire content, for a LITERAL (non-'*')
     # root_major -- settled 2026-08-12, CORRECTED same day: ':all()' is
@@ -753,6 +776,59 @@ class TestFlattenForOneNamedFile:
         )
         r = results.resolve()
         assert r.results[0].data == MIXED_MANIFEST[3]
+
+
+class TestGroupsForOneNamedFile:
+    # bare ':groups()' as name_one's entire content, for a LITERAL
+    # (non-'*') root_major -- added 2026-08-12, the any-depth GROUP peer
+    # of ':all()' (one-level GROUP)/':flatten()' (any-depth POOL). Same
+    # any-depth candidate gathering as ':flatten()' (MIXED_MANIFEST's two
+    # different-depth file_homes), but partitioned like ':all()' instead
+    # of pooled -- reaches BOTH distinct paths, each own reduction,
+    # exactly the case a literal/'*' pattern and ':all()' (both one
+    # level) cannot reach on their own.
+    def test_groups_last_gives_each_paths_own_latest_at_any_depth(self):
+        results = _finder("$mixed.files.:groups().:last()", MIXED_HOME, MIXED_MANIFEST)
+        r = results.query()
+        assert set(r.uuids) == {"u-zero-2", "u-deep-2"}
+
+    def test_groups_first_gives_each_paths_own_earliest_at_any_depth(self):
+        results = _finder("$mixed.files.:groups().:first()", MIXED_HOME, MIXED_MANIFEST)
+        r = results.query()
+        assert set(r.uuids) == {"u-zero-1", "u-deep-1"}
+
+    def test_groups_with_no_name_three_is_the_same_as_flatten(self):
+        # with no pointer, "partitioned" and "pooled" candidate sets are
+        # identical -- both just dedupe by file_home over the same
+        # any-depth gathering, same as ':all()'/'*' already coincide
+        # with no pointer.
+        groups_results = _finder("$mixed.files.:groups()", MIXED_HOME, MIXED_MANIFEST).query()
+        flatten_results = _finder(
+            "$mixed.files.:flatten()", MIXED_HOME, MIXED_MANIFEST
+        ).query()
+        assert set(groups_results.files) == set(flatten_results.files)
+
+    def test_a_literal_all_misses_the_two_level_entry_groups_does_not(self):
+        all_results = _finder(
+            "$mixed.files.:all().:last()", MIXED_HOME, MIXED_MANIFEST
+        ).query()
+        assert set(all_results.uuids) == {"u-zero-2"}
+        groups_results = _finder(
+            "$mixed.files.:groups().:last()", MIXED_HOME, MIXED_MANIFEST
+        ).query()
+        assert set(groups_results.uuids) == {"u-zero-2", "u-deep-2"}
+
+    def test_groups_combined_with_manifest_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$mixed.files.:groups().:last():manifest()", MIXED_HOME, MIXED_MANIFEST
+            ).query()
+
+    def test_groups_combined_with_a_field_accessor_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$mixed.files.:groups().:last():uuid()", MIXED_HOME, MIXED_MANIFEST
+            ).query()
 
 
 class TestManifestCombinedWithNameThree:

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -1109,6 +1109,47 @@ class TestDefinitionFieldAccessorFunctions:
         ).resolve()
         assert first.results[0].data == last.results[0].data
 
+    def test_bare_on_arrival_needs_no_name_or_version(self):
+        # settled 2026-08-12: on_arrival lives in the named-file's own
+        # definition.json (root_major-scoped), not any particular file/
+        # version, so it needs no :name(...)/pointer at all to resolve
+        # -- matches ":definition()" itself, which already gets this
+        # same bare treatment.
+        finder = _finder(
+            "$rich.files.:on_arrival()", RICH_HOME, RICH_MANIFEST, self.DEFINITION
+        )
+        results = finder.resolve()
+        assert results.results[0].data == self.DEFINITION["on_arrival"]
+        assert results.results[0].uuid is None
+
+    def test_bare_sources_needs_no_name_or_version(self):
+        finder = _finder(
+            "$rich.files.:sources()", RICH_HOME, RICH_MANIFEST, self.DEFINITION
+        )
+        results = finder.resolve()
+        assert results.results[0].data == self.DEFINITION["sources"]
+
+    def test_bare_on_arrival_never_configured_gives_none(self):
+        finder = _finder("$rich.files.:on_arrival()", RICH_HOME, RICH_MANIFEST)
+        results = finder.resolve()
+        assert results.results[0].data is None
+
+    def test_bare_on_arrival_query_gives_the_definition_path_no_uuid(self):
+        finder = _finder(
+            "$rich.files.:on_arrival()", RICH_HOME, RICH_MANIFEST, self.DEFINITION
+        )
+        results = finder.query()
+        assert results.files == [f"{RICH_HOME}/definition.json"]
+        assert results.results[0].uuid is None
+
+    def test_bare_manifest_sourced_field_accessor_still_requires_a_match(self):
+        # contrast case: SOURCE == "manifest" field accessors (e.g.
+        # :uuid()) genuinely vary by which version matched, so they are
+        # NOT given the same bare treatment -- still requires :name(...)
+        # (or '*') to identify a real candidate.
+        with pytest.raises(ReferenceException3):
+            _finder("$rich.files.:uuid()", RICH_HOME, RICH_MANIFEST).query()
+
 
 class TestPathFunction:
     # :path(inner) returns the filesystem path to whatever well-known

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -778,6 +778,113 @@ class TestFlattenForOneNamedFile:
         assert r.results[0].data == MIXED_MANIFEST[3]
 
 
+ANCHOR_HOME = "inputs/named_files/anchor"
+ANCHOR_MANIFEST = [
+    {
+        "file": "inputs/named_files/anchor/2025/orders.csv/aaa.csv",
+        "file_home": "inputs/named_files/anchor/2025/orders.csv",
+        "uuid": "u-one-pre-1",
+    },
+    {
+        "file": "inputs/named_files/anchor/orders.csv/bbb.csv",
+        "file_home": "inputs/named_files/anchor/orders.csv",
+        "uuid": "u-zero-pre-1",
+    },
+    {
+        "file": "inputs/named_files/anchor/returns.csv/ccc.csv",
+        "file_home": "inputs/named_files/anchor/returns.csv",
+        "uuid": "u-returns",
+    },
+    {
+        "file": "inputs/named_files/anchor/2025/returns.csv/ddd.csv",
+        "file_home": "inputs/named_files/anchor/2025/returns.csv",
+        "uuid": "u-nested-returns",
+    },
+]
+
+
+class TestFlattenPrefixedWithSuffix:
+    # ':flatten()' as name_one's FIRST segment, followed by more path --
+    # added 2026-08-12, David: "the last version of all orders.csv no
+    # matter how many template levels from 0 to n"
+    # ($alpha.files.:flatten()/:name("orders.csv").:last()). ANCHOR_
+    # MANIFEST has "orders.csv" at both zero segments preceding
+    # (directly under anchor's home) and one segment preceding
+    # ("2025/orders.csv"), plus "returns.csv" at both depths too (to
+    # prove the suffix anchor actually filters by name, not just by
+    # depth).
+    def test_last_pools_across_every_depth_including_zero(self):
+        # array order: one-pre, zero-pre, returns, nested-returns --
+        # zero-pre is LAST among the orders.csv-suffix matches, so it
+        # wins -- proves a zero-segment-preceding match is genuinely
+        # included, not just tolerated.
+        results = _finder(
+            '$anchor.files.:flatten()/:name("orders.csv").:last()',
+            ANCHOR_HOME,
+            ANCHOR_MANIFEST,
+        ).query()
+        assert results.uuids == ["u-zero-pre-1"]
+
+    def test_first_pools_across_every_depth_including_zero(self):
+        results = _finder(
+            '$anchor.files.:flatten()/:name("orders.csv").:first()',
+            ANCHOR_HOME,
+            ANCHOR_MANIFEST,
+        ).query()
+        assert results.uuids == ["u-one-pre-1"]
+
+    def test_only_matches_the_named_suffix_not_every_path(self):
+        # "returns.csv" entries at both depths must NOT appear.
+        results = _finder(
+            '$anchor.files.:flatten()/:name("orders.csv")',
+            ANCHOR_HOME,
+            ANCHOR_MANIFEST,
+        ).query()
+        assert set(results.files) == {
+            "inputs/named_files/anchor/orders.csv",
+            "inputs/named_files/anchor/2025/orders.csv",
+        }
+
+    def test_a_literal_name_alone_misses_the_deeper_entry(self):
+        # contrast: bare ':name("orders.csv")' alone is position-
+        # anchored (exactly one level), so it only sees the zero-
+        # preceding-segment match, never the "2025/orders.csv" one.
+        results = _finder(
+            '$anchor.files.:name("orders.csv")', ANCHOR_HOME, ANCHOR_MANIFEST
+        ).query()
+        assert results.files == ["inputs/named_files/anchor/orders.csv"]
+
+    def test_flatten_prefixed_rejects_an_argument(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$anchor.files.:flatten("x")/:name("orders.csv").:last()',
+                ANCHOR_HOME,
+                ANCHOR_MANIFEST,
+            ).query()
+
+    def test_a_literal_prefix_before_flatten_is_not_yet_supported(self):
+        # a THIRD shape -- literal prefix, THEN ':flatten()', THEN a
+        # literal/:name(...) suffix (e.g. "2025/:flatten()/:name(...)"
+        # -- "any orders.csv below 2025, at any depth") -- is a real,
+        # separate extension David flagged wanting eventually, deferred
+        # 2026-08-12 rather than built now. ':flatten()' is only
+        # recognized as name_one's FIRST segment today
+        # (_is_flatten_prefixed_reference); anywhere else it falls
+        # through to the ordinary _compile_path_pattern path, which
+        # raises cleanly rather than silently matching wrong -- adding
+        # this later is expected to be additive (a new elif branch
+        # keyed on ':flatten()' appearing at some OTHER position in
+        # name_one.path) and should not touch any non-prefixed shape's
+        # behavior, including the bare/no-prefix ':flatten()/...' shape
+        # this class already covers.
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$anchor.files.2025/:flatten()/:name("orders.csv").:last()',
+                ANCHOR_HOME,
+                ANCHOR_MANIFEST,
+            ).query()
+
+
 class TestGroupsForOneNamedFile:
     # bare ':groups()' as name_one's entire content, for a LITERAL
     # (non-'*') root_major -- added 2026-08-12, the any-depth GROUP peer

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -42,6 +42,36 @@ TEMPLATED_MANIFEST = [
     },
 ]
 
+# for TestAllForOneNamedFile -- one named-file (mixed) with two distinct
+# file_homes at DIFFERENT depths (one segment, two segments) under the
+# same home, each with more than one version. A literal/'*' pattern
+# always requires an exact segment count, so nothing before this could
+# reach both at once -- exactly the gap bare ':all()' fills for a single
+# named-file (settled 2026-08-12).
+MIXED_HOME = "inputs/named_files/mixed"
+MIXED_MANIFEST = [
+    {
+        "file": "inputs/named_files/mixed/zero.csv/aaa.csv",
+        "file_home": "inputs/named_files/mixed/zero.csv",
+        "uuid": "u-zero-1",
+    },
+    {
+        "file": "inputs/named_files/mixed/zero.csv/bbb.csv",
+        "file_home": "inputs/named_files/mixed/zero.csv",
+        "uuid": "u-zero-2",
+    },
+    {
+        "file": "inputs/named_files/mixed/nested/deep.csv/ccc.csv",
+        "file_home": "inputs/named_files/mixed/nested/deep.csv",
+        "uuid": "u-deep-1",
+    },
+    {
+        "file": "inputs/named_files/mixed/nested/deep.csv/ddd.csv",
+        "file_home": "inputs/named_files/mixed/nested/deep.csv",
+        "uuid": "u-deep-2",
+    },
+]
+
 
 class _FakeFileDescriber:
     def __init__(self, definition: dict):
@@ -560,6 +590,58 @@ class TestStarTraversalGroup:
     def test_all_combined_with_manifest_is_not_yet_supported(self):
         with pytest.raises(ReferenceException3):
             _star_finder("$*.files.:all().:last():manifest()").query()
+
+
+class TestAllForOneNamedFile:
+    # bare ':all()' as name_one's entire content, for a LITERAL (non-'*')
+    # root_major -- settled 2026-08-12. Mirrors TestStarTraversalGroup's
+    # own semantics exactly, just scoped to one named-file: every
+    # distinct file_home under this name, at ANY depth (not the exact
+    # one-level match a literal/'*' pattern always requires), each
+    # independently reduced by name_three's own pointer.
+    def test_all_with_last_gives_each_distinct_paths_own_latest(self):
+        results = _finder("$mixed.files.:all().:last()", MIXED_HOME, MIXED_MANIFEST)
+        r = results.query()
+        assert len(r.results) == 2
+        assert set(r.uuids) == {"u-zero-2", "u-deep-2"}
+
+    def test_all_with_first_gives_each_distinct_paths_own_earliest(self):
+        results = _finder("$mixed.files.:all().:first()", MIXED_HOME, MIXED_MANIFEST)
+        r = results.query()
+        assert len(r.results) == 2
+        assert set(r.uuids) == {"u-zero-1", "u-deep-1"}
+
+    def test_all_with_no_name_three_dedupes_to_file_home_directories_any_depth(self):
+        results = _finder("$mixed.files.:all()", MIXED_HOME, MIXED_MANIFEST)
+        r = results.query()
+        assert set(r.files) == {
+            "inputs/named_files/mixed/zero.csv",
+            "inputs/named_files/mixed/nested/deep.csv",
+        }
+
+    def test_a_literal_star_misses_the_two_level_entry_all_does_not(self):
+        # proves ':all()' is genuinely reaching further than '*' can --
+        # '*' requires exactly one level, so it only ever sees zero.csv.
+        star_results = _finder(
+            "$mixed.files.*.:last()", MIXED_HOME, MIXED_MANIFEST
+        ).query()
+        assert star_results.uuids == ["u-zero-2"]
+        all_results = _finder(
+            "$mixed.files.:all().:last()", MIXED_HOME, MIXED_MANIFEST
+        ).query()
+        assert set(all_results.uuids) == {"u-zero-2", "u-deep-2"}
+
+    def test_all_combined_with_manifest_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$mixed.files.:all().:last():manifest()", MIXED_HOME, MIXED_MANIFEST
+            ).query()
+
+    def test_all_combined_with_a_field_accessor_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$mixed.files.:all().:last():uuid()", MIXED_HOME, MIXED_MANIFEST
+            ).query()
 
 
 class TestManifestCombinedWithNameThree:

--- a/tests/references/test_normative_examples_files.py
+++ b/tests/references/test_normative_examples_files.py
@@ -157,6 +157,55 @@ class TestEveryVersionUnreduced:
         assert results.files == ["inputs/named_files/alpha/orders.csv"]
 
 
+class TestAllOnNameThree:
+    # doc line "### ':all()' in name_three" -- mirrors CSVPATHS' own
+    # ':all()' precedent: not a POINTER, so its whole effect is simply
+    # NOT reducing -- every matched version, unreduced, real uuids.
+    def test_all_gives_every_matched_version_with_real_uuids(self):
+        results = _finder(
+            '$alpha.files.:name("orders.csv").:all()', ALPHA_HOME, ALPHA_MANIFEST
+        ).query()
+        assert set(results.uuids) == {"u-orders-1", "u-orders-2", "u-orders-3"}
+
+
+HOME_TEST_HOME = "inputs/named_files/homer"
+HOME_TEST_MANIFEST = [
+    {
+        "file": "inputs/named_files/homer/aaa.csv",
+        "file_home": "inputs/named_files/homer",
+        "uuid": "u-zero-1",
+    },
+    {
+        "file": "inputs/named_files/homer/bbb.csv",
+        "file_home": "inputs/named_files/homer",
+        "uuid": "u-zero-2",
+    },
+    {
+        "file": "inputs/named_files/homer/orders.csv/ccc.csv",
+        "file_home": "inputs/named_files/homer/orders.csv",
+        "uuid": "u-one-level",
+    },
+]
+
+
+class TestHomeAsAZeroLevelSelector:
+    # doc lines "### ':home()' as a zero-level selector" -- mirrors
+    # RESULTS' own ':home()'.
+    def test_home_then_pointer_gives_the_latest_zero_level_entry(self):
+        results = _finder(
+            "$homer.files.:home().:last()", HOME_TEST_HOME, HOME_TEST_MANIFEST
+        ).query()
+        assert results.uuids == ["u-zero-2"]
+
+    def test_bare_home_dedupes_to_the_named_files_own_home_unreduced(self):
+        results = _finder(
+            "$homer.files.:home()", HOME_TEST_HOME, HOME_TEST_MANIFEST
+        ).query()
+        assert results.files == [HOME_TEST_HOME]
+        assert results.results[0].uuid is None
+        assert "u-one-level" not in results.uuids
+
+
 class TestPoolAcrossOneNamedFileExactlyOneLevel:
     # doc line "$alpha.files.*.:last()" -- pools every EXACTLY-one-level
     # path under alpha (orders.csv AND returns.csv) into one list, in

--- a/tests/references/test_normative_examples_files.py
+++ b/tests/references/test_normative_examples_files.py
@@ -248,6 +248,64 @@ class TestFlattenForOneNamedFile:
         }
 
 
+ANCHOR_HOME = "inputs/named_files/anchor"
+ANCHOR_MANIFEST = [
+    {
+        "file": "inputs/named_files/anchor/2025/orders.csv/aaa.csv",
+        "file_home": "inputs/named_files/anchor/2025/orders.csv",
+        "uuid": "u-one-pre-1",
+    },
+    {
+        "file": "inputs/named_files/anchor/orders.csv/bbb.csv",
+        "file_home": "inputs/named_files/anchor/orders.csv",
+        "uuid": "u-zero-pre-1",
+    },
+    {
+        "file": "inputs/named_files/anchor/returns.csv/ccc.csv",
+        "file_home": "inputs/named_files/anchor/returns.csv",
+        "uuid": "u-returns",
+    },
+]
+
+
+class TestFlattenPrefixedWithSuffix:
+    # doc lines "### ':flatten()' as name_one's FIRST segment, followed
+    # by a fixed literal/:name(...) suffix" -- built 2026-08-12. Reaches
+    # "orders.csv" at both zero segments preceding (directly under
+    # anchor's own home) and one segment preceding ("2025/orders.csv"),
+    # correctly excluding "returns.csv" at either depth.
+    def test_last_pools_across_every_depth_including_zero(self):
+        results = _finder(
+            '$anchor.files.:flatten()/:name("orders.csv").:last()',
+            ANCHOR_HOME,
+            ANCHOR_MANIFEST,
+        ).query()
+        assert results.uuids == ["u-zero-pre-1"]
+
+    def test_alone_gives_only_the_named_suffix_at_any_depth(self):
+        results = _finder(
+            '$anchor.files.:flatten()/:name("orders.csv")',
+            ANCHOR_HOME,
+            ANCHOR_MANIFEST,
+        ).query()
+        assert set(results.files) == {
+            "inputs/named_files/anchor/orders.csv",
+            "inputs/named_files/anchor/2025/orders.csv",
+        }
+
+    def test_a_literal_prefix_before_flatten_is_not_yet_supported(self):
+        # doc note: a literal prefix BEFORE ':flatten()' (e.g. "2025/
+        # :flatten()/:name(...)") is a real, deliberately deferred
+        # extension -- not built yet, confirmed to raise cleanly rather
+        # than match silently wrong.
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$anchor.files.2025/:flatten()/:name("orders.csv").:first()',
+                ANCHOR_HOME,
+                ANCHOR_MANIFEST,
+            ).query()
+
+
 class TestGroupsForOneNamedFile:
     # doc lines "### ':groups()' for ONE named-file" -- the any-depth
     # GROUP peer of ':all()' (one-level GROUP)/':flatten()' (any-depth

--- a/tests/references/test_normative_examples_files.py
+++ b/tests/references/test_normative_examples_files.py
@@ -248,6 +248,32 @@ class TestFlattenForOneNamedFile:
         }
 
 
+class TestGroupsForOneNamedFile:
+    # doc lines "### ':groups()' for ONE named-file" -- the any-depth
+    # GROUP peer of ':all()' (one-level GROUP)/':flatten()' (any-depth
+    # POOL), added 2026-08-12. Reaches both of MIXED_MANIFEST's distinct
+    # depths, each independently reduced -- the mixed-depth case ':all()'
+    # cannot reach on its own.
+    def test_groups_last_gives_each_paths_own_latest_at_any_depth(self):
+        results = _finder(
+            "$mixed.files.:groups().:last()", MIXED_HOME, MIXED_MANIFEST
+        ).query()
+        assert set(results.uuids) == {"u-zero-2", "u-deep-2"}
+
+    def test_groups_first_gives_each_paths_own_earliest_at_any_depth(self):
+        results = _finder(
+            "$mixed.files.:groups().:first()", MIXED_HOME, MIXED_MANIFEST
+        ).query()
+        assert set(results.uuids) == {"u-zero-1", "u-deep-1"}
+
+    def test_groups_alone_gives_every_distinct_path_any_depth_unreduced(self):
+        results = _finder("$mixed.files.:groups()", MIXED_HOME, MIXED_MANIFEST).query()
+        assert set(results.files) == {
+            "inputs/named_files/mixed/zero.csv",
+            "inputs/named_files/mixed/nested/deep.csv",
+        }
+
+
 class TestManifestEitherOrder:
     # doc lines "### The version's own manifest entry, either order"
     def test_pointer_then_manifest(self):
@@ -482,6 +508,20 @@ class TestStarTraversalFlattenAnyDepth:
         assert star_results.uuids == ["u-two-2"]
         flatten_results = _flatten_star_finder("$*.files.:flatten().:last()").query()
         assert flatten_results.uuids == ["u-gamma-deep-1"]
+
+
+class TestStarTraversalGroupsAnyDepth:
+    # doc line "### '*' traversal, GROUP, any depth" -- one result per
+    # (named-file, path) pair regardless of depth, including gamma's
+    # two-level entry that ':all()' cannot reach.
+    def test_last_gives_one_result_per_named_file_and_path_any_depth(self):
+        groups_results = _flatten_star_finder("$*.files.:groups().:last()").query()
+        assert set(groups_results.uuids) == {
+            "u-zero-1",
+            "u-one-2",
+            "u-two-2",
+            "u-gamma-deep-1",
+        }
 
 
 class TestFieldAccessorsOnOneMatchedVersion:

--- a/tests/references/test_normative_examples_files.py
+++ b/tests/references/test_normative_examples_files.py
@@ -199,22 +199,49 @@ MIXED_MANIFEST = [
 
 class TestAllForOneNamedFile:
     # doc lines "### ':all()' for ONE named-file" -- every distinct path
-    # under one named-file, at ANY depth (unlike '*' above, which
-    # requires exactly one level), each independently reduced.
+    # under one named-file, EXACTLY one level deep (same match as '*'),
+    # each independently reduced -- corrected 2026-08-12 to stay a
+    # one-level peer of '*', matching RESULTS' own vocabulary. Uses
+    # ALPHA_MANIFEST (orders.csv x3, returns.csv x1, both one level).
     def test_all_last_gives_each_paths_own_latest(self):
         results = _finder(
-            "$mixed.files.:all().:last()", MIXED_HOME, MIXED_MANIFEST
+            "$alpha.files.:all().:last()", ALPHA_HOME, ALPHA_MANIFEST
         ).query()
-        assert set(results.uuids) == {"u-zero-2", "u-deep-2"}
+        assert set(results.uuids) == {"u-orders-3", "u-returns-1"}
 
     def test_all_first_gives_each_paths_own_earliest(self):
         results = _finder(
-            "$mixed.files.:all().:first()", MIXED_HOME, MIXED_MANIFEST
+            "$alpha.files.:all().:first()", ALPHA_HOME, ALPHA_MANIFEST
         ).query()
-        assert set(results.uuids) == {"u-zero-1", "u-deep-1"}
+        assert set(results.uuids) == {"u-orders-1", "u-returns-1"}
 
-    def test_all_alone_gives_every_distinct_path_at_any_depth_unreduced(self):
-        results = _finder("$mixed.files.:all()", MIXED_HOME, MIXED_MANIFEST).query()
+    def test_all_alone_gives_every_distinct_one_level_path_unreduced(self):
+        results = _finder("$alpha.files.:all()", ALPHA_HOME, ALPHA_MANIFEST).query()
+        assert set(results.files) == {
+            "inputs/named_files/alpha/orders.csv",
+            "inputs/named_files/alpha/returns.csv",
+        }
+
+
+class TestFlattenForOneNamedFile:
+    # doc lines "### ':flatten()' for ONE named-file" -- the any-depth
+    # POOL peer of ':all()' (one-level GROUP)/'*' (one-level POOL),
+    # added 2026-08-12. MIXED_MANIFEST has two distinct file_homes at
+    # DIFFERENT depths -- exactly what '*'/':all()' cannot reach.
+    def test_flatten_last_pools_across_every_depth(self):
+        results = _finder(
+            "$mixed.files.:flatten().:last()", MIXED_HOME, MIXED_MANIFEST
+        ).query()
+        assert results.uuids == ["u-deep-2"]
+
+    def test_flatten_first_pools_across_every_depth(self):
+        results = _finder(
+            "$mixed.files.:flatten().:first()", MIXED_HOME, MIXED_MANIFEST
+        ).query()
+        assert results.uuids == ["u-zero-1"]
+
+    def test_flatten_alone_gives_every_distinct_path_any_depth_unreduced(self):
+        results = _finder("$mixed.files.:flatten()", MIXED_HOME, MIXED_MANIFEST).query()
         assert set(results.files) == {
             "inputs/named_files/mixed/zero.csv",
             "inputs/named_files/mixed/nested/deep.csv",
@@ -422,10 +449,39 @@ class TestStarTraversalPool:
 
 class TestStarTraversalGroup:
     # doc line "### '*' traversal, GROUP -- one result per (named-file,
-    # path) pair"
+    # path) pair, each match still exactly one level deep"
     def test_all_last_gives_one_result_per_named_file_and_path(self):
         results = _star_finder("$*.files.:all().:last()").query()
         assert set(results.uuids) == {"u-zero-1", "u-one-2", "u-two-2"}
+
+
+FLATTEN_GAMMA_HOME = "inputs/named_files/gamma"
+FLATTEN_GAMMA_MANIFEST = [
+    {
+        "file": "inputs/named_files/gamma/nested/deep.csv/fff.csv",
+        "file_home": "inputs/named_files/gamma/nested/deep.csv",
+        "uuid": "u-gamma-deep-1",
+        "time": "2026-01-06T00:00:00+00:00",
+    },
+]
+FLATTEN_BY_NAME = dict(STAR_BY_NAME, gamma=(FLATTEN_GAMMA_HOME, FLATTEN_GAMMA_MANIFEST))
+
+
+def _flatten_star_finder(reference: str) -> FilesReferenceFinder3:
+    csvpaths = _FakeCsvPaths(_FakeFileManager(None, None, by_name=FLATTEN_BY_NAME))
+    ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
+    return FilesReferenceFinder3(csvpaths=csvpaths, ref=ref)
+
+
+class TestStarTraversalFlattenAnyDepth:
+    # doc line "### '*' traversal, POOL, any depth" -- gamma's two-level
+    # entry (chronologically latest) is reachable only by ':flatten()',
+    # not by '*' (exactly one level).
+    def test_last_reaches_a_two_level_entry_star_cannot(self):
+        star_results = _flatten_star_finder("$*.files.*.:last()").query()
+        assert star_results.uuids == ["u-two-2"]
+        flatten_results = _flatten_star_finder("$*.files.:flatten().:last()").query()
+        assert flatten_results.uuids == ["u-gamma-deep-1"]
 
 
 class TestFieldAccessorsOnOneMatchedVersion:

--- a/tests/references/test_normative_examples_files.py
+++ b/tests/references/test_normative_examples_files.py
@@ -1,0 +1,521 @@
+"""Encodes the currently-buildable FILES examples from
+`references_notes/notes/normative_reference_examples.txt` as real, running
+assertions -- same methodology as `test_normative_examples_results.py`:
+David's own agreed alternative to relying on manual code review against the
+doc, rely on the normative references instead.
+
+Scope: FILES only. Every example in the doc's "The Files Datatype" section
+was verified against real code on 2026-08-11 (per the section's own note),
+and all of it is built -- there is nothing to exclude here the way RESULTS
+had unbuilt time/filter functions to skip. Doc lines are given by their
+current position in the doc as of 2026-08-12; each test is commented with
+the exact line(s) it encodes. When the doc's FILES section changes, update
+the line references here to match.
+"""
+
+import json
+
+import pytest
+
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+from csvpath.references.reference_parser_3 import ReferenceParser3
+from csvpath.references.files_reference_finder_3 import FilesReferenceFinder3
+
+
+class _FakeFileDescriber:
+    def __init__(self, definition: dict):
+        self._definition = definition
+
+    def get_config(self, name):
+        from csvpath.managers.files.file_descriptor import Config
+
+        return Config(**self._definition)
+
+
+class _FakeFileManager:
+    def __init__(
+        self,
+        home,
+        manifest,
+        definition: dict | None = None,
+        ledger=None,
+        by_name: dict | None = None,
+    ):
+        self._home = home
+        self._manifest = manifest
+        self._definition = definition or {}
+        self._ledger = manifest if ledger is None else ledger
+        self._by_name = by_name
+
+    def named_file_home(self, name):
+        if self._by_name is not None:
+            return self._by_name[name][0]
+        return self._home
+
+    def get_manifest(self, name):
+        if self._by_name is not None:
+            return self._by_name[name][1]
+        return self._manifest
+
+    @property
+    def named_file_names(self):
+        if self._by_name is not None:
+            return list(self._by_name.keys())
+        return []
+
+    @property
+    def files_root_manifest(self):
+        return self._ledger
+
+    @property
+    def describer(self):
+        return _FakeFileDescriber(self._definition)
+
+
+class _FakeConfig:
+    def __init__(self, inputs_files_path: str | None = None):
+        self.inputs_files_path = inputs_files_path
+
+
+class _FakeCsvPaths:
+    def __init__(self, file_manager, inputs_files_path: str | None = None):
+        self.file_manager = file_manager
+        self.config = _FakeConfig(inputs_files_path)
+
+
+def _finder(
+    reference: str,
+    home: str,
+    manifest: list,
+    definition: dict | None = None,
+    inputs_files_path: str | None = None,
+    ledger: list | None = None,
+    by_name: dict | None = None,
+) -> FilesReferenceFinder3:
+    csvpaths = _FakeCsvPaths(
+        _FakeFileManager(home, manifest, definition, ledger=ledger, by_name=by_name),
+        inputs_files_path=inputs_files_path,
+    )
+    ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
+    return FilesReferenceFinder3(csvpaths=csvpaths, ref=ref)
+
+
+ALPHA_HOME = "inputs/named_files/alpha"
+ALPHA_MANIFEST = [
+    {
+        "file": "inputs/named_files/alpha/orders.csv/aaa.csv",
+        "file_home": "inputs/named_files/alpha/orders.csv",
+        "uuid": "u-orders-1",
+    },
+    {
+        "file": "inputs/named_files/alpha/orders.csv/bbb.csv",
+        "file_home": "inputs/named_files/alpha/orders.csv",
+        "uuid": "u-orders-2",
+    },
+    {
+        "file": "inputs/named_files/alpha/returns.csv/ccc.csv",
+        "file_home": "inputs/named_files/alpha/returns.csv",
+        "uuid": "u-returns-1",
+    },
+    {
+        "file": "inputs/named_files/alpha/orders.csv/ddd.csv",
+        "file_home": "inputs/named_files/alpha/orders.csv",
+        "uuid": "u-orders-3",
+    },
+]
+
+
+class TestLiteralNamedFileOneVersion:
+    # doc lines "### Literal named-file, one version" -- the pointer/
+    # accessor lives in name_three, chained after a "." onto :name(...).
+    def test_last(self):
+        results = _finder(
+            '$alpha.files.:name("orders.csv").:last()', ALPHA_HOME, ALPHA_MANIFEST
+        ).query()
+        assert results.uuids == ["u-orders-3"]
+
+    def test_first(self):
+        results = _finder(
+            '$alpha.files.:name("orders.csv").:first()', ALPHA_HOME, ALPHA_MANIFEST
+        ).query()
+        assert results.uuids == ["u-orders-1"]
+
+    def test_index_is_zero_based(self):
+        results = _finder(
+            '$alpha.files.:name("orders.csv").:index(1)', ALPHA_HOME, ALPHA_MANIFEST
+        ).query()
+        assert results.uuids == ["u-orders-2"]
+
+
+class TestEveryVersionUnreduced:
+    # doc line "### Every version of a literal named-file, unreduced"
+    def test_every_version_of_one_named_path(self):
+        results = _finder(
+            '$alpha.files.:name("orders.csv")', ALPHA_HOME, ALPHA_MANIFEST
+        ).query()
+        assert results.uuids == [None]
+        assert results.files == ["inputs/named_files/alpha/orders.csv"]
+
+
+class TestPoolAcrossOneNamedFileExactlyOneLevel:
+    # doc line "$alpha.files.*.:last()" -- pools every EXACTLY-one-level
+    # path under alpha (orders.csv AND returns.csv) into one list, in
+    # true manifest-array arrival order (the last entry written wins,
+    # not the last alphabetically) -- confirms cross-path pooling, not
+    # just within one already-known path.
+    def test_last_across_every_one_level_path(self):
+        results = _finder("$alpha.files.*.:last()", ALPHA_HOME, ALPHA_MANIFEST).query()
+        assert results.uuids == ["u-orders-3"]
+
+    def test_first_across_every_one_level_path(self):
+        results = _finder("$alpha.files.*.:first()", ALPHA_HOME, ALPHA_MANIFEST).query()
+        assert results.uuids == ["u-orders-1"]
+
+
+MIXED_HOME = "inputs/named_files/mixed"
+MIXED_MANIFEST = [
+    {
+        "file": "inputs/named_files/mixed/zero.csv/aaa.csv",
+        "file_home": "inputs/named_files/mixed/zero.csv",
+        "uuid": "u-zero-1",
+    },
+    {
+        "file": "inputs/named_files/mixed/zero.csv/bbb.csv",
+        "file_home": "inputs/named_files/mixed/zero.csv",
+        "uuid": "u-zero-2",
+    },
+    {
+        "file": "inputs/named_files/mixed/nested/deep.csv/ccc.csv",
+        "file_home": "inputs/named_files/mixed/nested/deep.csv",
+        "uuid": "u-deep-1",
+    },
+    {
+        "file": "inputs/named_files/mixed/nested/deep.csv/ddd.csv",
+        "file_home": "inputs/named_files/mixed/nested/deep.csv",
+        "uuid": "u-deep-2",
+    },
+]
+
+
+class TestAllForOneNamedFile:
+    # doc lines "### ':all()' for ONE named-file" -- every distinct path
+    # under one named-file, at ANY depth (unlike '*' above, which
+    # requires exactly one level), each independently reduced.
+    def test_all_last_gives_each_paths_own_latest(self):
+        results = _finder(
+            "$mixed.files.:all().:last()", MIXED_HOME, MIXED_MANIFEST
+        ).query()
+        assert set(results.uuids) == {"u-zero-2", "u-deep-2"}
+
+    def test_all_first_gives_each_paths_own_earliest(self):
+        results = _finder(
+            "$mixed.files.:all().:first()", MIXED_HOME, MIXED_MANIFEST
+        ).query()
+        assert set(results.uuids) == {"u-zero-1", "u-deep-1"}
+
+    def test_all_alone_gives_every_distinct_path_at_any_depth_unreduced(self):
+        results = _finder("$mixed.files.:all()", MIXED_HOME, MIXED_MANIFEST).query()
+        assert set(results.files) == {
+            "inputs/named_files/mixed/zero.csv",
+            "inputs/named_files/mixed/nested/deep.csv",
+        }
+
+
+class TestManifestEitherOrder:
+    # doc lines "### The version's own manifest entry, either order"
+    def test_pointer_then_manifest(self):
+        results = _finder(
+            '$alpha.files.:name("orders.csv").:last():manifest()',
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+        ).resolve()
+        assert results.results[0].data == ALPHA_MANIFEST[3]
+
+    def test_manifest_then_pointer(self):
+        results = _finder(
+            '$alpha.files.:name("orders.csv").:manifest():last()',
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+        ).resolve()
+        assert results.results[0].data == ALPHA_MANIFEST[3]
+
+
+class TestDefinitionBare:
+    # doc line "$alpha.files.:definition()" -- bare, no :name(.../version
+    # needed, since definition.json is per named-file not per-version.
+    def test_resolves_the_raw_definition_bytes(self, tmp_path):
+        content = b'{"sources": {}}'
+        home = tmp_path / "alpha"
+        home.mkdir()
+        (home / "definition.json").write_bytes(content)
+        results = _finder(
+            "$alpha.files.:definition()", str(home), ALPHA_MANIFEST
+        ).resolve()
+        assert results.results[0].data == content
+
+
+RICH_HOME = "inputs/named_files/rich"
+RICH_MANIFEST = [
+    {
+        "file": "inputs/named_files/rich/orders.csv/aaaa.csv",
+        "file_home": "inputs/named_files/rich/orders.csv",
+        "uuid": "u-rich-1",
+        "time": "2026-01-01T00:00:00+00:00",
+        "fingerprint": "aaaa",
+        "from": "/staging/orders.csv",
+        "mark": "Sheet1",
+    },
+    {
+        "file": "inputs/named_files/rich/orders.csv/bbbb.csv",
+        "file_home": "inputs/named_files/rich/orders.csv",
+        "uuid": "u-rich-2",
+        "time": "2026-02-01T00:00:00+00:00",
+        "fingerprint": "bbbb",
+        "from": "/staging/orders.csv",
+    },
+]
+RICH_DEFINITION = {
+    "on_arrival": {
+        "named_paths_group": "order validations",
+        "run_method": "collect_paths",
+    },
+    "sources": {"a": {"address": "localhost", "port": 22}},
+}
+
+
+class TestDefinitionFieldAccessorsNeedAMatchedVersion:
+    # doc lines "### on_arrival/sources sub-objects DO need a matched
+    # version + '.' + accessor, even though the value is the same
+    # regardless of which version matched" -- SOURCE="definition", not
+    # versioned, but still syntactically hangs off a matched version.
+    def test_on_arrival(self):
+        results = _finder(
+            '$rich.files.:name("orders.csv").:first():on_arrival()',
+            RICH_HOME,
+            RICH_MANIFEST,
+            RICH_DEFINITION,
+        ).resolve()
+        assert results.results[0].data == RICH_DEFINITION["on_arrival"]
+
+    def test_sources(self):
+        results = _finder(
+            '$rich.files.:name("orders.csv").:first():sources()',
+            RICH_HOME,
+            RICH_MANIFEST,
+            RICH_DEFINITION,
+        ).resolve()
+        assert results.results[0].data == RICH_DEFINITION["sources"]
+
+
+class TestGlobalArrivalsLedger:
+    # doc line "### Global arrivals ledger -- every named-file's own
+    # arrival, one flat array"
+    def test_resolves_the_ledgers_raw_bytes(self, tmp_path):
+        content = b'[{"named_file_name": "alpha"}, {"named_file_name": "beta"}]'
+        root = tmp_path / "named_files"
+        root.mkdir()
+        (root / "manifest.json").write_bytes(content)
+        results = _finder(
+            "$*.files.:manifest()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path=str(root),
+        ).resolve()
+        assert results.results[0].data == content
+
+
+LEDGER = [
+    {"named_file_name": "alpha", "uuid": "u-ledger-1"},
+    {"named_file_name": "beta", "uuid": "u-ledger-2"},
+    {"named_file_name": "gamma", "uuid": "u-ledger-3"},
+]
+
+
+class TestGlobalArrivalsLedgerOrdinalIndexing:
+    # doc lines "### Ordinal indexing into the global ledger, either order"
+    def test_pointer_then_manifest(self):
+        results = _finder(
+            "$*.files.:last():manifest()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+            ledger=LEDGER,
+        ).resolve()
+        assert results.results[0].data == LEDGER[-1]
+
+    def test_manifest_then_pointer(self):
+        results = _finder(
+            "$*.files.:manifest():last()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+            ledger=LEDGER,
+        ).query()
+        assert results.results[0].uuid == "u-ledger-3"
+
+
+#
+# matches the spec compendium's own EXAMPLE SCENARIO ("Why a trailing bare
+# '*' is illegal but bare ':all()' is fine"): named-file alpha (zero.csv x1
+# version, one.csv x2 versions), named-file beta (two.csv x2 versions).
+# beta listed FIRST on purpose -- naive concatenation with no time-sort
+# would put alpha's own entries last, so a test asserting beta's true-
+# latest entry wins fails if the pool case's time-sort is ever broken.
+#
+STAR_ALPHA_HOME = "inputs/named_files/alpha"
+STAR_ALPHA_MANIFEST = [
+    {
+        "file": "inputs/named_files/alpha/zero.csv/aaa.csv",
+        "file_home": "inputs/named_files/alpha/zero.csv",
+        "uuid": "u-zero-1",
+        "time": "2026-01-01T00:00:00+00:00",
+    },
+    {
+        "file": "inputs/named_files/alpha/one.csv/bbb.csv",
+        "file_home": "inputs/named_files/alpha/one.csv",
+        "uuid": "u-one-1",
+        "time": "2026-01-02T00:00:00+00:00",
+    },
+    {
+        "file": "inputs/named_files/alpha/one.csv/ccc.csv",
+        "file_home": "inputs/named_files/alpha/one.csv",
+        "uuid": "u-one-2",
+        "time": "2026-01-03T00:00:00+00:00",
+    },
+]
+STAR_BETA_HOME = "inputs/named_files/beta"
+STAR_BETA_MANIFEST = [
+    {
+        "file": "inputs/named_files/beta/two.csv/ddd.csv",
+        "file_home": "inputs/named_files/beta/two.csv",
+        "uuid": "u-two-1",
+        "time": "2026-01-04T00:00:00+00:00",
+    },
+    {
+        "file": "inputs/named_files/beta/two.csv/eee.csv",
+        "file_home": "inputs/named_files/beta/two.csv",
+        "uuid": "u-two-2",
+        "time": "2026-01-05T00:00:00+00:00",
+    },
+]
+STAR_BY_NAME = {
+    "beta": (STAR_BETA_HOME, STAR_BETA_MANIFEST),
+    "alpha": (STAR_ALPHA_HOME, STAR_ALPHA_MANIFEST),
+}
+
+
+def _star_finder(reference: str) -> FilesReferenceFinder3:
+    csvpaths = _FakeCsvPaths(
+        _FakeFileManager(None, None, by_name=STAR_BY_NAME),
+    )
+    ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
+    return FilesReferenceFinder3(csvpaths=csvpaths, ref=ref)
+
+
+class TestStarTraversalPool:
+    # doc line "### '*' traversal, POOL -- single true-latest version
+    # across every named-file, each match still exactly one level deep"
+    def test_last_across_every_named_file(self):
+        results = _star_finder("$*.files.*.:last()").query()
+        assert results.uuids == ["u-two-2"]
+
+
+class TestStarTraversalGroup:
+    # doc line "### '*' traversal, GROUP -- one result per (named-file,
+    # path) pair"
+    def test_all_last_gives_one_result_per_named_file_and_path(self):
+        results = _star_finder("$*.files.:all().:last()").query()
+        assert set(results.uuids) == {"u-zero-1", "u-one-2", "u-two-2"}
+
+
+class TestFieldAccessorsOnOneMatchedVersion:
+    # doc lines "### Field accessors on one matched version"
+    def test_uuid(self):
+        results = _finder(
+            '$rich.files.:name("orders.csv").:last():uuid()',
+            RICH_HOME,
+            RICH_MANIFEST,
+        ).resolve()
+        assert results.results[0].data == "u-rich-2"
+
+    def test_time(self):
+        results = _finder(
+            '$rich.files.:name("orders.csv").:last():time()',
+            RICH_HOME,
+            RICH_MANIFEST,
+        ).resolve()
+        assert results.results[0].data == "2026-02-01T00:00:00+00:00"
+
+    def test_fingerprint(self):
+        results = _finder(
+            '$rich.files.:name("orders.csv").:last():fingerprint()',
+            RICH_HOME,
+            RICH_MANIFEST,
+        ).resolve()
+        assert results.results[0].data == "bbbb"
+
+    def test_home_gives_file_home(self):
+        results = _finder(
+            '$rich.files.:name("orders.csv").:last():home()',
+            RICH_HOME,
+            RICH_MANIFEST,
+        ).resolve()
+        assert results.results[0].data == "inputs/named_files/rich/orders.csv"
+
+    def test_origin(self):
+        results = _finder(
+            '$rich.files.:name("orders.csv").:last():origin()',
+            RICH_HOME,
+            RICH_MANIFEST,
+        ).resolve()
+        assert results.results[0].data == "/staging/orders.csv"
+
+    def test_mark_absent_gives_none(self):
+        # RICH_MANIFEST[1] (the last/most recent version) has no "mark"
+        # key -- absence is a normal, expected None, not an error.
+        results = _finder(
+            '$rich.files.:name("orders.csv").:last():mark()',
+            RICH_HOME,
+            RICH_MANIFEST,
+        ).resolve()
+        assert results.results[0].data is None
+
+
+class TestPathFunction:
+    # doc lines "### The filesystem path to a whole-resource function's
+    # own resource, rather than its content"
+    def test_path_wrapping_manifest_bare(self):
+        results = _finder(
+            '$alpha.files.:name("orders.csv").:path(:manifest())',
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+        ).resolve()
+        assert results.results[0].data == f"{ALPHA_HOME}/manifest.json"
+
+    def test_path_wrapping_manifest_beside_a_pointer(self):
+        results = _finder(
+            '$alpha.files.:name("orders.csv").:last():path(:manifest())',
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+        ).resolve()
+        assert results.results[0].data == f"{ALPHA_HOME}/manifest.json"
+
+
+class TestComputedFields:
+    # doc lines "### Computed fields -- never stored, derived from the
+    # reference itself"
+    def test_named_file_name(self):
+        results = _finder(
+            '$alpha.files.:name("orders.csv").:named_file_name()',
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+        ).resolve()
+        assert [r.data for r in results.results] == ["alpha", "alpha", "alpha"]
+
+    def test_named_file_home(self):
+        results = _finder(
+            '$alpha.files.:name("orders.csv").:first():named_file_home()',
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+        ).resolve()
+        assert results.results[0].data == ALPHA_HOME

--- a/tests/references/test_normative_examples_files.py
+++ b/tests/references/test_normative_examples_files.py
@@ -336,26 +336,20 @@ RICH_DEFINITION = {
 }
 
 
-class TestDefinitionFieldAccessorsNeedAMatchedVersion:
-    # doc lines "### on_arrival/sources sub-objects DO need a matched
-    # version + '.' + accessor, even though the value is the same
-    # regardless of which version matched" -- SOURCE="definition", not
-    # versioned, but still syntactically hangs off a matched version.
+class TestBareDefinitionFieldAccessors:
+    # doc lines "### on_arrival/sources" -- corrected 2026-08-12, David:
+    # an arrival activation lives in the named-file's own description.
+    # json, it does not go to the version level -- bare, no :name(.../
+    # version needed, matching ":definition()" itself.
     def test_on_arrival(self):
         results = _finder(
-            '$rich.files.:name("orders.csv").:first():on_arrival()',
-            RICH_HOME,
-            RICH_MANIFEST,
-            RICH_DEFINITION,
+            "$rich.files.:on_arrival()", RICH_HOME, RICH_MANIFEST, RICH_DEFINITION
         ).resolve()
         assert results.results[0].data == RICH_DEFINITION["on_arrival"]
 
     def test_sources(self):
         results = _finder(
-            '$rich.files.:name("orders.csv").:first():sources()',
-            RICH_HOME,
-            RICH_MANIFEST,
-            RICH_DEFINITION,
+            "$rich.files.:sources()", RICH_HOME, RICH_MANIFEST, RICH_DEFINITION
         ).resolve()
         assert results.results[0].data == RICH_DEFINITION["sources"]
 

--- a/tests/references/test_normative_examples_results.py
+++ b/tests/references/test_normative_examples_results.py
@@ -14,8 +14,9 @@ supported, add/move the corresponding test here -- this file is meant to
 grow in lockstep with the doc, not be written once and left behind.
 
 Excluded doc lines and why (checked directly against the doc as of
-2026-08-11, not assumed):
-  - line 39 (:groups()) -- not built, explicitly deferred.
+2026-08-12, not assumed):
+  - line 39 (:groups()) -- built 2026-08-12 (was excluded/deferred as of
+    this file's original writing); see TestFindingTheLastRun.
   - lines 42/48/51 (:from()/:yesterday()/:hour()/:message()/:count()/
     :above()) -- none of these functions are built yet. Lines 42/51 also
     use a bare '*' in name_three, which is illegal (see
@@ -192,6 +193,23 @@ class TestFindingTheLastRun:
         _write_json(tmp_path / "manifest.json", ledger)
         results = _finder("$*.results.:manifest():last()", str(tmp_path)).resolve()
         assert results.results[0].data["run_uuid"] == "run-2"
+
+    def test_line_39_groups_reaches_every_template_and_non_template_run_dir(
+        self, alpha_archive
+    ):
+        # $alpha.results.:groups():last() >> runs for every template and
+        # non-template run dir -- added 2026-08-12 (was excluded/not
+        # built as of this file's original writing). alpha_archive has
+        # four distinct groups (zero-level, "zero", "beta/x", "beta/y"),
+        # each with exactly one run here, so ':last()' of each group is
+        # just that one run.
+        results = _finder("$alpha.results.:groups():last()", alpha_archive).query()
+        assert set(results.uuids) == {
+            "flat-uuid",
+            "zero-uuid",
+            "beta-x-uuid",
+            "beta-y-uuid",
+        }
 
 
 class TestAllIsAOneLevelOperator:

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -458,6 +458,116 @@ class TestAllGrouping:
             ).query()
 
 
+class TestGroups:
+    # ':groups()' -- added 2026-08-12, the any-depth GROUP peer of
+    # ':all()' (one-level GROUP)/':flatten()' (any-depth POOL), built
+    # alongside FILES' own ':groups()' in the same pass (David: keep
+    # functions meaning the same thing across datatypes). Same any-depth
+    # candidate set as ':flatten()', but partitioned by _group_key
+    # (each run's FULL relative path, not just its last segment -- see
+    # that method's own docstring for why: two runs at different depths
+    # sharing a common trailing segment, e.g. "beta/x" vs. "gamma/x",
+    # must never be conflated into one group).
+    def test_groups_reaches_every_depth_independently_no_collisions(
+        self, tmp_path
+    ):
+        base = tmp_path / "alpha"
+        flat_run = _make_run(base, "2026-01-01_00-00-00", "flat-uuid", {})
+        beta_x_1 = _make_run(base / "beta" / "x", "2026-01-02_00-00-00", "beta-x-1", {})
+        beta_x_2 = _make_run(base / "beta" / "x", "2026-01-03_00-00-00", "beta-x-2", {})
+        gamma_x = _make_run(base / "gamma" / "x", "2026-01-04_00-00-00", "gamma-x-1", {})
+        _write_archive_manifest(
+            tmp_path, "alpha", [flat_run, beta_x_1, beta_x_2, gamma_x]
+        )
+        results = _finder("$alpha.results.:groups():last()", str(tmp_path)).query()
+        # three distinct groups: zero-level (flat), "beta/x", "gamma/x" --
+        # "beta/x" and "gamma/x" both end in "x" but are NOT conflated.
+        assert len(results.results) == 3
+        assert set(results.uuids) == {"flat-uuid", "beta-x-2", "gamma-x-1"}
+
+    def test_groups_with_first_gives_each_groups_earliest_at_any_depth(
+        self, tmp_path
+    ):
+        base = tmp_path / "alpha"
+        flat_run = _make_run(base, "2026-01-01_00-00-00", "flat-uuid", {})
+        beta_x_1 = _make_run(base / "beta" / "x", "2026-01-02_00-00-00", "beta-x-1", {})
+        beta_x_2 = _make_run(base / "beta" / "x", "2026-01-03_00-00-00", "beta-x-2", {})
+        _write_archive_manifest(tmp_path, "alpha", [flat_run, beta_x_1, beta_x_2])
+        results = _finder("$alpha.results.:groups():first()", str(tmp_path)).query()
+        assert set(results.uuids) == {"flat-uuid", "beta-x-1"}
+
+    def test_groups_with_no_pointer_is_the_same_as_flatten(self, tmp_path):
+        # with no pointer, grouped/pooled candidate sets are identical --
+        # same reasoning already documented for ':all()' vs. '*'.
+        base = tmp_path / "alpha"
+        flat_run = _make_run(base, "2026-01-01_00-00-00", "flat-uuid", {})
+        deep_run = _make_run(
+            base / "beta" / "x", "2026-01-02_00-00-00", "deep-uuid", {}
+        )
+        _write_archive_manifest(tmp_path, "alpha", [flat_run, deep_run])
+        groups_results = _finder("$alpha.results.:groups()", str(tmp_path)).query()
+        flatten_results = _finder("$alpha.results.:flatten()", str(tmp_path)).query()
+        assert set(groups_results.uuids) == set(flatten_results.uuids)
+
+    def test_prefixed_groups_reaches_every_depth_beyond_the_prefix(
+        self, tmp_path
+    ):
+        base = tmp_path / "acme"
+        beta_only = _make_run(base / "beta", "2026-01-01_00-00-00", "beta-only", {})
+        beta_x_1 = _make_run(base / "beta" / "x", "2026-01-02_00-00-00", "beta-x-1", {})
+        beta_x_2 = _make_run(base / "beta" / "x", "2026-01-03_00-00-00", "beta-x-2", {})
+        other = _make_run(base / "gamma", "2026-01-04_00-00-00", "other", {})
+        _write_archive_manifest(
+            tmp_path, "acme", [beta_only, beta_x_1, beta_x_2, other]
+        )
+        results = _finder(
+            "$acme.results.beta/:groups():last()", str(tmp_path)
+        ).query()
+        # zero additional segments beyond "beta/" is its own group too.
+        assert set(results.uuids) == {"beta-only", "beta-x-2"}
+
+    def test_bare_groups_rejects_an_argument(self, tmp_path):
+        base = tmp_path / "alpha"
+        run1 = _make_run(base, "2026-01-01_00-00-00", "run1-uuid", {})
+        _write_archive_manifest(tmp_path, "alpha", [run1])
+        with pytest.raises(ReferenceException3):
+            _finder('$alpha.results.:groups("x"):last()', str(tmp_path)).query()
+
+    def test_prefixed_groups_rejects_an_argument(self, tmp_path):
+        base = tmp_path / "acme"
+        run1 = _make_run(base / "beta", "2026-01-01_00-00-00", "run1-uuid", {})
+        _write_archive_manifest(tmp_path, "acme", [run1])
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$acme.results.beta/:groups("x"):last()', str(tmp_path)
+            ).query()
+
+    def test_groups_combined_with_all_is_rejected(self, tmp_path):
+        base = tmp_path / "alpha"
+        run1 = _make_run(base / "zero", "2026-01-01_00-00-00", "zero-1", {})
+        _write_archive_manifest(tmp_path, "alpha", [run1])
+        with pytest.raises(ReferenceException3):
+            _finder("$alpha.results.:all():groups():last()", str(tmp_path)).query()
+
+    def test_groups_combined_with_flatten_is_rejected(self, tmp_path):
+        base = tmp_path / "alpha"
+        run1 = _make_run(base / "zero", "2026-01-01_00-00-00", "zero-1", {})
+        _write_archive_manifest(tmp_path, "alpha", [run1])
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$alpha.results.:flatten():groups():last()", str(tmp_path)
+            ).query()
+
+    def test_groups_combined_with_manifest_is_not_yet_supported(self, tmp_path):
+        base = tmp_path / "alpha"
+        run1 = _make_run(base / "zero", "2026-01-01_00-00-00", "zero-1", {})
+        _write_archive_manifest(tmp_path, "alpha", [run1])
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$alpha.results.:groups():last():manifest()", str(tmp_path)
+            ).query()
+
+
 class TestHomeAsAZeroLevelSelector:
     # settled 2026-08-11: bare ':home()' (David's own framing --
     # "everything that has its home here") fills the one real gap left


### PR DESCRIPTION
## Summary
- Adds `:all()` as name_one's entire content for a literal (non-`*`) root_major -- every distinct path under one named-file, at any depth, each independently reduced by name_three's own pointer. Mirrors `_query_star_traversal`'s existing `is_grouped` branch, just scoped to one name instead of every named-file. Fills a real gap: a literal/`*` pattern always requires an exact segment count, so there was no way to reach a named-file whose distinct paths sit at different depths.
- Adds `tests/references/test_normative_examples_files.py`, locking in every example from `references_notes/notes/normative_reference_examples.txt`'s FILES section (already verified against real code on 2026-08-11) as real, running assertions -- same methodology used for RESULTS in #241/#242.
- Minor doc wording fix: FILES' `*` traversal across every named-file was labeled "FLATTEN," which now means any-depth pooling in this project's vocabulary (RESULTS' `:flatten()`) -- relabeled "POOL" since FILES' `*` is always an exact one-level match.

## Test plan
- [x] `tests/references/test_files_reference_finder_3.py` -- 77 passed (new `TestAllForOneNamedFile` class)
- [x] `tests/references/test_normative_examples_files.py` -- 29 passed (new file)
- [x] `tests/references/` full suite -- 813 passed
- [x] Full suite -- 2401 passed, 11 failed (known SFTP/S3/Nos baseline, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
