### PR TITLE
Punch-list follow-ups: :home() test, :from()/:to() run-level range

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -44,15 +44,22 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
     #    for csvpaths and are rejected. :uuid() is not yet a registered
     #    function, so it is "not yet supported" for now like any other
     #    unbuilt function.
-    #  - name_three, if present, is an identity lookup into that
-    #    version's named_paths_identities list -- matched by identity
-    #    string, or by the stringified index an unnamed statement is
-    #    given at load time (both already live in
+    #  - name_three, if present, is either a literal identity lookup
+    #    into that version's named_paths_identities list -- matched by
+    #    identity string, or by the stringified index an unnamed
+    #    statement is given at load time (both already live in
     #    named_paths_identities, so a single exact-match lookup covers
-    #    both cases). A function chain on name_three is not yet
-    #    supported -- no metadata-access functions exist yet for
-    #    csvpaths (see "creating references v3.txt"'s † footnote on
-    #    this).
+    #    both cases) -- OR ":from()'/':to()' (added 2026-08-13),
+    #    windowing that same ordered identities list to a positional
+    #    range (index-mode only -- csvpaths has no arrival-date concept,
+    #    date-mode bounds are rejected). A literal identity and a range
+    #    are mutually exclusive on the same name_three. Because
+    #    csvpaths has no per-statement uuid (only the whole GROUP
+    #    VERSION has one), a range's results share identical path/uuid
+    #    across every matched statement -- ReferenceResult3.identity
+    #    (see its own docstring) is what _extract_data() uses to tell
+    #    them apart. No other function chain on name_three is supported
+    #    yet (see "creating references v3.txt"'s † footnote on this).
     #
     # storage facts this relies on (confirmed against PathsManager/
     # PathsRegistrar and the real per-group manifest schema, not
@@ -147,30 +154,86 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 )
 
         name_three = reference.name_three
+        from_call = to_call = None
         if name_three is not None:
             if name_three.functions:
-                raise ReferenceException3(
-                    "CsvpathsReferenceFinder3 does not yet support functions "
-                    "on name_three -- no metadata-access functions are "
-                    "registered for csvpaths yet."
-                )
-            if name_three.body is None or isinstance(name_three.body, Star3):
+                built = ReferenceFunctionFactory.build_chain(name_three.functions)
+                from_call = next((f for f in built if f.name == "from"), None)
+                to_call = next((f for f in built if f.name == "to"), None)
+                unrecognized = [
+                    f for f in built if f.name not in ("from", "to")
+                ]
+                if unrecognized:
+                    raise ReferenceException3(
+                        "CsvpathsReferenceFinder3 does not yet support "
+                        f":{unrecognized[0].name}() on name_three -- only "
+                        "a literal statement identity/index, or "
+                        "':from()'/':to()', are supported."
+                    )
+                for f in (from_call, to_call):
+                    if f is not None and isinstance(self._range_bound(f), str):
+                        raise ReferenceException3(
+                            "CsvpathsReferenceFinder3's ':from()'/':to()' "
+                            "only supports index-mode bounds (int/:index(n)) "
+                            "-- statements have no arrival date of their own."
+                        )
+                if name_three.body is not None and (from_call or to_call):
+                    raise ReferenceException3(
+                        "CsvpathsReferenceFinder3 cannot combine a literal "
+                        "identity with ':from()'/':to()' -- they select "
+                        "statements two different, contradictory ways."
+                    )
+            if (
+                name_three.body is None
+                and from_call is None
+                and to_call is None
+            ) or isinstance(name_three.body, Star3):
                 raise ReferenceException3(
                     "CsvpathsReferenceFinder3 requires name_three to be a "
-                    "literal statement identity or index."
+                    "literal statement identity/index, or ':from()'/':to()'."
                 )
 
         results = []
         for selected in selected_versions:
-            if name_three is not None:
-                identities = selected.get("named_paths_identities") or []
+            if name_three is None:
+                results.append(
+                    ReferenceResult3(
+                        path=selected["group_file_path"], uuid=selected["uuid"]
+                    )
+                )
+                continue
+            identities = selected.get("named_paths_identities") or []
+            if from_call is not None or to_call is not None:
+                # ':from()'/':to()' as a name_three statement range --
+                # added 2026-08-13, David's own FlightPath v2 use case:
+                # rewind/replay starting from a specific csvpath
+                # statement (e.g. "$acme.csvpaths.:last().:from(:index(2))").
+                # Windows THIS version's own ordered statement-identity
+                # list, one ReferenceResult3 per identity in the window
+                # -- each carries its OWN identity (see
+                # ReferenceResult3.identity's docstring for why this is
+                # necessary: path/uuid are identical across every
+                # statement in ONE version, CSVPATHS has no per-
+                # statement uuid at all).
+                windowed = self._apply_range(identities, from_call, to_call)
+                for identity in windowed:
+                    results.append(
+                        ReferenceResult3(
+                            path=selected["group_file_path"],
+                            uuid=selected["uuid"],
+                            identity=identity,
+                        )
+                    )
+            else:
                 if self._find_by_identity(name_three.body, identities) is None:
                     continue
-            results.append(
-                ReferenceResult3(
-                    path=selected["group_file_path"], uuid=selected["uuid"]
+                results.append(
+                    ReferenceResult3(
+                        path=selected["group_file_path"],
+                        uuid=selected["uuid"],
+                        identity=name_three.body,
+                    )
                 )
-            )
         return ReferenceResults3(results=results)
 
     def _query_star_traversal(self, reference: Reference3) -> ReferenceResults3:
@@ -363,6 +426,13 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
             # the same "no default" rule as a directory-level, name_one-
             # terminal result in FilesReferenceFinder3.
             return None
+        if result.identity is None:
+            # should not happen once every name_three-bearing result
+            # carries its own identity (query() sets it unconditionally
+            # now, both for the literal-identity case and the
+            # ':from()'/':to()' range case, added 2026-08-13) -- guarded
+            # defensively rather than assumed.
+            return None
 
         manifest = self.csvpaths.paths_manager.get_manifest_for_name(
             reference.root_major
@@ -371,7 +441,14 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         if selected is None:
             return None
         identities = selected.get("named_paths_identities") or []
-        index = self._find_by_identity(name_three.body, identities)
+        # uses result.identity, NOT name_three.body -- settled 2026-08-13:
+        # a ':from()'/':to()' range produces several results sharing one
+        # version's path/uuid, each identified only by its OWN identity
+        # (see ReferenceResult3.identity's docstring). name_three.body is
+        # only ever set for the single-literal-identity shape, so it
+        # cannot distinguish results in a range the way result.identity
+        # already does for every shape.
+        index = self._find_by_identity(result.identity, identities)
         if index is None:
             return None
         statements = selected.get("named_paths") or []

--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -33,7 +33,16 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
     #    actually reached. ":having('identity')' (added 2026-08-13)
     #    filters the version list down to versions whose own
     #    named_paths_identities actually contains that identity, before
-    #    any pointer reduces further -- see _resolve_versions.
+    #    any pointer reduces further. ":from()'/':to()' (also added
+    #    2026-08-13, David: a named-paths group's own load time is a
+    #    real arrival-date concept, "give me the versions loaded between
+    #    date-one and date-two") then windows the (possibly ':having()'-
+    #    filtered) version list to a RANGE, before any pointer reduces
+    #    that -- index-mode (int/:index(n)) POSITIONALLY slices;
+    #    date-mode (str/:date(...)) FILTERS by each version's own "time"
+    #    manifest field (see functions/fields/time_3.py). Mixing modes
+    #    in one pair is rejected. Not yet supported combined with '*'
+    #    traversal -- see _resolve_versions/_query_star_traversal.
     #    ":manifest()" may ride alongside the version
     #    pointer in this same combined chain (e.g. ":last():manifest()")
     #    -- it never narrows/selects itself (see functions/manifest_3.py),
@@ -51,9 +60,11 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
     #    named_paths_identities, so a single exact-match lookup covers
     #    both cases) -- OR ":from()'/':to()' (added 2026-08-13),
     #    windowing that same ordered identities list to a positional
-    #    range (index-mode only -- csvpaths has no arrival-date concept,
-    #    date-mode bounds are rejected). A literal identity and a range
-    #    are mutually exclusive on the same name_three. Because
+    #    range (index-mode only -- unlike name_one's own ':from()'/
+    #    ':to()' above, an individual STATEMENT has no arrival time of
+    #    its own, only the GROUP VERSION it belongs to does, so date-
+    #    mode bounds are rejected here specifically). A literal identity
+    #    and a range are mutually exclusive on the same name_three. Because
     #    csvpaths has no per-statement uuid (only the whole GROUP
     #    VERSION has one), a range's results share identical path/uuid
     #    across every matched statement -- ReferenceResult3.identity
@@ -298,15 +309,16 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
         unsupported = (
             any(f.name == "manifest" for f in built)
+            or any(f.name in ("from", "to") for f in built)
             or self._find_field_function_call(calls) is not None
         )
         if unsupported:
             raise ReferenceException3(
                 "CsvpathsReferenceFinder3 does not yet support combining "
-                "'*' traversal with :manifest() or a field-accessor "
-                "function -- only a plain pointer (:first()/:last()/"
-                ":index(n)), optionally combined with :all() for one "
-                "result per group, is supported so far."
+                "'*' traversal with :manifest(), ':from()'/':to()', or a "
+                "field-accessor function -- only a plain pointer "
+                "(:first()/:last()/:index(n)), optionally combined with "
+                ":all() for one result per group, is supported so far."
             )
 
         if is_grouped:
@@ -463,11 +475,21 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         `manifest` down to versions whose own "named_paths_identities"
         list contains that identity, BEFORE any pointer reduces further
         -- e.g. ":having('my_validations'):last()" is "the last version
-        that actually has a my_validations statement." At most one
-        pointer function is allowed among the combined chain
-        (build_chain() enforces this): if present, it reduces the
-        (possibly ':having()'-filtered) list to that one version; if
-        absent (e.g. a bare :all()), every version in the list is
+        that actually has a my_validations statement." ':from()'/':to()'
+        (added 2026-08-13, David: a named-paths group's own load time is
+        a real arrival-date concept -- "give me the versions loaded
+        between date-one and date-two") window the (possibly
+        ':having()'-filtered) manifest to a RANGE next, same position
+        RESULTS'/FILES' own version-level range occupies -- index-mode
+        (int/:index(n)) POSITIONALLY slices via the shared
+        _apply_range(); date-mode (str/:date(...)) FILTERS by each
+        version's own "time" manifest field via the shared
+        _apply_manifest_date_range(). At most one pointer function is
+        allowed among the combined chain (build_chain() enforces this):
+        if present, it reduces the (possibly filtered/windowed) list to
+        that one version -- riding alongside ':from()'/':to()', it
+        reduces the RANGE, not the full candidate set, same as FILES.
+        If absent (e.g. a bare :all()), every version in the list is
         returned, unreduced."""
         if len(name_one.path) != 1 or not isinstance(name_one.path[0], FunctionCall3):
             raise ReferenceException3(
@@ -484,6 +506,31 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 for entry in manifest
                 if having_call.arg in (entry.get("named_paths_identities") or [])
             ]
+        from_call = next((f for f in built if f.name == "from"), None)
+        to_call = next((f for f in built if f.name == "to"), None)
+        if from_call is not None or to_call is not None:
+            from_bound = self._range_bound(from_call) if from_call is not None else None
+            to_bound = self._range_bound(to_call) if to_call is not None else None
+            from_is_date = isinstance(from_bound, str)
+            to_is_date = isinstance(to_bound, str)
+            if (from_bound is not None and to_bound is not None) and (
+                from_is_date != to_is_date
+            ):
+                raise ReferenceException3(
+                    "CsvpathsReferenceFinder3 does not support mixing "
+                    "index-mode and date-mode ':from()'/':to()' bounds in "
+                    "the same range."
+                )
+            if from_is_date or to_is_date:
+                if from_is_date:
+                    self._validate_date_format(from_bound)
+                if to_is_date:
+                    self._validate_date_format(to_bound)
+                manifest = self._apply_manifest_date_range(
+                    manifest, from_bound, to_bound
+                )
+            else:
+                manifest = self._apply_range(manifest, from_call, to_call)
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
         if not pointers:
             return manifest

--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -30,7 +30,11 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
     #    absent (e.g. a bare :all()), every version in the manifest is
     #    returned, unreduced -- this is how "list of versions in the
     #    form: (path-to-group.csvpaths, uuid)" (STRUCTURE table) is
-    #    actually reached. ":manifest()" may ride alongside the version
+    #    actually reached. ":having('identity')' (added 2026-08-13)
+    #    filters the version list down to versions whose own
+    #    named_paths_identities actually contains that identity, before
+    #    any pointer reduces further -- see _resolve_versions.
+    #    ":manifest()" may ride alongside the version
     #    pointer in this same combined chain (e.g. ":last():manifest()")
     #    -- it never narrows/selects itself (see functions/manifest_3.py),
     #    it just changes what _extract_data() resolves to: the matched
@@ -378,11 +382,16 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         version(s) to work with, so its path_prefix must reduce to
         exactly one function-segment (no literal/"*" path-building, no
         worksheet marker) -- combined with its own trailing function
-        chain, if any. At most one pointer function is allowed among
-        the combined chain (build_chain() enforces this): if present,
-        it reduces `manifest` to that one version; if absent (e.g. a
-        bare :all()), every version in `manifest` is returned,
-        unreduced."""
+        chain, if any. ':having("identity")' (added 2026-08-13) filters
+        `manifest` down to versions whose own "named_paths_identities"
+        list contains that identity, BEFORE any pointer reduces further
+        -- e.g. ":having('my_validations'):last()" is "the last version
+        that actually has a my_validations statement." At most one
+        pointer function is allowed among the combined chain
+        (build_chain() enforces this): if present, it reduces the
+        (possibly ':having()'-filtered) list to that one version; if
+        absent (e.g. a bare :all()), every version in the list is
+        returned, unreduced."""
         if len(name_one.path) != 1 or not isinstance(name_one.path[0], FunctionCall3):
             raise ReferenceException3(
                 "CsvpathsReferenceFinder3 requires name_one to be a version-"
@@ -391,6 +400,13 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
             )
         calls = [name_one.path[0], *name_one.functions]
         built = ReferenceFunctionFactory.build_chain(calls)
+        having_call = next((f for f in built if f.name == "having"), None)
+        if having_call is not None:
+            manifest = [
+                entry
+                for entry in manifest
+                if having_call.arg in (entry.get("named_paths_identities") or [])
+            ]
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
         if not pointers:
             return manifest

--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -516,6 +516,18 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
             if (from_bound is not None and to_bound is not None) and (
                 from_is_date != to_is_date
             ):
+                # rejected -- not because it is meaningless (e.g.
+                # ":from(:date('2025-01-01')):to(:index(10))" is a
+                # reasonable ask: "10 versions starting from this
+                # date"), but because it is AMBIGUOUS and undecided
+                # which of at least two readings is meant -- is the
+                # index bound absolute position in the full version
+                # list, or relative to wherever the date bound starts
+                # matching? Nothing here picks one, so mixing is
+                # rejected until that anchor semantics question is
+                # deliberately settled, not attempted here for lack of
+                # a driving use case (same reasoning as RESULTS'/FILES'
+                # own version-level ranges).
                 raise ReferenceException3(
                     "CsvpathsReferenceFinder3 does not support mixing "
                     "index-mode and date-mode ':from()'/':to()' bounds in "

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -198,6 +198,43 @@ class FilesReferenceFinder3(ReferenceFinder3):
             # undefined (only SOURCE == "definition" functions get bare
             # treatment via _bare_definition_field_call).
             candidates = self._candidates_for_name(root_major, [])
+        elif self._is_bare_fingerprint_reference(name_one):
+            # bare ':fingerprint("hash...")' -- added 2026-08-13. Content-
+            # hash identity does not care which file/path slot a version
+            # happens to be registered under (unlike ':name()', which
+            # matches file_home, a path identity, not a content one), so
+            # this searches the WHOLE named-file's manifest directly --
+            # every file_home/path, not just a pattern-matched subset --
+            # for the entry whose own "fingerprint" field matches.
+            # Confirmed against FileRegistrar's real write path: the
+            # version file itself is literally stored/named by its own
+            # fingerprint, so an exact match here is reliable. At most
+            # one match is expected in practice (two DIFFERENT logical
+            # files sharing byte-identical content is the only way to
+            # get more than one) -- not specially guarded against.
+            #
+            # Returns the matched version(s) directly, with their real
+            # path/uuid, and does NOT fall through to the shared "no
+            # name_three -> dedupe to a directory, uuid=None" logic below
+            # -- unlike ':name()', a fingerprint already identifies one
+            # SPECIFIC version, there is no further "which version"
+            # narrowing step to defer. name_three combined with this
+            # shape is not yet supported (redundant by construction --
+            # there is nothing left to narrow).
+            if reference.name_three is not None:
+                raise ReferenceException3(
+                    "FilesReferenceFinder3 does not yet support combining "
+                    "a bare ':fingerprint(...)' lookup with name_three -- "
+                    "it already identifies one specific version on its own."
+                )
+            manifest = self.csvpaths.file_manager.get_manifest(root_major)
+            fingerprint = name_one.path[0].arg
+            matched = [e for e in manifest if e.get("fingerprint") == fingerprint]
+            return ReferenceResults3(
+                results=[
+                    ReferenceResult3(path=e["file"], uuid=e["uuid"]) for e in matched
+                ]
+            )
         elif self._is_flatten_prefixed_reference(name_one):
             # ':flatten()' as name_one's FIRST segment, followed by more
             # path -- settled 2026-08-12, David: "the last version of
@@ -254,6 +291,22 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "(:first()/:last()/:index(n))."
             )
         built = ReferenceFunctionFactory.build_chain(name_three.functions)
+        for f in built:
+            if f.name == "fingerprint" and f.arg is not None:
+                # ':fingerprint(...)' only takes an argument in its bare,
+                # name_one lookup form (settled 2026-08-13) -- riding
+                # alongside a matched version here, in its ordinary
+                # field-accessor position, it takes none (it reads
+                # whatever the matched version's own fingerprint IS, it
+                # does not filter by a given one). Raising here avoids
+                # an arg being silently ignored, which ARG_TYPES = (str,)
+                # would otherwise allow through unnoticed.
+                raise ReferenceException3(
+                    "FilesReferenceFinder3's ':fingerprint()' only takes "
+                    "an argument in its bare, name_one lookup form -- "
+                    "riding alongside a matched version in name_three, "
+                    "it takes none."
+                )
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
         has_manifest = any(f.name == "manifest" for f in built)
         has_field_function = self._find_field_function_call(built) is not None
@@ -570,6 +623,22 @@ class FilesReferenceFinder3(ReferenceFinder3):
             and isinstance(name_one.path[0], FunctionCall3)
             and name_one.path[0].name == "home"
             and name_one.path[0].arg is None
+        )
+
+    @staticmethod
+    def _is_bare_fingerprint_reference(name_one) -> bool:
+        """same shape as _is_bare_home_reference, for ':fingerprint(...)'
+        -- settled 2026-08-13, but the OPPOSITE arg requirement: WITH an
+        arg (the hash to search for), not without -- a bare, argument-
+        less ':fingerprint()' has no candidate to read the field off of
+        at this position, so it is deliberately NOT recognized here and
+        falls through to the ordinary "not yet supported" rejection."""
+        return (
+            not name_one.functions
+            and len(name_one.path) == 1
+            and isinstance(name_one.path[0], FunctionCall3)
+            and name_one.path[0].name == "fingerprint"
+            and name_one.path[0].arg is not None
         )
 
     @staticmethod

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -67,6 +67,14 @@ class FilesReferenceFinder3(ReferenceFinder3):
     #    :all()" gives every matched version, unreduced, with real
     #    paths/uuids -- unlike name_three being absent entirely, which
     #    dedupes to directory-level results with uuid=None instead).
+    #    ":from()'/':to()' (added 2026-08-13, David: rewind/replay and
+    #    comparing versions) window the ordered VERSION list the same
+    #    way a pointer does -- "the last N versions"/"version M through
+    #    N," unreduced unless a real pointer also rides alongside it (it
+    #    then reduces the RANGE, not the full candidate set). Index-mode
+    #    only here (int/:index(n)) -- date-mode is RESULTS-only, FILES
+    #    has no arrival-date comparison wired up. Combining with
+    #    ':all()'/':groups()' grouping in name_one is not yet supported.
     #    name_three is
     #    optional: when absent, name_one alone is a prefix search that
     #    returns zero or more paths to file-home directories (one per
@@ -312,21 +320,47 @@ class FilesReferenceFinder3(ReferenceFinder3):
         has_field_function = self._find_field_function_call(built) is not None
         has_path = self._find_path_call(built) is not None
         has_all = any(f.name == "all" for f in built)
+        from_call = next((f for f in built if f.name == "from"), None)
+        to_call = next((f for f in built if f.name == "to"), None)
+        has_range = from_call is not None or to_call is not None
+        if has_range:
+            # ':from()'/':to()' as a name_three version range -- added
+            # 2026-08-13, David: rewind/replay and version comparison
+            # need "the last N versions of orders.csv" the same way
+            # RESULTS' own run-level range does, plus "version M through
+            # N." Windows the ordered VERSION list of the already
+            # name_one-matched file(s), same position :first()/:last()/
+            # :index(n) already occupy -- a pointer riding alongside
+            # either one reduces the RANGE, not the full candidate set
+            # (identical pattern to RESULTS). Index-mode only for FILES
+            # -- there is no "arrival date" comparison wired up here
+            # (unlike RESULTS' own run-directory timestamps), so a
+            # date-mode bound (str/:date(...)) is rejected explicitly
+            # rather than silently doing nothing useful.
+            for f in (from_call, to_call):
+                if f is not None and isinstance(self._range_bound(f), str):
+                    raise ReferenceException3(
+                        "FilesReferenceFinder3's ':from()'/':to()' only "
+                        "supports index-mode bounds (int/:index(n)) -- "
+                        "date-mode is RESULTS-only for now."
+                    )
         if (
             not pointers
             and not has_manifest
             and not has_field_function
             and not has_path
             and not has_all
+            and not has_range
         ):
             raise ReferenceException3(
                 "FilesReferenceFinder3 requires name_three to resolve to "
                 "exactly one pointer function (:first()/:last()/:index(n)), "
-                "optionally combined with :manifest(), :path(), :all(), or "
-                "a registered field-accessor function (e.g. :uuid())."
+                "optionally combined with :manifest(), :path(), :all(), "
+                "':from()'/':to()', or a registered field-accessor "
+                "function (e.g. :uuid())."
             )
 
-        if partitioned and pointers and (has_manifest or has_field_function or has_path):
+        if partitioned and (has_range or (pointers and (has_manifest or has_field_function or has_path))):
             # mirrors ResultsReferenceFinder3's own ':all()'-grouping
             # restriction (settled 2026-08-11 there): grouping (one-
             # level ':all()' or any-depth ':groups()') plus :manifest()/
@@ -341,6 +375,15 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "or a field-accessor function -- resolve the grouped "
                 "versions on their own first."
             )
+
+        if has_range:
+            # narrow to the RANGE first -- a pointer riding alongside it
+            # (below) then reduces that range, not the full candidate
+            # set, same as RESULTS' own run-level range does. `partitioned`
+            # combined with `has_range` already raised above, so this
+            # never runs concurrently with the by_file_home partition
+            # branch below.
+            candidates = self._apply_range(candidates, from_call, to_call)
 
         if pointers:
             if partitioned:

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -351,9 +351,17 @@ class FilesReferenceFinder3(ReferenceFinder3):
             # RESULTS already filters run-level ranges by) FILTERS by
             # each version's own "time" manifest field instead, via the
             # shared _apply_manifest_date_range(). Mixing the two modes
-            # in one ':from()'/':to()' pair is rejected -- there is no
-            # coherent single meaning for e.g.
-            # ":from(2):to(:date('2025-01-01'))".
+            # in one ':from()'/':to()' pair is rejected -- not because
+            # it is meaningless (e.g.
+            # ":from(:date('2025-01-01')):to(:index(10))" is a
+            # reasonable ask: "10 versions starting from this date"),
+            # but because it is AMBIGUOUS and undecided which of at
+            # least two readings is meant -- is the index bound
+            # absolute position in the full version list, or relative
+            # to wherever the date bound starts matching? Nothing here
+            # picks one, so mixing is rejected until that anchor
+            # semantics question is deliberately settled, not attempted
+            # here for lack of a driving use case.
             from_bound = self._range_bound(from_call) if from_call is not None else None
             to_bound = self._range_bound(to_call) if to_call is not None else None
             from_is_date = isinstance(from_bound, str)

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -71,10 +71,15 @@ class FilesReferenceFinder3(ReferenceFinder3):
     #    comparing versions) window the ordered VERSION list the same
     #    way a pointer does -- "the last N versions"/"version M through
     #    N," unreduced unless a real pointer also rides alongside it (it
-    #    then reduces the RANGE, not the full candidate set). Index-mode
-    #    only here (int/:index(n)) -- date-mode is RESULTS-only, FILES
-    #    has no arrival-date comparison wired up. Combining with
-    #    ':all()'/':groups()' grouping in name_one is not yet supported.
+    #    then reduces the RANGE, not the full candidate set). Two modes,
+    #    picked by each bound's own value type: index-mode (int/
+    #    :index(n)) POSITIONALLY slices; date-mode (str/:date(...),
+    #    broadened from RESULTS-only 2026-08-13 -- a named-file
+    #    version's own registration/load "time" is a real arrival-date
+    #    concept, same as RESULTS' run start time) FILTERS by each
+    #    version's own "time" manifest field. Mixing modes in one pair
+    #    is rejected. Combining with ':all()'/':groups()' grouping in
+    #    name_one is not yet supported.
     #    name_three is
     #    optional: when absent, name_one alone is a prefix search that
     #    returns zero or more paths to file-home directories (one per
@@ -323,6 +328,8 @@ class FilesReferenceFinder3(ReferenceFinder3):
         from_call = next((f for f in built if f.name == "from"), None)
         to_call = next((f for f in built if f.name == "to"), None)
         has_range = from_call is not None or to_call is not None
+        from_is_date = to_is_date = False
+        from_bound = to_bound = None
         if has_range:
             # ':from()'/':to()' as a name_three version range -- added
             # 2026-08-13, David: rewind/replay and version comparison
@@ -332,18 +339,37 @@ class FilesReferenceFinder3(ReferenceFinder3):
             # name_one-matched file(s), same position :first()/:last()/
             # :index(n) already occupy -- a pointer riding alongside
             # either one reduces the RANGE, not the full candidate set
-            # (identical pattern to RESULTS). Index-mode only for FILES
-            # -- there is no "arrival date" comparison wired up here
-            # (unlike RESULTS' own run-directory timestamps), so a
-            # date-mode bound (str/:date(...)) is rejected explicitly
-            # rather than silently doing nothing useful.
-            for f in (from_call, to_call):
-                if f is not None and isinstance(self._range_bound(f), str):
-                    raise ReferenceException3(
-                        "FilesReferenceFinder3's ':from()'/':to()' only "
-                        "supports index-mode bounds (int/:index(n)) -- "
-                        "date-mode is RESULTS-only for now."
-                    )
+            # (identical pattern to RESULTS).
+            #
+            # Two independent MODES, picked by each bound's own value
+            # type, same as RESULTS' own run-level range: index-mode
+            # (int/:index(n)) POSITIONALLY slices via the shared
+            # _apply_range(); date-mode (str/:date(...), broadened from
+            # RESULTS-only 2026-08-13 -- David: a named-file version's
+            # own registration/load "time" (see functions/fields/
+            # time_3.py) is a real arrival-date concept, the same one
+            # RESULTS already filters run-level ranges by) FILTERS by
+            # each version's own "time" manifest field instead, via the
+            # shared _apply_manifest_date_range(). Mixing the two modes
+            # in one ':from()'/':to()' pair is rejected -- there is no
+            # coherent single meaning for e.g.
+            # ":from(2):to(:date('2025-01-01'))".
+            from_bound = self._range_bound(from_call) if from_call is not None else None
+            to_bound = self._range_bound(to_call) if to_call is not None else None
+            from_is_date = isinstance(from_bound, str)
+            to_is_date = isinstance(to_bound, str)
+            if (from_bound is not None and to_bound is not None) and (
+                from_is_date != to_is_date
+            ):
+                raise ReferenceException3(
+                    "FilesReferenceFinder3 does not support mixing index-"
+                    "mode and date-mode ':from()'/':to()' bounds in the "
+                    "same range."
+                )
+            if from_is_date:
+                self._validate_date_format(from_bound)
+            if to_is_date:
+                self._validate_date_format(to_bound)
         if (
             not pointers
             and not has_manifest
@@ -383,7 +409,12 @@ class FilesReferenceFinder3(ReferenceFinder3):
             # combined with `has_range` already raised above, so this
             # never runs concurrently with the by_file_home partition
             # branch below.
-            candidates = self._apply_range(candidates, from_call, to_call)
+            if from_is_date or to_is_date:
+                candidates = self._apply_manifest_date_range(
+                    candidates, from_bound, to_bound
+                )
+            else:
+                candidates = self._apply_range(candidates, from_call, to_call)
 
         if pointers:
             if partitioned:

--- a/csvpath/references/functions/fields/fingerprint_3.py
+++ b/csvpath/references/functions/fields/fingerprint_3.py
@@ -12,17 +12,36 @@ class Fingerprint3(Function3):
     # per manifest_field_functions_proposal.md's Part A note on this
     # function.
     #
+    # ARG_TYPES accepts an optional str -- added 2026-08-13, for FILES
+    # only, to support the bare-lookup shape
+    # ("$alpha.files.:fingerprint('hash...')", no :name(...) needed):
+    # search the WHOLE named-file's manifest for the entry whose own
+    # fingerprint matches, since content-hash identity does not care
+    # which file/path slot a version happens to be registered under
+    # (unlike :name(), which matches file_home, a path identity). See
+    # FilesReferenceFinder3._is_bare_fingerprint_reference/query() for
+    # where this is actually recognized and handled -- this class's own
+    # ROLE stays VALUE (unchanged) specifically so it keeps NOT counting
+    # as a second pointer when it rides alongside a real one in its
+    # ordinary field-accessor position (e.g.
+    # ":name('orders.csv').:first():fingerprint()"); the bare-lookup
+    # shape is recognized structurally (bare, sole content of name_one,
+    # WITH an arg), the same way ':all()'/':flatten()'/':groups()'/
+    # ':home()' are already recognized, not via ROLE.
+    #
     NAME = "fingerprint"
     SUMMARY = (
         "The content-integrity hash of the resolved named-file/named-"
         "paths version's own defining content (the file's bytes, or "
         "group.csvpaths' text) -- SHA256 in most cases; S3-backed "
         "content uses MD5 instead, per the same fingerprint mechanism "
-        "used throughout the framework."
+        "used throughout the framework. For FILES only, also usable "
+        "bare with a known hash to look up the specific version it "
+        "identifies, across every path under a named-file."
     )
     ROLE = Function3.VALUE
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS)
-    ARG_TYPES = ()
+    ARG_TYPES = (str,)
     ARG_REQUIRED = False
     SOURCE = "manifest"
     KEY = {

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -17,6 +17,7 @@ class ReferenceFunctionFactory:
     @classmethod
     def _load(cls) -> None:
         from .selectors.all_3 import All3
+        from .selectors.date_3 import Date3
         from .selectors.first_3 import First3
         from .selectors.flatten_3 import Flatten3
         from .selectors.from_3 import From3
@@ -89,6 +90,7 @@ class ReferenceFunctionFactory:
             From3.NAME: From3,
             To3.NAME: To3,
             Having3.NAME: Having3,
+            Date3.NAME: Date3,
             Manifest3.NAME: Manifest3,
             Definition3.NAME: Definition3,
             Errors3.NAME: Errors3,

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -21,6 +21,7 @@ class ReferenceFunctionFactory:
         from .selectors.flatten_3 import Flatten3
         from .selectors.from_3 import From3
         from .selectors.groups_3 import Groups3
+        from .selectors.having_3 import Having3
         from .selectors.index_3 import Index3
         from .selectors.last_3 import Last3
         from .selectors.name_3 import Name3
@@ -87,6 +88,7 @@ class ReferenceFunctionFactory:
             Groups3.NAME: Groups3,
             From3.NAME: From3,
             To3.NAME: To3,
+            Having3.NAME: Having3,
             Manifest3.NAME: Manifest3,
             Definition3.NAME: Definition3,
             Errors3.NAME: Errors3,

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -19,10 +19,12 @@ class ReferenceFunctionFactory:
         from .selectors.all_3 import All3
         from .selectors.first_3 import First3
         from .selectors.flatten_3 import Flatten3
+        from .selectors.from_3 import From3
         from .selectors.groups_3 import Groups3
         from .selectors.index_3 import Index3
         from .selectors.last_3 import Last3
         from .selectors.name_3 import Name3
+        from .selectors.to_3 import To3
 
         from .well_known_files.data_3 import Data3
         from .well_known_files.definition_3 import Definition3
@@ -83,6 +85,8 @@ class ReferenceFunctionFactory:
             All3.NAME: All3,
             Flatten3.NAME: Flatten3,
             Groups3.NAME: Groups3,
+            From3.NAME: From3,
+            To3.NAME: To3,
             Manifest3.NAME: Manifest3,
             Definition3.NAME: Definition3,
             Errors3.NAME: Errors3,

--- a/csvpath/references/functions/selectors/date_3.py
+++ b/csvpath/references/functions/selectors/date_3.py
@@ -1,0 +1,31 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class Date3(Function3):
+    #
+    # a literal calendar date, added 2026-08-13 as :from()/:to()'s
+    # date-mode bound -- David: "arrival and run order is even more
+    # important than indexing." DATE-only granularity for this pass
+    # (a plain "YYYY-MM-DD" string, compared against a run's own
+    # arrival date) -- hour/minute-level filtering (e.g. a future
+    # ":yesterday(:hour(18))") is a separate, deferred extension of the
+    # same comparison mechanism, not built here.
+    #
+    # ROLE is VALUE (it computes/holds a value, does not touch scope
+    # itself) -- mirrors Index3's own role as an argument-only wrapper:
+    # ":from(:date('2025-01-01'))" must give the same result as
+    # ":from('2025-01-01')" (a bare date string, no wrapper), the same
+    # "wrapper is optional but must be technically possible" pattern
+    # already established for :from()/:index().
+    #
+    NAME = "date"
+    SUMMARY = (
+        "A literal calendar date (YYYY-MM-DD) -- used as :from()'s/"
+        ":to()'s date-mode bound, e.g. ':from(:date(\"2025-01-01\"))' "
+        "for 'runs from this date onward.'"
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = (str,)
+    ARG_REQUIRED = True

--- a/csvpath/references/functions/selectors/from_3.py
+++ b/csvpath/references/functions/selectors/from_3.py
@@ -1,0 +1,40 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+from .index_3 import Index3
+
+
+class From3(Function3):
+    #
+    # index-mode range selector -- added 2026-08-13, RESULTS only for
+    # now (the doc's own confirmed examples are all RESULTS; FILES/
+    # CSVPATHS get this later if a concrete need shows up, per this
+    # session's own "build only what's confirmed" discipline). Packaged
+    # together with :to() on purpose (David: "our version of BETWEEN in
+    # SQL or range() in Python... I'd only separate them if there is
+    # some underlying implementation detail that makes them better
+    # tackled as two things" -- there isn't; both slice an already-
+    # ordered candidate list, :from() sets the start bound, :to() the
+    # end bound, see ReferenceFinder3._range_bound()).
+    #
+    # ARG_TYPES includes Index3, not just int, because the doc's own
+    # NOTES block explicitly requires ":from(:index(-3))" to be legal
+    # and identical to ":from(-3)" -- by the time ReferenceFunctionFactory
+    # .build() constructs this function, a nested ":index(...)" arg has
+    # already been recursively built into a real Index3 instance (not a
+    # plain int), so both shapes need to be accepted here. Does not
+    # count as a POINTER for build_chain()'s "at most one pointer per
+    # chain" rule -- it is a nested ARGUMENT, already unwrapped before
+    # build_chain() ever sees the outer chain, exactly like
+    # ":idchain()"/":from(:index(0))" nested-arg precedent noted
+    # elsewhere in this codebase's design history.
+    #
+    NAME = "from"
+    SUMMARY = (
+        "The start of an index-based range over the current scope's "
+        "ordered items -- from this 0-based position (negative counts "
+        "from the end) to the end, or to :to()'s position if present."
+    )
+    ROLE = Function3.CONTEXT_SETTER
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = (int, Index3)
+    ARG_REQUIRED = True

--- a/csvpath/references/functions/selectors/from_3.py
+++ b/csvpath/references/functions/selectors/from_3.py
@@ -6,10 +6,12 @@ from .index_3 import Index3
 
 class From3(Function3):
     #
-    # a range selector -- added 2026-08-13, RESULTS only for now (the
-    # doc's own confirmed examples are all RESULTS; FILES/CSVPATHS get
-    # this later if a concrete need shows up, per this session's own
-    # "build only what's confirmed" discipline). Packaged together with
+    # a range selector -- added 2026-08-13 for RESULTS, extended the
+    # same day to FILES (David: rewind/replay and comparing versions
+    # need "the last N versions of a named-file" the same way). CSVPATHS
+    # windows an ordered statement list instead of a version list --
+    # see CsvpathsReferenceFinder3's own comments for why that needed a
+    # ReferenceResult3 change first, not just DATATYPES. Packaged together with
     # :to() on purpose (David: "our version of BETWEEN in SQL or
     # range() in Python... I'd only separate them if there is some
     # underlying implementation detail that makes them better tackled
@@ -49,6 +51,6 @@ class From3(Function3):
         "run's own arrival date."
     )
     ROLE = Function3.CONTEXT_SETTER
-    DATATYPES = (Reference3.RESULTS,)
+    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = (int, Index3, str, Date3)
     ARG_REQUIRED = True

--- a/csvpath/references/functions/selectors/from_3.py
+++ b/csvpath/references/functions/selectors/from_3.py
@@ -1,40 +1,54 @@
 from ...reference_3 import Reference3
 from ..function_3 import Function3
+from .date_3 import Date3
 from .index_3 import Index3
 
 
 class From3(Function3):
     #
-    # index-mode range selector -- added 2026-08-13, RESULTS only for
-    # now (the doc's own confirmed examples are all RESULTS; FILES/
-    # CSVPATHS get this later if a concrete need shows up, per this
-    # session's own "build only what's confirmed" discipline). Packaged
-    # together with :to() on purpose (David: "our version of BETWEEN in
-    # SQL or range() in Python... I'd only separate them if there is
-    # some underlying implementation detail that makes them better
-    # tackled as two things" -- there isn't; both slice an already-
-    # ordered candidate list, :from() sets the start bound, :to() the
-    # end bound, see ReferenceFinder3._range_bound()).
+    # a range selector -- added 2026-08-13, RESULTS only for now (the
+    # doc's own confirmed examples are all RESULTS; FILES/CSVPATHS get
+    # this later if a concrete need shows up, per this session's own
+    # "build only what's confirmed" discipline). Packaged together with
+    # :to() on purpose (David: "our version of BETWEEN in SQL or
+    # range() in Python... I'd only separate them if there is some
+    # underlying implementation detail that makes them better tackled
+    # as two things" -- there isn't; both narrow an already-ordered
+    # candidate list, :from() sets the start bound, :to() the end
+    # bound). Two independent MODES, picked by which arg type is given
+    # -- index-mode (int/Index3, see ReferenceFinder3._range_bound()):
+    # positional, "from this 0-based position to the end." date-mode
+    # (str/Date3, added the same day David asked for it specifically --
+    # "arrival and run order is even more important than indexing"):
+    # "from this calendar date onward," compared against each run's own
+    # arrival date (see ResultsReferenceFinder3._apply_date_range()).
+    # The two modes are never mixed within one :from()/:to() pair --
+    # query() rejects that combination explicitly.
     #
-    # ARG_TYPES includes Index3, not just int, because the doc's own
-    # NOTES block explicitly requires ":from(:index(-3))" to be legal
-    # and identical to ":from(-3)" -- by the time ReferenceFunctionFactory
-    # .build() constructs this function, a nested ":index(...)" arg has
-    # already been recursively built into a real Index3 instance (not a
-    # plain int), so both shapes need to be accepted here. Does not
-    # count as a POINTER for build_chain()'s "at most one pointer per
-    # chain" rule -- it is a nested ARGUMENT, already unwrapped before
-    # build_chain() ever sees the outer chain, exactly like
-    # ":idchain()"/":from(:index(0))" nested-arg precedent noted
-    # elsewhere in this codebase's design history.
+    # ARG_TYPES includes Index3/Date3, not just int/str, because the
+    # doc's own NOTES block explicitly requires ":from(:index(-3))" to
+    # be legal and identical to ":from(-3)" (and, by the same "wrapper
+    # is optional but must be technically possible" pattern,
+    # ":from(:date(...))" identical to a bare date string) -- by the
+    # time ReferenceFunctionFactory.build() constructs this function, a
+    # nested ":index(...)"/":date(...)" arg has already been recursively
+    # built into a real Index3/Date3 instance (not a plain int/str), so
+    # both shapes need to be accepted here. Neither counts as a POINTER
+    # for build_chain()'s "at most one pointer per chain" rule -- both
+    # are nested ARGUMENTS, already unwrapped before build_chain() ever
+    # sees the outer chain, exactly like ":idchain()"/":from(:index(0))"
+    # nested-arg precedent noted elsewhere in this codebase's design
+    # history.
     #
     NAME = "from"
     SUMMARY = (
-        "The start of an index-based range over the current scope's "
-        "ordered items -- from this 0-based position (negative counts "
-        "from the end) to the end, or to :to()'s position if present."
+        "The start of a range over the current scope's ordered items -- "
+        "index-mode: from this 0-based position (negative counts from "
+        "the end) to the end, or to :to()'s position if present. date-"
+        "mode: from this calendar date onward, compared against each "
+        "run's own arrival date."
     )
     ROLE = Function3.CONTEXT_SETTER
     DATATYPES = (Reference3.RESULTS,)
-    ARG_TYPES = (int, Index3)
+    ARG_TYPES = (int, Index3, str, Date3)
     ARG_REQUIRED = True

--- a/csvpath/references/functions/selectors/having_3.py
+++ b/csvpath/references/functions/selectors/having_3.py
@@ -1,0 +1,33 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class Having3(Function3):
+    #
+    # CSVPATHS-only version filter -- added 2026-08-13. Filters a named-
+    # paths group's version manifest down to versions whose own
+    # "named_paths_identities" list (confirmed against PathsRegistrar's
+    # real manifest schema -- one entry per loaded/reloaded version,
+    # already read by CsvpathsReferenceFinder3 for name_three identity
+    # lookups) contains the given identity -- "the last version of this
+    # group that actually HAS a statement named this" (a group's
+    # statement set can change release to release; not every version
+    # necessarily has every identity). Named after SQL's HAVING (filters
+    # groups by a condition on their own contents, as opposed to WHERE,
+    # which filters rows) -- David's own framing.
+    #
+    # ROLE is CONTEXT_SETTER, not POINTER -- it narrows the candidate
+    # version list without resolving to exactly one; a real pointer
+    # (":last()" etc.) riding alongside it reduces the FILTERED list,
+    # the same "narrow, then optionally reduce" pattern ':all()'/
+    # ':from()'/':to()' already use elsewhere in this codebase.
+    #
+    NAME = "having"
+    SUMMARY = (
+        "Filters this named-paths group's versions down to those whose "
+        "own statement list contains a statement with this identity."
+    )
+    ROLE = Function3.CONTEXT_SETTER
+    DATATYPES = (Reference3.CSVPATHS,)
+    ARG_TYPES = (str,)
+    ARG_REQUIRED = True

--- a/csvpath/references/functions/selectors/to_3.py
+++ b/csvpath/references/functions/selectors/to_3.py
@@ -1,0 +1,25 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+from .index_3 import Index3
+
+
+class To3(Function3):
+    #
+    # the closing bound of :from()'s range -- see From3's own comment
+    # for why the two are packaged together and why ARG_TYPES includes
+    # Index3. INCLUSIVE of its own position (matches :index(n) pointing
+    # AT a position, and SQL's BETWEEN, which David explicitly named as
+    # the model): ":from(2):to(5)" is positions 2 through 5, both ends
+    # included, five items total.
+    #
+    NAME = "to"
+    SUMMARY = (
+        "The end of an index-based range over the current scope's "
+        "ordered items -- up to and including this 0-based position "
+        "(negative counts from the end), from the start or from "
+        ":from()'s position if present."
+    )
+    ROLE = Function3.CONTEXT_SETTER
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = (int, Index3)
+    ARG_REQUIRED = True

--- a/csvpath/references/functions/selectors/to_3.py
+++ b/csvpath/references/functions/selectors/to_3.py
@@ -25,6 +25,6 @@ class To3(Function3):
         "date."
     )
     ROLE = Function3.CONTEXT_SETTER
-    DATATYPES = (Reference3.RESULTS,)
+    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = (int, Index3, str, Date3)
     ARG_REQUIRED = True

--- a/csvpath/references/functions/selectors/to_3.py
+++ b/csvpath/references/functions/selectors/to_3.py
@@ -1,25 +1,30 @@
 from ...reference_3 import Reference3
 from ..function_3 import Function3
+from .date_3 import Date3
 from .index_3 import Index3
 
 
 class To3(Function3):
     #
     # the closing bound of :from()'s range -- see From3's own comment
-    # for why the two are packaged together and why ARG_TYPES includes
-    # Index3. INCLUSIVE of its own position (matches :index(n) pointing
-    # AT a position, and SQL's BETWEEN, which David explicitly named as
-    # the model): ":from(2):to(5)" is positions 2 through 5, both ends
-    # included, five items total.
+    # for why the two are packaged together, the two independent index/
+    # date modes, and why ARG_TYPES includes Index3/Date3. INCLUSIVE of
+    # its own position/date (matches :index(n) pointing AT a position,
+    # and SQL's BETWEEN, which David explicitly named as the model):
+    # ":from(2):to(5)" is positions 2 through 5, both ends included,
+    # five items total; ":to(:date('2025-01-31'))" includes runs that
+    # arrived ON 2025-01-31 itself, not just before it.
     #
     NAME = "to"
     SUMMARY = (
-        "The end of an index-based range over the current scope's "
-        "ordered items -- up to and including this 0-based position "
+        "The end of a range over the current scope's ordered items -- "
+        "index-mode: up to and including this 0-based position "
         "(negative counts from the end), from the start or from "
-        ":from()'s position if present."
+        ":from()'s position if present. date-mode: up to and including "
+        "this calendar date, compared against each run's own arrival "
+        "date."
     )
     ROLE = Function3.CONTEXT_SETTER
     DATATYPES = (Reference3.RESULTS,)
-    ARG_TYPES = (int, Index3)
+    ARG_TYPES = (int, Index3, str, Date3)
     ARG_REQUIRED = True

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -98,6 +98,41 @@ class ReferenceFinder3(ABC):
         raise ReferenceException3(f"Unsupported pointer function: {pointer.name}")
 
     @staticmethod
+    def _range_bound(function) -> int:
+        """the plain int a built ':from()'/':to()' function's arg
+        represents -- handles both a bare int (":from(-3)") and a
+        nested ":index(n)" (":from(:index(-3))"), which
+        ReferenceFunctionFactory.build() already recursively compiled
+        into a real Index3 instance (not a plain int) by the time this
+        function exists -- see From3/To3's own comments for why both
+        shapes must be accepted."""
+        return function.arg if isinstance(function.arg, int) else function.arg.arg
+
+    @classmethod
+    def _apply_range(cls, items: list, from_call, to_call) -> list:
+        """slices `items` (already in the scope's own natural order)
+        using ':from()'/':to()' -- added 2026-08-13, RESULTS' index-mode
+        range selector, David's own framing: "our version of BETWEEN in
+        SQL or range() in Python." ':to()' is INCLUSIVE of its own
+        position (matches SQL BETWEEN and :index(n) itself pointing AT a
+        position -- ':from(2):to(5)' is positions 2 through 5, both
+        ends included). Either bound may be absent (an open range on
+        that side); negative bounds count from the end, same convention
+        :index(n) already has -- Python slicing already does the right
+        thing there natively, no special-casing needed except when
+        :to()'s own bound is exactly -1 (the last item): "+1" for
+        inclusivity would otherwise wrap -1 to 0, which means "nothing"
+        in a slice, not "to the end" -- that one case needs an explicit
+        fix, everything else falls out of ordinary slice semantics."""
+        start = cls._range_bound(from_call) if from_call is not None else None
+        if to_call is None:
+            return items[start:]
+        end = cls._range_bound(to_call)
+        if end == -1:
+            return items[start:]
+        return items[start : end + 1]
+
+    @staticmethod
     def _is_bare_pointer_reference(reference: Reference3, name: str) -> bool:
         """true when name_one's entire content is a single, argument-
         less ":name()" call -- no other path segments, no trailing

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -98,15 +98,19 @@ class ReferenceFinder3(ABC):
         raise ReferenceException3(f"Unsupported pointer function: {pointer.name}")
 
     @staticmethod
-    def _range_bound(function) -> int:
-        """the plain int a built ':from()'/':to()' function's arg
-        represents -- handles both a bare int (":from(-3)") and a
-        nested ":index(n)" (":from(:index(-3))"), which
+    def _range_bound(function) -> "int | str":
+        """the plain int/str value a built ':from()'/':to()' function's
+        arg represents -- handles bare leaf values (int for index-mode,
+        str for date-mode, added 2026-08-13) and nested wrapper
+        functions (":index(n)"/":date(...)"), which
         ReferenceFunctionFactory.build() already recursively compiled
-        into a real Index3 instance (not a plain int) by the time this
-        function exists -- see From3/To3's own comments for why both
-        shapes must be accepted."""
-        return function.arg if isinstance(function.arg, int) else function.arg.arg
+        into a real Index3/Date3 instance (not a plain int/str) by the
+        time this function exists -- see From3/To3's own comments for
+        why every shape must be accepted."""
+        arg = function.arg
+        if isinstance(arg, (int, str)):
+            return arg
+        return arg.arg
 
     @classmethod
     def _apply_range(cls, items: list, from_call, to_call) -> list:

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -1,5 +1,6 @@
 import json
 from abc import ABC, abstractmethod
+from datetime import datetime
 
 from csvpath.util.file_readers import DataFileReader
 from csvpath.util.nos import Nos
@@ -135,6 +136,54 @@ class ReferenceFinder3(ABC):
         if end == -1:
             return items[start:]
         return items[start : end + 1]
+
+    @staticmethod
+    def _validate_date_format(value: str) -> None:
+        """raises unless `value` is a real calendar date in "YYYY-MM-DD"
+        form -- shared 2026-08-13 (previously RESULTS-only) alongside
+        FILES/CSVPATHS getting their own date-mode ':from()'/':to()'.
+        Function3.check_valid()'s own generic ARG_TYPES check only
+        confirms an arg is A str, not that its CONTENT is a valid date --
+        a malformed date bound would otherwise be silently compared as
+        an ordinary string (no crash, just a meaningless answer), which
+        is worse than a clear, immediate rejection."""
+        try:
+            datetime.strptime(value, "%Y-%m-%d")
+        except ValueError:
+            raise ReferenceException3(
+                "date-mode ':from()'/':to()' requires a real calendar "
+                f"date in 'YYYY-MM-DD' form, got {value!r}."
+            ) from None
+
+    @staticmethod
+    def _apply_manifest_date_range(
+        entries: list, from_date: str | None, to_date: str | None, key: str = "time"
+    ) -> list:
+        """filters `entries` (manifest-entry dicts) to those whose own
+        `entries[i][key]` (an ISO datetime string, e.g. FILES/CSVPATHS'
+        own "time" field -- registration/load time, see functions/
+        fields/time_3.py's own SUMMARY) falls within [from_date, to_date],
+        both INCLUSIVE -- date-mode ':from()'/':to()' for FILES/CSVPATHS,
+        added 2026-08-13. Unlike index-mode (_apply_range, a POSITIONAL
+        slice), this is a FILTER, not a slice -- comparing positions
+        would be meaningless for a date bound. Compares only the first
+        10 characters (the "YYYY-MM-DD" date portion) of the stored
+        timestamp -- ISO date strings sort/compare lexicographically in
+        true chronological order, so plain string comparison is correct,
+        not just convenient (same convention ResultsReferenceFinder3's
+        own _run_dir_date/_apply_date_range already use for run
+        directories -- here the date comes straight from a stored field
+        instead of being parsed from a path, since FILES/CSVPATHS
+        manifest entries already carry it directly)."""
+        result = []
+        for entry in entries:
+            d = str(entry.get(key, ""))[:10]
+            if from_date is not None and d < from_date:
+                continue
+            if to_date is not None and d > to_date:
+                continue
+            result.append(entry)
+        return result
 
     @staticmethod
     def _is_bare_pointer_reference(reference: Reference3, name: str) -> bool:

--- a/csvpath/references/reference_results_3.py
+++ b/csvpath/references/reference_results_3.py
@@ -15,7 +15,14 @@ from uuid import UUID
 
 
 class ReferenceResult3:
-    def __init__(self, *, path: str, uuid: str | None, data: Any = None) -> None:
+    def __init__(
+        self,
+        *,
+        path: str,
+        uuid: str | None,
+        data: Any = None,
+        identity: str | None = None,
+    ) -> None:
         if not path:
             raise ValueError("ReferenceResult3 path cannot be None or empty")
         if uuid is not None and not uuid:
@@ -24,9 +31,15 @@ class ReferenceResult3:
                 "is no uuid (e.g. a directory-level, name_three-absent result "
                 "has no single version/registration to identify)"
             )
+        if identity is not None and not identity:
+            raise ValueError(
+                "ReferenceResult3 identity cannot be empty -- use None if "
+                "there is none"
+            )
         self._path = path
         self._uuid = uuid
         self._data = data
+        self._identity = identity
 
     @property
     def path(self) -> str:
@@ -46,18 +59,32 @@ class ReferenceResult3:
         # fills data in afterward on the same instances.
         self._data = data
 
+    @property
+    def identity(self) -> str | None:
+        """which specific sub-entity, within path+uuid, this result is
+        for -- added 2026-08-13 for CSVPATHS' statement-level range
+        selector (":from()'/':to()"). Unlike FILES/RESULTS, CSVPATHS has
+        no per-statement uuid at all (only the whole GROUP VERSION has
+        one) -- path/uuid are identical across every statement matched
+        by one query(), so _extract_data() cannot tell them apart from
+        those two fields alone the way it can for the other two
+        datatypes. None for every other case (path/uuid alone are
+        already enough there)."""
+        return self._identity
+
     def __eq__(self, other) -> bool:
         return (
             isinstance(other, ReferenceResult3)
             and other.path == self._path
             and other.uuid == self._uuid
             and other.data == self._data
+            and other.identity == self._identity
         )
 
     def __repr__(self) -> str:
         return (
             f"ReferenceResult3(path={self._path!r}, uuid={self._uuid!r}, "
-            f"data={self._data!r})"
+            f"data={self._data!r}, identity={self._identity!r})"
         )
 
 
@@ -98,12 +125,17 @@ class ReferenceResults3:
         return None
 
     def select(self, identifiers: list) -> "ReferenceResults3":
-        """a new ReferenceResults3 holding only the entries whose path
-        or uuid matches one of `identifiers` -- how resolve_from() turns
-        a caller-narrowed list[str | UUID] back into a subset to
-        resolve, without re-touching storage."""
+        """a new ReferenceResults3 holding only the entries whose path,
+        uuid, or identity (added 2026-08-13, see ReferenceResult3.
+        identity's own docstring for why) matches one of `identifiers`
+        -- how resolve_from() turns a caller-narrowed list[str | UUID]
+        back into a subset to resolve, without re-touching storage."""
         wanted = {str(i) for i in identifiers}
-        selected = [r for r in self._results if r.path in wanted or r.uuid in wanted]
+        selected = [
+            r
+            for r in self._results
+            if r.path in wanted or r.uuid in wanted or r.identity in wanted
+        ]
         return ReferenceResults3(results=selected)
 
     def remove(self, result: ReferenceResult3) -> None:

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -390,7 +390,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 )
             candidates = self._apply_range(candidates, from_call, to_call)
 
-        identity, match_all, accessor, _ = self._name_three_selector(
+        identity, match_all, accessor, _, range_bounds = self._name_three_selector(
             reference.name_three
         )
         has_manifest = any(
@@ -458,7 +458,11 @@ class ResultsReferenceFinder3(ReferenceFinder3):
 
         results = []
         for run_dir in selected_runs:
-            results.extend(self._results_for_run(run_dir, identity, match_all))
+            results.extend(
+                self._results_for_run(
+                    run_dir, identity, match_all, range_bounds, accessor
+                )
+            )
         return ReferenceResults3(results=results)
 
     def _query_star_traversal(self, reference: Reference3) -> ReferenceResults3:
@@ -676,7 +680,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             # _read_accessor already handles the idchain-filtering
             # internally based on accessor.arg, so both kinds resolve
             # identically from here.
-            _, _, accessor, field_call = self._name_three_selector(
+            _, _, accessor, field_call, _ = self._name_three_selector(
                 reference.name_three
             )
             if accessor is not None:
@@ -773,9 +777,14 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         return [pair for pair in homes if Nos(pair[0]).exists()]
 
     def _results_for_run(
-        self, run_dir: str, identity: str | None, match_all: bool
+        self,
+        run_dir: str,
+        identity: str | None,
+        match_all: bool,
+        range_bounds: tuple | None = None,
+        accessor=None,
     ) -> list[ReferenceResult3]:
-        if identity is None and not match_all:
+        if identity is None and not match_all and range_bounds is None:
             uuid = self._read_json_field(
                 Nos(run_dir).join("manifest.json"), "run_uuid"
             )
@@ -784,6 +793,29 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         instances = self._list_instance_identities(run_dir)
         if match_all:
             matched = instances
+        elif range_bounds is not None:
+            # ':from()'/':to()' as a statement-level range -- added
+            # 2026-08-13, David: ":from(:index(2)):unmatched() should
+            # definitely not work" -- a range is "more than one entity"
+            # the same way ':all()' already is, so it gets the same
+            # restriction combined with a content accessor. Unlike
+            # ':all()'s own BLANKET rejection there, this is count-
+            # DEPENDENT (checked per run, since different runs can have
+            # different statement counts) -- mirrors query()'s own
+            # run-level "more than one candidate" check exactly, rather
+            # than introducing a second style of restriction. A range
+            # that happens to narrow to exactly one statement in THIS
+            # run is fine with an accessor, same as a bare pointer
+            # narrowing a run-list to one already is.
+            from_call, to_call = range_bounds
+            matched = self._apply_range(instances, from_call, to_call)
+            if len(matched) > 1 and accessor is not None:
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3 requires ':from()'/':to()' to "
+                    "narrow to exactly one statement to read full well-"
+                    "known-file content -- resolving full content always "
+                    "touches exactly one entity, same as ':all()'."
+                )
         else:
             index = self._find_by_identity(identity, instances)
             matched = [instances[index]] if index is not None else []
@@ -856,36 +888,57 @@ class ResultsReferenceFinder3(ReferenceFinder3):
     _ACCESSOR_NAMES = ("errors", "vars", "meta", "data", "unmatched", "file")
 
     @staticmethod
-    def _name_three_selector(name_three) -> tuple[str | None, bool, object, object]:
-        """returns (identity, match_all, accessor, field_call) for
-        name_three -- identity is a literal statement-identity string to
-        look up (None if match_all, or if no identity/:all() selector is
-        present at all); match_all is True for :all() (every instance in
-        the run); accessor is the built well-known-file Function3 riding
-        alongside the identity/:all() selector; field_call is a
-        registered field-accessor Function3 (e.g. :uuid()) riding there
-        instead -- kept separate from accessor rather than one shared
-        variable, since field accessors are exempt from the single-
-        entity pooling rule (see query()) and content accessors are not;
-        conflating them would risk the same "field accessor accidentally
-        restricted like a content accessor" bug already hit twice during
-        the #228 merge. Resolving with neither present gives None -- "no
-        default". An unrecognized function raises via build_chain()
-        itself ("Unknown reference function") if it is not registered at
-        all, or is rejected here directly if it is registered but not
-        meaningful as a name_three function (e.g. :manifest())."""
+    def _name_three_selector(
+        name_three,
+    ) -> tuple[str | None, bool, object, object, tuple]:
+        """returns (identity, match_all, accessor, field_call,
+        range_bounds) for name_three -- identity is a literal statement-
+        identity string to look up (None if match_all/range_bounds, or
+        if no selector is present at all); match_all is True for :all()
+        (every instance in the run); range_bounds is (from_call, to_call)
+        for ':from()'/':to()' (a positional slice of instances -- added
+        2026-08-13, David: ":from(:index(2)):unmatched() should
+        definitely not work" -- confirmed a range is "more than one
+        entity" the same way :all() already is, see query()'s own
+        per-run count check for how this is enforced; unlike :all()'s
+        blanket rejection there, though, a range's rejection is count-
+        DEPENDENT, mirroring the run-level "more than one candidate"
+        check this whole file already uses elsewhere -- a range that
+        happens to narrow to exactly one instance is fine with an
+        accessor, same as a bare pointer narrowing to one run already
+        is), None if absent; accessor is the built well-known-file
+        Function3 riding alongside the identity/:all()/range selector;
+        field_call is a registered field-accessor Function3 (e.g.
+        :uuid()) riding there instead -- kept separate from accessor
+        rather than one shared variable, since field accessors are
+        exempt from the single-entity pooling rule (see query()) and
+        content accessors are not; conflating them would risk the same
+        "field accessor accidentally restricted like a content
+        accessor" bug already hit twice during the #228 merge.
+        Resolving with none of identity/match_all/range_bounds present
+        gives None -- "no default". An unrecognized function raises via
+        build_chain() itself ("Unknown reference function") if it is
+        not registered at all, or is rejected here directly if it is
+        registered but not meaningful as a name_three function (e.g.
+        :manifest())."""
         if name_three is None:
-            return None, False, None, None
+            return None, False, None, None, None
 
         match_all = False
         accessor = None
         field_call = None
+        from_call = None
+        to_call = None
         if name_three.functions:
             built = ReferenceFunctionFactory.build_chain(name_three.functions)
             field_call = ResultsReferenceFinder3._find_field_function_call(built)
             for f in built:
                 if f.name == "all":
                     match_all = True
+                elif f.name == "from":
+                    from_call = f
+                elif f.name == "to":
+                    to_call = f
                 elif f.name in ResultsReferenceFinder3._ACCESSOR_NAMES:
                     accessor = f
                 elif f is field_call:
@@ -895,6 +948,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                         f"ResultsReferenceFinder3 does not yet support "
                         f":{f.name}() as a name_three function."
                     )
+        range_bounds = (from_call, to_call) if (from_call or to_call) else None
 
         body = name_three.body
         if isinstance(body, Star3):
@@ -902,19 +956,20 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 "ResultsReferenceFinder3 does not support a bare '*' as "
                 "name_three's body -- use :all() instead."
             )
-        if body is not None and match_all:
+        if sum([body is not None, match_all, range_bounds is not None]) > 1:
             raise ReferenceException3(
                 "ResultsReferenceFinder3 cannot combine a literal "
-                "identity with :all() -- they select instances two "
-                "different, contradictory ways."
+                "identity, :all(), and ':from()'/':to()' -- each selects "
+                "instances a different, contradictory way; use only one."
             )
-        if body is None and not match_all:
+        if body is None and not match_all and range_bounds is None:
             raise ReferenceException3(
                 "ResultsReferenceFinder3 requires name_three to be a "
-                "literal statement identity or :all() to select which "
-                "instance(s) a well-known-file function applies to."
+                "literal statement identity, :all(), or ':from()'/':to()' "
+                "to select which instance(s) a well-known-file function "
+                "applies to."
             )
-        return body, match_all, accessor, field_call
+        return body, match_all, accessor, field_call, range_bounds
 
     @classmethod
     def _group_key(cls, run_home: str, home: str, prefix_len: int = 0) -> tuple:
@@ -991,17 +1046,42 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 return False
         return True
 
-    @staticmethod
-    def _list_instance_identities(run_dir: str) -> list[str]:
+    @classmethod
+    def _list_instance_identities(cls, run_dir: str) -> list[str]:
         """every csvpath statement's own result subdirectory within a
-        run, named by that statement's identity -- "_extra_data" is the
-        one non-instance directory a run dir can contain (manifest.json
-        is a file, already excluded by dirs_only)."""
-        return [
+        run, named by that statement's identity, sorted into real
+        DECLARATION order -- "_extra_data" is the one non-instance
+        directory a run dir can contain (manifest.json is a file,
+        already excluded by dirs_only).
+
+        Fixed 2026-08-13: this used to return raw directory-listing
+        order, which is filesystem-implementation-defined, NOT
+        declaration order -- a real, latent bug that ':all()' never
+        surfaced (it does not care about order) but ':from()'/':to()'
+        absolutely does ("the 3rd through last statement" is meaningless
+        without real order). Confirmed by tracing csvpaths.py's own
+        enumerate(paths)/enumerate(csvpath_objects) through Result/
+        ResultRegistrar/ResultMetadata to the actual written JSON key:
+        each instance's own manifest.json carries its declaration-order
+        position as "instance_index" (an int, stringified into the
+        directory name itself for unnamed statements, but always present
+        as this field regardless of whether the statement has an
+        explicit identity). Sorting by it, rather than trusting listdir
+        order, is the fix."""
+        names = [
             name
             for name in Nos(run_dir).listdir(dirs_only=True)
             if name != "_extra_data"
         ]
+
+        def _index(name: str) -> int:
+            inst_dir = Nos(run_dir).join(name)
+            idx = cls._read_json_field(
+                Nos(inst_dir).join("manifest.json"), "instance_index"
+            )
+            return int(idx) if idx is not None else 0
+
+        return sorted(names, key=_index)
 
     @classmethod
     def _read_json_field(cls, path: str, field: str):

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -374,6 +374,22 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             ]
         candidates = sorted(candidates, key=self._run_dir_sort_key)
 
+        from_call, to_call = self._range_calls_from_calls(calls)
+        if from_call is not None or to_call is not None:
+            # ':from()'/':to()' as a run-level index range -- added
+            # 2026-08-13, e.g. "customers:from(:index(-3))" -- "the
+            # last three runs with template customers." Stays a LIST
+            # (not reduced to one) unless a real pointer also rides
+            # alongside it, same as ':all()'/':groups()' already do --
+            # the pointer, if present, reduces the SLICE, not the full
+            # candidate set.
+            if group_key_for:
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3 does not yet support combining "
+                    "':from()'/':to()' with ':all()'/':groups()' grouping."
+                )
+            candidates = self._apply_range(candidates, from_call, to_call)
+
         identity, match_all, accessor, _ = self._name_three_selector(
             reference.name_three
         )
@@ -820,6 +836,22 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         built = ReferenceFunctionFactory.build_chain(calls)
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
         return pointers[0] if pointers else None
+
+    @staticmethod
+    def _range_calls_from_calls(calls: list) -> tuple:
+        """(from_call, to_call) -- the built ':from()'/':to()' Function3
+        instances among the combined chain, or None for whichever is
+        absent. Neither is a POINTER (both ROLE == CONTEXT_SETTER), so
+        they never compete with a real pointer for build_chain()'s "at
+        most one pointer" rule -- a pointer riding alongside either one
+        reduces the SLICE ':from()'/':to()' already narrowed to, same as
+        it already does for ':all()'/':groups()'."""
+        if not calls:
+            return None, None
+        built = ReferenceFunctionFactory.build_chain(calls)
+        from_call = next((f for f in built if f.name == "from"), None)
+        to_call = next((f for f in built if f.name == "to"), None)
+        return from_call, to_call
 
     _ACCESSOR_NAMES = ("errors", "vars", "meta", "data", "unmatched", "file")
 

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -391,8 +391,16 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             # arrival date instead, via _apply_date_range() below --
             # comparing POSITIONS would be meaningless for a date bound.
             # Mixing the two modes in one :from()/:to() pair is rejected
-            # -- there is no coherent single meaning for e.g.
-            # ":from(2):to(:date('2025-01-01'))".
+            # -- not because it is meaningless (e.g.
+            # ":from(:date('2025-01-01')):to(:index(10))" is a
+            # reasonable ask: "10 runs starting from this date"), but
+            # because it is AMBIGUOUS and undecided which of at least
+            # two readings is meant -- is the index bound absolute
+            # position in the full candidate list, or relative to
+            # wherever the date bound starts matching? Nothing here
+            # picks one, so mixing is rejected until that anchor
+            # semantics question is deliberately settled, not attempted
+            # here for lack of a driving use case.
             if group_key_for:
                 raise ReferenceException3(
                     "ResultsReferenceFinder3 does not yet support combining "

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -1,6 +1,5 @@
 import json
 import re
-from datetime import datetime
 
 from csvpath.util.file_readers import DataFileReader
 from csvpath.util.nos import Nos
@@ -914,28 +913,6 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         from_call = next((f for f in built if f.name == "from"), None)
         to_call = next((f for f in built if f.name == "to"), None)
         return from_call, to_call
-
-    @staticmethod
-    def _validate_date_format(value: str) -> None:
-        """raises unless `value` is a real calendar date in "YYYY-MM-DD"
-        form -- added 2026-08-13 alongside date-mode ':from()'/':to()'.
-        Function3.check_valid()'s own generic ARG_TYPES check only
-        confirms an arg is A str, not that its CONTENT is a valid date
-        (same as it never validates an int's semantic meaningfulness
-        either) -- a malformed date bound would otherwise be silently
-        compared as an ordinary string (no crash, just a meaningless
-        answer), which is worse than a clear, immediate rejection.
-        Checked once here, covering both the bare-string and
-        ':date(...)'-wrapped shapes identically, since _range_bound()
-        already unwraps both down to a plain string before this runs."""
-        try:
-            datetime.strptime(value, "%Y-%m-%d")
-        except ValueError:
-            raise ReferenceException3(
-                f"ResultsReferenceFinder3's date-mode ':from()'/':to()' "
-                f"requires a real calendar date in 'YYYY-MM-DD' form, got "
-                f"{value!r}."
-            ) from None
 
     @classmethod
     def _apply_date_range(

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -1,5 +1,6 @@
 import json
 import re
+from datetime import datetime
 
 from csvpath.util.file_readers import DataFileReader
 from csvpath.util.nos import Nos
@@ -376,19 +377,48 @@ class ResultsReferenceFinder3(ReferenceFinder3):
 
         from_call, to_call = self._range_calls_from_calls(calls)
         if from_call is not None or to_call is not None:
-            # ':from()'/':to()' as a run-level index range -- added
-            # 2026-08-13, e.g. "customers:from(:index(-3))" -- "the
-            # last three runs with template customers." Stays a LIST
-            # (not reduced to one) unless a real pointer also rides
-            # alongside it, same as ':all()'/':groups()' already do --
-            # the pointer, if present, reduces the SLICE, not the full
-            # candidate set.
+            # ':from()'/':to()' as a run-level range -- added 2026-08-13,
+            # e.g. "customers:from(:index(-3))" -- "the last three runs
+            # with template customers." Stays a LIST (not reduced to
+            # one) unless a real pointer also rides alongside it, same
+            # as ':all()'/':groups()' already do -- the pointer, if
+            # present, reduces the RANGE, not the full candidate set.
+            #
+            # Two independent MODES, picked by each bound's own value
+            # type: index-mode (int/:index(n)) POSITIONALLY slices, via
+            # the shared _apply_range(); date-mode (str/:date(...),
+            # added the same day, David: "arrival and run order is even
+            # more important than indexing") FILTERS by each run's own
+            # arrival date instead, via _apply_date_range() below --
+            # comparing POSITIONS would be meaningless for a date bound.
+            # Mixing the two modes in one :from()/:to() pair is rejected
+            # -- there is no coherent single meaning for e.g.
+            # ":from(2):to(:date('2025-01-01'))".
             if group_key_for:
                 raise ReferenceException3(
                     "ResultsReferenceFinder3 does not yet support combining "
                     "':from()'/':to()' with ':all()'/':groups()' grouping."
                 )
-            candidates = self._apply_range(candidates, from_call, to_call)
+            from_bound = self._range_bound(from_call) if from_call is not None else None
+            to_bound = self._range_bound(to_call) if to_call is not None else None
+            from_is_date = isinstance(from_bound, str)
+            to_is_date = isinstance(to_bound, str)
+            if (from_bound is not None and to_bound is not None) and (
+                from_is_date != to_is_date
+            ):
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3 does not support mixing index-"
+                    "mode and date-mode ':from()'/':to()' bounds in the "
+                    "same range."
+                )
+            if from_is_date or to_is_date:
+                if from_is_date:
+                    self._validate_date_format(from_bound)
+                if to_is_date:
+                    self._validate_date_format(to_bound)
+                candidates = self._apply_date_range(candidates, from_bound, to_bound)
+            else:
+                candidates = self._apply_range(candidates, from_call, to_call)
 
         identity, match_all, accessor, _, range_bounds = self._name_three_selector(
             reference.name_three
@@ -884,6 +914,64 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         from_call = next((f for f in built if f.name == "from"), None)
         to_call = next((f for f in built if f.name == "to"), None)
         return from_call, to_call
+
+    @staticmethod
+    def _validate_date_format(value: str) -> None:
+        """raises unless `value` is a real calendar date in "YYYY-MM-DD"
+        form -- added 2026-08-13 alongside date-mode ':from()'/':to()'.
+        Function3.check_valid()'s own generic ARG_TYPES check only
+        confirms an arg is A str, not that its CONTENT is a valid date
+        (same as it never validates an int's semantic meaningfulness
+        either) -- a malformed date bound would otherwise be silently
+        compared as an ordinary string (no crash, just a meaningless
+        answer), which is worse than a clear, immediate rejection.
+        Checked once here, covering both the bare-string and
+        ':date(...)'-wrapped shapes identically, since _range_bound()
+        already unwraps both down to a plain string before this runs."""
+        try:
+            datetime.strptime(value, "%Y-%m-%d")
+        except ValueError:
+            raise ReferenceException3(
+                f"ResultsReferenceFinder3's date-mode ':from()'/':to()' "
+                f"requires a real calendar date in 'YYYY-MM-DD' form, got "
+                f"{value!r}."
+            ) from None
+
+    @classmethod
+    def _apply_date_range(
+        cls, run_homes: list, from_date: str | None, to_date: str | None
+    ) -> list:
+        """filters `run_homes` to those whose own arrival date (parsed
+        from each directory's own fixed-width timestamp prefix, see
+        _run_dir_date) falls within [from_date, to_date], both
+        INCLUSIVE -- date-mode ':from()'/':to()', added 2026-08-13.
+        Unlike index-mode (_apply_range, a POSITIONAL slice), this is a
+        FILTER, not a slice -- comparing run positions would be
+        meaningless for a date bound. run_homes is not assumed to
+        already be date-sorted (though in practice it always is, via
+        _run_dir_sort_key, since this runs after that sort in query())."""
+        result = []
+        for rh in run_homes:
+            d = cls._run_dir_date(rh)
+            if from_date is not None and d < from_date:
+                continue
+            if to_date is not None and d > to_date:
+                continue
+            result.append(rh)
+        return result
+
+    @staticmethod
+    def _run_dir_date(run_home: str) -> str:
+        """the run's own arrival date ("YYYY-MM-DD"), parsed from its
+        directory name's own fixed-width timestamp prefix -- RunHomeMaker
+        always writes "%Y-%m-%d_%H-%M-%S[_N]", so the first 10
+        characters are always the date, regardless of any "_N"
+        disambiguation suffix. ISO date strings sort/compare
+        lexicographically in true chronological order, so plain string
+        comparison (see _apply_date_range) is correct, not just
+        convenient."""
+        seg = run_home.rstrip("/").rsplit("/", 1)[-1]
+        return seg[:10]
 
     _ACCESSOR_NAMES = ("errors", "vars", "meta", "data", "unmatched", "file")
 

--- a/tests/references/functions/fields/test_fingerprint_3.py
+++ b/tests/references/functions/fields/test_fingerprint_3.py
@@ -22,6 +22,13 @@ def test_no_arg_is_valid():
     Fingerprint3().check_valid()  # should not raise
 
 
-def test_arg_is_rejected():
+def test_str_arg_is_valid():
+    # settled 2026-08-13: an optional str arg supports the bare-lookup
+    # shape for FILES ("$alpha.files.:fingerprint('hash...')") -- see
+    # FilesReferenceFinder3._is_bare_fingerprint_reference/query().
+    Fingerprint3(arg="x").check_valid()  # should not raise
+
+
+def test_non_str_arg_is_rejected():
     with pytest.raises(ReferenceException3):
-        Fingerprint3(arg="x").check_valid()
+        Fingerprint3(arg=1).check_valid()

--- a/tests/references/functions/selectors/test_date_3.py
+++ b/tests/references/functions/selectors/test_date_3.py
@@ -1,0 +1,27 @@
+import pytest
+
+from csvpath.references.functions.selectors.date_3 import Date3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Date3(arg="2025-01-01")
+    assert f.name == "date"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+
+
+def test_str_arg_is_valid():
+    Date3(arg="2025-01-01").check_valid()  # should not raise
+
+
+def test_no_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Date3().check_valid()
+
+
+def test_non_str_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Date3(arg=1).check_valid()

--- a/tests/references/functions/selectors/test_from_3.py
+++ b/tests/references/functions/selectors/test_from_3.py
@@ -1,0 +1,32 @@
+import pytest
+
+from csvpath.references.functions.selectors.from_3 import From3
+from csvpath.references.functions.selectors.index_3 import Index3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = From3(arg=1)
+    assert f.name == "from"
+    assert f.ROLE == Function3.CONTEXT_SETTER
+    assert f.DATATYPES == (Reference3.RESULTS,)
+
+
+def test_int_arg_is_valid():
+    From3(arg=-3).check_valid()  # should not raise
+
+
+def test_nested_index_arg_is_valid():
+    From3(arg=Index3(arg=-3)).check_valid()  # should not raise
+
+
+def test_no_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        From3().check_valid()
+
+
+def test_string_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        From3(arg="x").check_valid()

--- a/tests/references/functions/selectors/test_from_3.py
+++ b/tests/references/functions/selectors/test_from_3.py
@@ -12,7 +12,7 @@ def test_metadata():
     f = From3(arg=1)
     assert f.name == "from"
     assert f.ROLE == Function3.CONTEXT_SETTER
-    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
 
 
 def test_int_arg_is_valid():

--- a/tests/references/functions/selectors/test_from_3.py
+++ b/tests/references/functions/selectors/test_from_3.py
@@ -1,5 +1,6 @@
 import pytest
 
+from csvpath.references.functions.selectors.date_3 import Date3
 from csvpath.references.functions.selectors.from_3 import From3
 from csvpath.references.functions.selectors.index_3 import Index3
 from csvpath.references.functions.function_3 import Function3
@@ -22,11 +23,22 @@ def test_nested_index_arg_is_valid():
     From3(arg=Index3(arg=-3)).check_valid()  # should not raise
 
 
+def test_str_arg_is_valid():
+    # settled 2026-08-13: a bare str is date-mode's leaf shape (the
+    # format itself is validated by ResultsReferenceFinder3, not here --
+    # see Function3.check_valid()'s own "structural, not value" scope).
+    From3(arg="2025-01-01").check_valid()  # should not raise
+
+
+def test_nested_date_arg_is_valid():
+    From3(arg=Date3(arg="2025-01-01")).check_valid()  # should not raise
+
+
 def test_no_arg_is_rejected():
     with pytest.raises(ReferenceException3):
         From3().check_valid()
 
 
-def test_string_arg_is_rejected():
+def test_non_leaf_type_is_rejected():
     with pytest.raises(ReferenceException3):
-        From3(arg="x").check_valid()
+        From3(arg=1.5).check_valid()

--- a/tests/references/functions/selectors/test_having_3.py
+++ b/tests/references/functions/selectors/test_having_3.py
@@ -1,0 +1,27 @@
+import pytest
+
+from csvpath.references.functions.selectors.having_3 import Having3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = Having3(arg="my_validations")
+    assert f.name == "having"
+    assert f.ROLE == Function3.CONTEXT_SETTER
+    assert f.DATATYPES == (Reference3.CSVPATHS,)
+
+
+def test_str_arg_is_valid():
+    Having3(arg="x").check_valid()  # should not raise
+
+
+def test_no_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Having3().check_valid()
+
+
+def test_non_str_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        Having3(arg=1).check_valid()

--- a/tests/references/functions/selectors/test_to_3.py
+++ b/tests/references/functions/selectors/test_to_3.py
@@ -1,5 +1,6 @@
 import pytest
 
+from csvpath.references.functions.selectors.date_3 import Date3
 from csvpath.references.functions.selectors.to_3 import To3
 from csvpath.references.functions.selectors.index_3 import Index3
 from csvpath.references.functions.function_3 import Function3
@@ -22,11 +23,21 @@ def test_nested_index_arg_is_valid():
     To3(arg=Index3(arg=5)).check_valid()  # should not raise
 
 
+def test_str_arg_is_valid():
+    # settled 2026-08-13: a bare str is date-mode's leaf shape (the
+    # format itself is validated by ResultsReferenceFinder3, not here).
+    To3(arg="2025-01-31").check_valid()  # should not raise
+
+
+def test_nested_date_arg_is_valid():
+    To3(arg=Date3(arg="2025-01-31")).check_valid()  # should not raise
+
+
 def test_no_arg_is_rejected():
     with pytest.raises(ReferenceException3):
         To3().check_valid()
 
 
-def test_string_arg_is_rejected():
+def test_non_leaf_type_is_rejected():
     with pytest.raises(ReferenceException3):
-        To3(arg="x").check_valid()
+        To3(arg=1.5).check_valid()

--- a/tests/references/functions/selectors/test_to_3.py
+++ b/tests/references/functions/selectors/test_to_3.py
@@ -1,0 +1,32 @@
+import pytest
+
+from csvpath.references.functions.selectors.to_3 import To3
+from csvpath.references.functions.selectors.index_3 import Index3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = To3(arg=1)
+    assert f.name == "to"
+    assert f.ROLE == Function3.CONTEXT_SETTER
+    assert f.DATATYPES == (Reference3.RESULTS,)
+
+
+def test_int_arg_is_valid():
+    To3(arg=5).check_valid()  # should not raise
+
+
+def test_nested_index_arg_is_valid():
+    To3(arg=Index3(arg=5)).check_valid()  # should not raise
+
+
+def test_no_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        To3().check_valid()
+
+
+def test_string_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        To3(arg="x").check_valid()

--- a/tests/references/functions/selectors/test_to_3.py
+++ b/tests/references/functions/selectors/test_to_3.py
@@ -12,7 +12,7 @@ def test_metadata():
     f = To3(arg=1)
     assert f.name == "to"
     assert f.ROLE == Function3.CONTEXT_SETTER
-    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
 
 
 def test_int_arg_is_valid():

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -211,10 +211,90 @@ class TestIdentityLookupOnNameThree:
         # (path, uuid) as name_one alone for csvpaths -- name_three only
         # adds an existence constraint, it does not select a different
         # physical thing (there isn't one -- one file, one uuid per
-        # version, regardless of which statement within it).
+        # version, regardless of which statement within it). identity
+        # DOES differ (added 2026-08-13, see ReferenceResult3.identity's
+        # own docstring) -- that is the whole point of it, not a bug.
         with_three = _finder("$acme.csvpaths.:first().company_names").query()
         without_three = _finder("$acme.csvpaths.:first()").query()
-        assert with_three.results == without_three.results
+        assert with_three.files == without_three.files
+        assert with_three.uuids == without_three.uuids
+        assert with_three.results[0].identity == "company_names"
+        assert without_three.results[0].identity is None
+
+
+RANGE_GROUP_FILE_PATH = "named_paths/ranger/group.csvpath"
+RANGE_MANIFEST = [
+    {
+        "group_file_path": RANGE_GROUP_FILE_PATH,
+        "uuid": "range-uuid",
+        "named_paths": [
+            "stmt one text",
+            "stmt two text",
+            "stmt three text",
+            "stmt four text",
+            "stmt five text",
+        ],
+        "named_paths_identities": ["one", "two", "three", "four", "five"],
+    },
+]
+
+
+class TestNameThreeRange:
+    # ':from()'/':to()' as a name_three statement range -- added
+    # 2026-08-13, David's own FlightPath v2 use case: rewind/replay
+    # starting from a specific csvpath statement (e.g.
+    # "$acme.csvpaths.:last().:from(:index(2))"). Windows the matched
+    # version's own ordered "named_paths_identities" list; each windowed
+    # result carries its OWN identity since csvpaths has no per-
+    # statement uuid (see ReferenceResult3.identity's own docstring).
+    def test_from_index_negative_gives_the_last_n(self):
+        results = _finder(
+            "$ranger.csvpaths.:first().:from(-2)", RANGE_MANIFEST
+        ).query()
+        assert [r.identity for r in results.results] == ["four", "five"]
+        assert results.uuids == ["range-uuid", "range-uuid"]
+        assert results.files == [RANGE_GROUP_FILE_PATH, RANGE_GROUP_FILE_PATH]
+
+    def test_from_and_to_together_is_an_inclusive_range(self):
+        results = _finder(
+            "$ranger.csvpaths.:first().:from(:index(1)):to(:index(3))",
+            RANGE_MANIFEST,
+        ).query()
+        assert [r.identity for r in results.results] == ["two", "three", "four"]
+
+    def test_resolve_gives_each_windowed_statements_own_text(self):
+        results = _finder(
+            "$ranger.csvpaths.:first().:from(:index(1)):to(:index(2))",
+            RANGE_MANIFEST,
+        ).resolve()
+        assert [r.data for r in results.results] == [
+            "stmt two text",
+            "stmt three text",
+        ]
+
+    def test_date_mode_is_not_supported(self):
+        # csvpaths statements have no arrival date of their own -- only
+        # index-mode bounds are meaningful.
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$ranger.csvpaths.:first().:from(:date("2025-01-01"))',
+                RANGE_MANIFEST,
+            ).query()
+
+    def test_combining_a_literal_identity_with_a_range_is_rejected(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$ranger.csvpaths.:first().one:from(-1)", RANGE_MANIFEST
+            ).query()
+
+    def test_an_unrecognized_function_on_name_three_is_rejected(self):
+        # anything other than a literal identity or ':from()'/':to()'
+        # is not yet supported on name_three -- e.g. a pointer riding
+        # alongside the range, which FILES allows but csvpaths does not.
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$ranger.csvpaths.:first().:from(-2):last()", RANGE_MANIFEST
+            ).query()
 
 
 class TestResolve:

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -164,6 +164,35 @@ class TestNoPointerReturnsEveryVersion:
         assert results.files == []
 
 
+class TestHaving:
+    # ':having("identity")' -- added 2026-08-13, filters the version
+    # list down to versions whose own "named_paths_identities" actually
+    # contains that identity, before any pointer reduces further --
+    # "company_names" only exists in ACME_MANIFEST's v0.
+    def test_having_then_pointer_reduces_the_filtered_list(self):
+        results = _finder("$acme.csvpaths.:having(\"company_names\"):last()").query()
+        assert results.uuids == ["v0-uuid"]
+
+    def test_having_alone_lists_matching_versions_unreduced(self):
+        results = _finder('$acme.csvpaths.:having("company_names")').query()
+        assert results.uuids == ["v0-uuid"]
+
+    def test_having_with_no_matching_version_is_empty(self):
+        results = _finder('$acme.csvpaths.:having("nope")').query()
+        assert results.uuids == []
+
+    def test_having_matches_an_unnamed_statements_stringified_index_too(self):
+        # v1's sole statement is unnamed -- its identity is "0" (the
+        # stringified load-time index), same convention name_three
+        # identity lookups already use.
+        results = _finder('$acme.csvpaths.:having("0"):last()').query()
+        assert results.uuids == ["v1-uuid"]
+
+    def test_having_requires_an_argument(self):
+        with pytest.raises(ReferenceException3):
+            _finder("$acme.csvpaths.:having():last()").query()
+
+
 class TestIdentityLookupOnNameThree:
     def test_matches_named_identity(self):
         results = _finder("$acme.csvpaths.:first().company_names").query()

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -193,6 +193,90 @@ class TestHaving:
             _finder("$acme.csvpaths.:having():last()").query()
 
 
+VERSION_RANGE_GROUP_FILE_PATH = "named_paths/dater/group.csvpath"
+VERSION_RANGE_MANIFEST = [
+    {
+        "group_file_path": VERSION_RANGE_GROUP_FILE_PATH,
+        "uuid": f"v{i}-uuid",
+        "named_paths": [f"stmt {i} text"],
+        "named_paths_identities": [str(i)],
+        "time": f"2026-01-0{i + 1}T00:00:00+00:00",
+    }
+    for i in range(5)
+]
+
+
+class TestVersionRange:
+    # ':from()'/':to()' as a name_one VERSION range -- added 2026-08-13,
+    # David: a named-paths group's own load time is a real arrival-date
+    # concept ("give me the versions loaded between date-one and
+    # date-two"), the same one RESULTS'/FILES' own version-level ranges
+    # already filter by. Windows the (possibly ':having()'-filtered)
+    # manifest -- a real pointer riding alongside reduces the RANGE, not
+    # the full candidate set, same as RESULTS/FILES.
+    def test_from_index_negative_gives_the_last_n_versions(self):
+        results = _finder(
+            "$dater.csvpaths.:from(-2)", VERSION_RANGE_MANIFEST
+        ).query()
+        assert results.uuids == ["v3-uuid", "v4-uuid"]
+
+    def test_from_and_to_together_is_an_inclusive_range(self):
+        results = _finder(
+            "$dater.csvpaths.:from(1):to(3)", VERSION_RANGE_MANIFEST
+        ).query()
+        assert results.uuids == ["v1-uuid", "v2-uuid", "v3-uuid"]
+
+    def test_a_pointer_reduces_the_range_not_the_full_candidate_set(self):
+        results = _finder(
+            "$dater.csvpaths.:from(-3):last()", VERSION_RANGE_MANIFEST
+        ).query()
+        assert results.uuids == ["v4-uuid"]
+
+    def test_date_mode_from_filters_by_the_versions_own_load_time(self):
+        results = _finder(
+            '$dater.csvpaths.:from(:date("2026-01-03"))', VERSION_RANGE_MANIFEST
+        ).query()
+        assert results.uuids == ["v2-uuid", "v3-uuid", "v4-uuid"]
+
+    def test_date_mode_from_and_to_together_is_an_inclusive_range(self):
+        results = _finder(
+            '$dater.csvpaths.:from("2026-01-02"):to("2026-01-04")',
+            VERSION_RANGE_MANIFEST,
+        ).query()
+        assert results.uuids == ["v1-uuid", "v2-uuid", "v3-uuid"]
+
+    def test_mixing_index_mode_and_date_mode_bounds_is_rejected(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$dater.csvpaths.:from(1):to(:date("2026-01-01"))',
+                VERSION_RANGE_MANIFEST,
+            ).query()
+
+    def test_a_malformed_date_bound_is_rejected(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$dater.csvpaths.:from("not-a-date")', VERSION_RANGE_MANIFEST
+            ).query()
+
+    def test_having_filters_before_the_range_windows(self):
+        # ':having("4")' only matches v4, so the range (last 3) has just
+        # that one entry to window -- confirms the two compose in the
+        # order the docstring describes (having, then range, then
+        # pointer), not independently.
+        results = _finder(
+            '$dater.csvpaths.:having("4"):from(-3)', VERSION_RANGE_MANIFEST
+        ).query()
+        assert results.uuids == ["v4-uuid"]
+
+    def test_range_combined_with_star_traversal_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$*.csvpaths.:from(-2):last()",
+                VERSION_RANGE_MANIFEST,
+                by_name={"dater": VERSION_RANGE_MANIFEST},
+            ).query()
+
+
 class TestIdentityLookupOnNameThree:
     def test_matches_named_identity(self):
         results = _finder("$acme.csvpaths.:first().company_names").query()

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -1071,6 +1071,61 @@ class TestBareFingerprintLookup:
             ).query()
 
 
+RANGE_HOME = "inputs/named_files/ranger"
+RANGE_MANIFEST = [
+    {
+        "file": f"inputs/named_files/ranger/orders.csv/v{i}.csv",
+        "file_home": "inputs/named_files/ranger/orders.csv",
+        "uuid": f"v{i}",
+    }
+    for i in range(5)
+]
+
+
+class TestNameThreeRange:
+    # ':from()'/':to()' as a name_three version range -- added
+    # 2026-08-13, David: rewind/replay and comparing versions need "the
+    # last N versions of a named-file" the same way RESULTS' own
+    # run-level range does. Windows the ordered version list of the
+    # already name_one-matched file, same position :first()/:last()/
+    # :index(n) already occupy.
+    def test_from_index_negative_gives_the_last_n(self):
+        results = _finder(
+            '$ranger.files.:name("orders.csv").:from(-3)', RANGE_HOME, RANGE_MANIFEST
+        ).query()
+        assert results.uuids == ["v2", "v3", "v4"]
+
+    def test_from_and_to_together_is_an_inclusive_range(self):
+        results = _finder(
+            '$ranger.files.:name("orders.csv").:from(1):to(3)',
+            RANGE_HOME,
+            RANGE_MANIFEST,
+        ).query()
+        assert results.uuids == ["v1", "v2", "v3"]
+
+    def test_a_pointer_reduces_the_range_not_the_full_candidate_set(self):
+        results = _finder(
+            '$ranger.files.:name("orders.csv").:from(-3):last()',
+            RANGE_HOME,
+            RANGE_MANIFEST,
+        ).query()
+        assert results.uuids == ["v4"]
+
+    def test_date_mode_is_not_supported_for_files(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$ranger.files.:name("orders.csv").:from(:date("2025-01-01"))',
+                RANGE_HOME,
+                RANGE_MANIFEST,
+            ).query()
+
+    def test_range_combined_with_grouping_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$ranger.files.:all().:from(-1)", RANGE_HOME, RANGE_MANIFEST
+            ).query()
+
+
 class TestGroupsForOneNamedFile:
     # bare ':groups()' as name_one's entire content, for a LITERAL
     # (non-'*') root_major -- added 2026-08-12, the any-depth GROUP peer

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -1070,6 +1070,29 @@ class TestBareFingerprintLookup:
                 FINGERPRINT_MANIFEST,
             ).query()
 
+    def test_two_different_logical_files_sharing_one_fingerprint_both_come_back(self):
+        # confirms the "at most one match is expected in practice... not
+        # specially guarded against" comment in query() -- two DIFFERENT
+        # logical files (different file_home) with byte-identical content
+        # share one fingerprint here; the lookup is not artificially
+        # restricted to one result, it returns every real match.
+        shared_manifest = FINGERPRINT_MANIFEST + [
+            {
+                "file": "inputs/named_files/finn/backups/orders.csv/aaaa.csv",
+                "file_home": "inputs/named_files/finn/backups/orders.csv",
+                "uuid": "u-orders-backup-1",
+                "fingerprint": "aaaa",
+            }
+        ]
+        results = _finder(
+            '$finn.files.:fingerprint("aaaa")', FINGERPRINT_HOME, shared_manifest
+        ).query()
+        assert results.files == [
+            "inputs/named_files/finn/orders.csv/aaaa.csv",
+            "inputs/named_files/finn/backups/orders.csv/aaaa.csv",
+        ]
+        assert results.uuids == ["u-orders-1", "u-orders-backup-1"]
+
 
 RANGE_HOME = "inputs/named_files/ranger"
 RANGE_MANIFEST = [

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -1077,6 +1077,7 @@ RANGE_MANIFEST = [
         "file": f"inputs/named_files/ranger/orders.csv/v{i}.csv",
         "file_home": "inputs/named_files/ranger/orders.csv",
         "uuid": f"v{i}",
+        "time": f"2026-01-0{i + 1}T00:00:00+00:00",
     }
     for i in range(5)
 ]
@@ -1111,10 +1112,39 @@ class TestNameThreeRange:
         ).query()
         assert results.uuids == ["v4"]
 
-    def test_date_mode_is_not_supported_for_files(self):
+    def test_date_mode_from_filters_by_the_versions_own_arrival_time(self):
+        # broadened from RESULTS-only 2026-08-13 -- David: a named-file
+        # version's own registration/load "time" is a real arrival-date
+        # concept, same as RESULTS' run start time.
+        results = _finder(
+            '$ranger.files.:name("orders.csv").:from(:date("2026-01-03"))',
+            RANGE_HOME,
+            RANGE_MANIFEST,
+        ).query()
+        assert results.uuids == ["v2", "v3", "v4"]
+
+    def test_date_mode_from_and_to_together_is_an_inclusive_range(self):
+        # the bare-string shape (no ':date()' wrapper) is also valid,
+        # same as RESULTS' own date-mode.
+        results = _finder(
+            '$ranger.files.:name("orders.csv").:from("2026-01-02"):to("2026-01-04")',
+            RANGE_HOME,
+            RANGE_MANIFEST,
+        ).query()
+        assert results.uuids == ["v1", "v2", "v3"]
+
+    def test_mixing_index_mode_and_date_mode_bounds_is_rejected(self):
         with pytest.raises(ReferenceException3):
             _finder(
-                '$ranger.files.:name("orders.csv").:from(:date("2025-01-01"))',
+                '$ranger.files.:name("orders.csv").:from(1):to(:date("2026-01-01"))',
+                RANGE_HOME,
+                RANGE_MANIFEST,
+            ).query()
+
+    def test_a_malformed_date_bound_is_rejected(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$ranger.files.:name("orders.csv").:from("not-a-date")',
                 RANGE_HOME,
                 RANGE_MANIFEST,
             ).query()

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -992,6 +992,85 @@ class TestAllOnNameThree:
         assert results.uuids == ["u-one-2"]
 
 
+FINGERPRINT_HOME = "inputs/named_files/finn"
+FINGERPRINT_MANIFEST = [
+    {
+        "file": "inputs/named_files/finn/orders.csv/aaaa.csv",
+        "file_home": "inputs/named_files/finn/orders.csv",
+        "uuid": "u-orders-1",
+        "fingerprint": "aaaa",
+    },
+    {
+        "file": "inputs/named_files/finn/2025/returns.csv/cccc.csv",
+        "file_home": "inputs/named_files/finn/2025/returns.csv",
+        "uuid": "u-returns-1",
+        "fingerprint": "cccc",
+    },
+]
+
+
+class TestBareFingerprintLookup:
+    # bare ':fingerprint("hash...")' -- added 2026-08-13, a content-hash
+    # lookup across the WHOLE named-file's manifest, every file_home/
+    # path -- unlike ':name()' (a path identity), content identity does
+    # not care which slot a version is registered under.
+    # FINGERPRINT_MANIFEST deliberately has its match at TWO levels deep
+    # (2025/returns.csv), proving this is not just pattern-matching one
+    # level like ':name()' would be.
+    def test_finds_the_matching_version_with_real_path_and_uuid(self):
+        results = _finder(
+            '$finn.files.:fingerprint("cccc")', FINGERPRINT_HOME, FINGERPRINT_MANIFEST
+        ).query()
+        assert results.files == ["inputs/named_files/finn/2025/returns.csv/cccc.csv"]
+        assert results.uuids == ["u-returns-1"]
+
+    def test_no_match_gives_empty(self):
+        results = _finder(
+            '$finn.files.:fingerprint("nope")', FINGERPRINT_HOME, FINGERPRINT_MANIFEST
+        ).query()
+        assert results.results == []
+
+    def test_bare_no_arg_is_not_recognized_here(self):
+        # no arg means there is no candidate to read the field off of at
+        # this position -- falls through to the ordinary "not yet
+        # supported" rejection, not a silent no-op.
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$finn.files.:fingerprint()", FINGERPRINT_HOME, FINGERPRINT_MANIFEST
+            ).query()
+
+    def test_combined_with_name_three_is_not_yet_supported(self):
+        # a fingerprint already identifies one specific version -- no
+        # further narrowing is meaningful.
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$finn.files.:fingerprint("cccc").:last()',
+                FINGERPRINT_HOME,
+                FINGERPRINT_MANIFEST,
+            ).query()
+
+    def test_ordinary_field_accessor_usage_is_unaffected(self):
+        # riding alongside a matched version in name_three (its original,
+        # pre-existing job) still works exactly as before.
+        results = _finder(
+            '$finn.files.:name("orders.csv").:first():fingerprint()',
+            FINGERPRINT_HOME,
+            FINGERPRINT_MANIFEST,
+        ).resolve()
+        assert results.results[0].data == "aaaa"
+
+    def test_an_argument_in_the_field_accessor_position_is_rejected(self):
+        # ARG_TYPES now allows a str arg (for the bare lookup form) --
+        # confirm it does NOT get silently ignored when :fingerprint()
+        # rides in its ordinary field-accessor position instead.
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$finn.files.:name("orders.csv").:first():fingerprint("x")',
+                FINGERPRINT_HOME,
+                FINGERPRINT_MANIFEST,
+            ).query()
+
+
 class TestGroupsForOneNamedFile:
     # bare ':groups()' as name_one's entire content, for a LITERAL
     # (non-'*') root_major -- added 2026-08-12, the any-depth GROUP peer

--- a/tests/references/test_reference_results_3.py
+++ b/tests/references/test_reference_results_3.py
@@ -36,6 +36,29 @@ class TestReferenceResult3:
         assert a == b
         assert a != c
 
+    def test_identity_defaults_to_none(self):
+        r = ReferenceResult3(path="p1", uuid="u1")
+        assert r.identity is None
+
+    def test_identity_is_settable_at_construction(self):
+        # added 2026-08-13 for CSVPATHS' statement-level range selector
+        # -- path/uuid alone are identical across every statement in a
+        # range (CSVPATHS has no per-statement uuid), so identity is
+        # what lets _extract_data() tell them apart.
+        r = ReferenceResult3(path="p1", uuid="u1", identity="my_validations")
+        assert r.identity == "my_validations"
+
+    def test_rejects_empty_identity(self):
+        with pytest.raises(ValueError):
+            ReferenceResult3(path="p1", uuid="u1", identity="")
+
+    def test_equality_considers_identity(self):
+        a = ReferenceResult3(path="p1", uuid="u1", identity="a")
+        b = ReferenceResult3(path="p1", uuid="u1", identity="a")
+        c = ReferenceResult3(path="p1", uuid="u1", identity="b")
+        assert a == b
+        assert a != c
+
 
 class TestReferenceResults3:
     def _results(self):
@@ -86,6 +109,19 @@ class TestReferenceResults3:
         r = self._results()
         selected = r.select(["nope"])
         assert len(selected) == 0
+
+    def test_select_by_identity(self):
+        # added 2026-08-13 -- needed when path/uuid are identical across
+        # results (CSVPATHS' statement-level range), identity is the
+        # only thing that can distinguish them for resolve_from().
+        results = [
+            ReferenceResult3(path="p1", uuid="u1", identity="a"),
+            ReferenceResult3(path="p1", uuid="u1", identity="b"),
+        ]
+        r = ReferenceResults3(results=results)
+        selected = r.select(["a"])
+        assert len(selected) == 1
+        assert selected.results[0].identity == "a"
 
     def test_len_and_iter(self):
         r = self._results()

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -855,6 +855,42 @@ class TestFieldAccessorFunctions:
         ).resolve()
         assert results.results[0].data == "run1-uuid"
 
+    def test_home_at_run_scope_reads_run_home(self, tmp_path):
+        # doc line ~171: "$widgets.results.:first():home() >> run_home"
+        # -- no committed test locked this in before (found during the
+        # 2026-08-12 normative-doc sweep); confirmed against
+        # results_registrar.py that "run_home" is a real, written field,
+        # not just documented.
+        base = tmp_path / "widgets"
+        run_dir = base / "2026-01-01_00-00-00"
+        _write_json(
+            run_dir / "manifest.json",
+            {"run_uuid": "run1-uuid", "run_home": str(run_dir)},
+        )
+        _write_archive_manifest(tmp_path, "widgets", [str(run_dir)])
+        results = _finder(
+            "$widgets.results.:first():home()", str(tmp_path)
+        ).resolve()
+        assert results.results[0].data == str(run_dir)
+
+    def test_home_at_instance_scope_reads_instance_home(self, tmp_path):
+        # doc line ~192: "$widgets.results.:first().company_names:home()
+        # >> instance_home" -- same gap as above, confirmed against
+        # result_registrar.py that "instance_home" is a real field.
+        base = tmp_path / "widgets"
+        run_dir = base / "2026-01-01_00-00-00"
+        instance_dir = run_dir / "company_names"
+        _write_json(run_dir / "manifest.json", {"run_uuid": "run1-uuid"})
+        _write_json(
+            instance_dir / "manifest.json",
+            {"uuid": "inst1-uuid", "instance_home": str(instance_dir)},
+        )
+        _write_archive_manifest(tmp_path, "widgets", [str(run_dir)])
+        results = _finder(
+            "$widgets.results.:first().company_names:home()", str(tmp_path)
+        ).resolve()
+        assert results.results[0].data == str(instance_dir)
+
     def test_uuid_at_instance_scope(self, acme_archive):
         results = _finder(
             "$acme.results.customers/2025:first().company_names:uuid()",

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -646,6 +646,128 @@ class TestRunLevelRange:
             ).query()
 
 
+class TestStatementLevelRange:
+    # ':from()'/':to()' as a name_three statement-level range -- added
+    # 2026-08-13. David: ":from(:index(2)):unmatched() should definitely
+    # not work" -- a range is "more than one entity" the same way
+    # ':all()' already is, so it gets the same restriction combined with
+    # a content accessor -- but count-DEPENDENT (checked per run), not
+    # ':all()'s own blanket rejection, mirroring the run-level "more
+    # than one candidate" check this file already uses elsewhere.
+    #
+    # Fixture deliberately writes instances in a NON-declaration-order
+    # sequence (both dict order and directory-write order scrambled) --
+    # this exercises the 2026-08-13 ordering fix to
+    # _list_instance_identities (it used to trust raw filesystem
+    # listdir() order, which is NOT declaration order; now sorts by
+    # each instance's own "instance_index", confirmed via
+    # csvpaths.py -> Result -> ResultRegistrar -> ResultMetadata to be
+    # the real, written declaration-order field). Without that fix this
+    # whole class would be testing filesystem-dependent noise instead
+    # of real statement position.
+    @pytest.fixture
+    def one_run_five_statements(self, tmp_path):
+        base = tmp_path / "acme" / "customers" / "2025"
+        run_dir = base / "2026-01-01_00-00-00"
+        _write_json(run_dir / "manifest.json", {"run_uuid": "run1-uuid"})
+        # identity -> (uuid, instance_index); written out of order on
+        # purpose.
+        scrambled = {
+            "four": ("f-uuid", 4),
+            "zero": ("z-uuid", 0),
+            "two": ("t-uuid", 2),
+            "one": ("o-uuid", 1),
+            "three": ("th-uuid", 3),
+        }
+        for identity, (uuid, idx) in scrambled.items():
+            _write_json(
+                run_dir / identity / "manifest.json",
+                {"uuid": uuid, "instance_index": idx},
+            )
+        _write_archive_manifest(tmp_path, "acme", [str(run_dir)])
+        return str(tmp_path)
+
+    def test_from_gives_statements_in_true_declaration_order(
+        self, one_run_five_statements
+    ):
+        results = _finder(
+            "$acme.results.customers/2025:first().:from(2)",
+            one_run_five_statements,
+        ).query()
+        assert results.uuids == ["t-uuid", "th-uuid", "f-uuid"]
+
+    def test_from_and_to_together_is_an_inclusive_range(
+        self, one_run_five_statements
+    ):
+        results = _finder(
+            "$acme.results.customers/2025:first().:from(1):to(3)",
+            one_run_five_statements,
+        ).query()
+        assert results.uuids == ["o-uuid", "t-uuid", "th-uuid"]
+
+    def test_open_ended_range_combined_with_content_accessor_raises(
+        self, one_run_five_statements
+    ):
+        # the exact case David flagged: ":from(2):unmatched()" matches
+        # 3 statements here, "more than one entity" -- must raise, the
+        # doc's own original example describing this as working was
+        # wrong.
+        finder = _finder(
+            "$acme.results.customers/2025:first().:from(2):unmatched()",
+            one_run_five_statements,
+        )
+        with pytest.raises(ReferenceException3):
+            finder.resolve()
+
+    def test_range_narrowed_to_exactly_one_with_accessor_is_fine(
+        self, one_run_five_statements
+    ):
+        # a degenerate single-item range is fine with a content
+        # accessor, same as a pointer narrowing a run-list to one
+        # already is -- count-dependent, not a blanket rejection.
+        results = _finder(
+            "$acme.results.customers/2025:first().:from(2):to(2):unmatched()",
+            one_run_five_statements,
+        ).resolve()
+        assert results.results[0].data is None  # never written, not an error
+
+    def test_range_combined_with_a_field_accessor_is_poolable(
+        self, one_run_five_statements
+    ):
+        # field accessors are exempt from the single-entity rule, same
+        # exemption ':all()' + a field accessor already gets.
+        results = _finder(
+            "$acme.results.customers/2025:first().:from(2):uuid()",
+            one_run_five_statements,
+        ).resolve()
+        assert [r.data for r in results.results] == ["t-uuid", "th-uuid", "f-uuid"]
+
+    def test_range_alone_with_no_accessor_lists_unreduced(
+        self, one_run_five_statements
+    ):
+        results = _finder(
+            "$acme.results.customers/2025:first().:from(2)",
+            one_run_five_statements,
+        ).query()
+        assert len(results.results) == 3
+
+    def test_range_cannot_combine_with_a_literal_identity(
+        self, one_run_five_statements
+    ):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$acme.results.customers/2025:first().two:from(2)",
+                one_run_five_statements,
+            ).query()
+
+    def test_range_cannot_combine_with_all(self, one_run_five_statements):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$acme.results.customers/2025:first().:all():from(2)",
+                one_run_five_statements,
+            ).query()
+
+
 class TestHomeAsAZeroLevelSelector:
     # settled 2026-08-11: bare ':home()' (David's own framing --
     # "everything that has its home here") fills the one real gap left

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -627,9 +627,22 @@ class TestRunLevelRange:
         ).query()
         assert results.uuids == ["run-5"]
 
-    def test_from_rejects_a_non_int_non_index_argument(self, five_runs):
+    def test_from_rejects_a_malformed_date_string_argument(self, five_runs):
+        # settled 2026-08-13: a bare str arg is now date-mode's leaf
+        # shape (":from('2025-01-01')" == ":from(:date('2025-01-01'))"),
+        # not simply rejected -- but its CONTENT must be a real calendar
+        # date, see TestRunLevelDateRange for the date-mode cases
+        # themselves.
         with pytest.raises(ReferenceException3):
             _finder('$acme.results.customers:from("x")', five_runs).query()
+
+    def test_from_rejects_an_unrelated_nested_function_argument(
+        self, five_runs
+    ):
+        # ':uuid()' is a real, registered function, so this parses fine
+        # -- but it is neither Index3 nor Date3, so ARG_TYPES rejects it.
+        with pytest.raises(ReferenceException3):
+            _finder("$acme.results.customers:from(:uuid())", five_runs).query()
 
     def test_from_combined_with_all_grouping_is_not_yet_supported(
         self, five_runs
@@ -643,6 +656,86 @@ class TestRunLevelRange:
         with pytest.raises(ReferenceException3):
             _finder(
                 "$acme.results.customers:from(-3):manifest()", five_runs
+            ).query()
+
+
+class TestRunLevelDateRange:
+    # ':from()'/':to()' date-mode -- added 2026-08-13, David: "arrival
+    # and run order is even more important than indexing." A FILTER by
+    # each run's own arrival date (parsed from its directory name's own
+    # timestamp prefix), not a positional slice -- ':to()' is INCLUSIVE
+    # of its own date, same convention as index-mode. A bare date string
+    # (no ':date(...)' wrapper) must give identical results to the
+    # wrapped form, same "wrapper optional but must be possible" pattern
+    # already established for index-mode.
+    @pytest.fixture
+    def dated_runs(self, tmp_path):
+        base = tmp_path / "acme" / "customers"
+        runs = {
+            "run-before": _make_run(
+                base, "2024-12-31_00-00-00", "run-before", {}
+            ),
+            "run-jan1": _make_run(base, "2025-01-01_00-00-00", "run-jan1", {}),
+            "run-jan15": _make_run(
+                base, "2025-01-15_00-00-00", "run-jan15", {}
+            ),
+            "run-feb1": _make_run(base, "2025-02-01_00-00-00", "run-feb1", {}),
+        }
+        _write_archive_manifest(tmp_path, "acme", list(runs.values()))
+        return str(tmp_path)
+
+    def test_from_date_is_inclusive_and_open_ended(self, dated_runs):
+        results = _finder(
+            '$acme.results.customers:from(:date("2025-01-01"))', dated_runs
+        ).query()
+        assert set(results.uuids) == {"run-jan1", "run-jan15", "run-feb1"}
+
+    def test_to_date_is_inclusive_and_open_started(self, dated_runs):
+        results = _finder(
+            '$acme.results.customers:to(:date("2025-01-15"))', dated_runs
+        ).query()
+        assert set(results.uuids) == {"run-before", "run-jan1", "run-jan15"}
+
+    def test_from_and_to_date_together_is_an_inclusive_range(self, dated_runs):
+        results = _finder(
+            '$acme.results.customers:from(:date("2025-01-01")):to(:date("2025-01-15"))',
+            dated_runs,
+        ).query()
+        assert set(results.uuids) == {"run-jan1", "run-jan15"}
+
+    def test_bare_date_string_is_identical_to_wrapped(self, dated_runs):
+        wrapped = _finder(
+            '$acme.results.customers:from(:date("2025-01-01"))', dated_runs
+        ).query()
+        bare = _finder(
+            '$acme.results.customers:from("2025-01-01")', dated_runs
+        ).query()
+        assert set(wrapped.uuids) == set(bare.uuids) == {
+            "run-jan1",
+            "run-jan15",
+            "run-feb1",
+        }
+
+    def test_a_pointer_reduces_the_dated_range_not_the_full_set(
+        self, dated_runs
+    ):
+        results = _finder(
+            '$acme.results.customers:from(:date("2025-01-01")):last()',
+            dated_runs,
+        ).query()
+        assert results.uuids == ["run-feb1"]
+
+    def test_malformed_date_raises_clearly(self, dated_runs):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$acme.results.customers:from("not-a-date")', dated_runs
+            ).query()
+
+    def test_mixing_index_and_date_modes_is_rejected(self, dated_runs):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$acme.results.customers:from(1):to(:date("2025-01-01"))',
+                dated_runs,
             ).query()
 
 

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -568,6 +568,84 @@ class TestGroups:
             ).query()
 
 
+class TestRunLevelRange:
+    # ':from()'/':to()' as a run-level index range -- added 2026-08-13,
+    # David: "our version of BETWEEN in SQL or range() in Python," built
+    # together since both slice the same already-ordered candidate list
+    # (no implementation reason to split them). ':to()' is INCLUSIVE of
+    # its own position. Index-mode only for this pass -- date-mode
+    # (":from(:date(...))"/":from(:yesterday())") is deliberately
+    # deferred, needs :date()/:yesterday() first.
+    @pytest.fixture
+    def five_runs(self, tmp_path):
+        base = tmp_path / "acme" / "customers"
+        runs = [
+            _make_run(base, f"2026-01-0{i}_00-00-00", f"run-{i}", {})
+            for i in range(1, 6)
+        ]
+        _write_archive_manifest(tmp_path, "acme", runs)
+        return str(tmp_path)
+
+    def test_from_index_negative_gives_the_last_n(self, five_runs):
+        results = _finder(
+            "$acme.results.customers:from(:index(-3))", five_runs
+        ).query()
+        assert results.uuids == ["run-3", "run-4", "run-5"]
+
+    def test_from_bare_int_is_identical_to_from_index(self, five_runs):
+        # doc's own NOTES block: ":from(:index(-3))" is identical to
+        # ":from(-3))" -- both legal, both must give the same answer.
+        via_index = _finder(
+            "$acme.results.customers:from(:index(-3))", five_runs
+        ).query()
+        via_int = _finder("$acme.results.customers:from(-3)", five_runs).query()
+        assert via_index.uuids == via_int.uuids == ["run-3", "run-4", "run-5"]
+
+    def test_from_and_to_together_is_an_inclusive_range(self, five_runs):
+        results = _finder(
+            "$acme.results.customers:from(1):to(3)", five_runs
+        ).query()
+        assert results.uuids == ["run-2", "run-3", "run-4"]
+
+    def test_to_alone_is_open_at_the_start(self, five_runs):
+        results = _finder("$acme.results.customers:to(1)", five_runs).query()
+        assert results.uuids == ["run-1", "run-2"]
+
+    def test_to_with_negative_one_reaches_the_true_end(self, five_runs):
+        # the one edge case _apply_range's own docstring calls out: a
+        # naive "end + 1" would wrap -1 to 0 and give an empty slice.
+        results = _finder(
+            "$acme.results.customers:from(1):to(-1)", five_runs
+        ).query()
+        assert results.uuids == ["run-2", "run-3", "run-4", "run-5"]
+
+    def test_a_pointer_reduces_the_slice_not_the_full_candidate_set(
+        self, five_runs
+    ):
+        results = _finder(
+            "$acme.results.customers:from(-3):last()", five_runs
+        ).query()
+        assert results.uuids == ["run-5"]
+
+    def test_from_rejects_a_non_int_non_index_argument(self, five_runs):
+        with pytest.raises(ReferenceException3):
+            _finder('$acme.results.customers:from("x")', five_runs).query()
+
+    def test_from_combined_with_all_grouping_is_not_yet_supported(
+        self, five_runs
+    ):
+        with pytest.raises(ReferenceException3):
+            _finder("$acme.results.:all():from(1):last()", five_runs).query()
+
+    def test_from_with_manifest_and_more_than_one_run_requires_a_pointer(
+        self, five_runs
+    ):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$acme.results.customers:from(-3):manifest()", five_runs
+            ).query()
+
+
 class TestHomeAsAZeroLevelSelector:
     # settled 2026-08-11: bare ':home()' (David's own framing --
     # "everything that has its home here") fills the one real gap left


### PR DESCRIPTION
## Summary
First two items off the punch list from the pre-#243-merge doc sweep (still in progress, more commits to follow -- :fingerprint()/:having() and statement-level :from()/:to() are still pending):

- Added missing test coverage locking in RESULTS' :home() as a field accessor (run scope "run_home", instance scope "instance_home") -- confirmed the underlying fields are genuinely written in production before writing the tests, this was a coverage gap only, no code change.
- Added :from()/:to() as an index-mode run-level range selector for RESULTS (":from(:index(-3))"/":from(-3)" for "the last three runs," ":from(1):to(3)" for an inclusive range). Built together deliberately, not staggered -- same underlying slicing mechanism for both bounds. Date-mode and the statement-level (name_three) position are deliberately not included yet -- see the doc's own new note on why the statement-level case needs a design decision first (does a range of statements get the same single-entity restriction :all() already has for content accessors, or not -- the doc's own example implies the opposite answer).

## Test plan
- [x] New Function3 metadata tests for From3/To3
- [x] `TestRunLevelRange` in `test_results_reference_finder_3.py` -- 9 new tests
- [x] `tests/references/` full suite -- 897 passed
- [x] Full suite -- 2485 passed, 11 failed (known SFTP/S3/Nos baseline, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
