### PR TITLE
Add references-v3 function coverage matrix generator

### DIFF
--- a/tests/references/tools/generate_function_matrix.py
+++ b/tests/references/tools/generate_function_matrix.py
@@ -1,0 +1,200 @@
+"""Generates a coverage matrix of every registered references-v3 function:
+role, which datatypes it declares support for, arg shape, field source, and
+whether it has real test coverage -- both at the function-unit level and
+integration-tested (actually exercised via a real reference string against a
+real Finder) per datatype.
+
+David asked for "a better lay of the land" on the references-v3 surface --
+this is the mechanical half of that: it turns "what's covered" from tribal
+knowledge spread across three Finder files plus one doc into a single,
+regeneratable, auditable table. Deliberately NOT a fuzzer (that idea is
+deferred, separately) -- this only reports on the finite, enumerable set of
+functions that already exist; it does not explore what a random/generated
+reference string would do at runtime.
+
+Run:
+    CSVPATH_CONFIG_PATH=assets/config/config.ini poetry run python3 \
+        tests/references/tools/generate_function_matrix.py
+
+Writes the report to references_notes/notes/function_coverage_matrix.md.
+
+Mechanically derived every run (always accurate, no manual upkeep): role,
+datatypes, arg shape, source, unit-test-file-exists, integration-test-grep-
+hit-per-datatype.
+
+Manually curated (accurate as of 2026-08-13; re-check if a Finder's query()
+logic changes): the position/notes column. WHERE in a reference string
+(name_one/name_two/name_three) a function is legal is enforced by
+procedural code scattered across three different Finder classes, not
+declared anywhere as data -- reliably auto-deriving it would need a much
+heavier static-analysis pass than this script attempts, so it is
+hand-written here instead, from direct reading of all three Finders during
+the same work that produced this script.
+"""
+
+import re
+from pathlib import Path
+
+from csvpath.references.functions.reference_function_factory_3 import (
+    ReferenceFunctionFactory as RFF,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+INTEGRATION_TEST_FILES = {
+    "files": [
+        REPO_ROOT / "tests/references/test_files_reference_finder_3.py",
+        REPO_ROOT / "tests/references/test_normative_examples_files.py",
+    ],
+    "csvpaths": [
+        REPO_ROOT / "tests/references/test_csvpaths_reference_finder_3.py",
+        REPO_ROOT / "tests/references/test_normative_examples_csvpaths.py",
+    ],
+    "results": [
+        REPO_ROOT / "tests/references/test_results_reference_finder_3.py",
+        REPO_ROOT / "tests/references/test_normative_examples_results.py",
+    ],
+}
+
+#
+# manually curated -- see module docstring's "Manually curated" section.
+# Every function NOT listed here is a plain field accessor (SOURCE=
+# "manifest"/"definition"/"computed") and gets DEFAULT_FIELD_ACCESSOR_NOTE
+# instead -- they all share one rule (ride beside the matched entity's own
+# pointer chain), so listing each individually would be pure repetition.
+#
+POSITION_NOTES = {
+    "first": "CSVPATHS/RESULTS: name_one (version/run selector). FILES: name_three (version selector).",
+    "last": "same position(s) as :first().",
+    "index": "same position(s) as :first().",
+    "name": "FILES name_one only -- the literal-path-building selector (:name(\"x\")). Not meaningful for CSVPATHS/RESULTS (no path dimension in name_one there); RESULTS uses literal/'*' path segments instead of :name().",
+    "all": "FILES/CSVPATHS: rides beside the pointer in whichever chain occupies the version-selector position (name_three for FILES, name_one for CSVPATHS). RESULTS: name_one (run-level), one-level GROUP peer of '*'.",
+    "flatten": "FILES: name_one, first-segment-only, any-depth POOL peer of ':all()'/'*'. RESULTS: name_one, any-depth POOL peer of ':all()'/'*'. Not built for CSVPATHS -- no depth dimension to flatten (groups do not nest).",
+    "groups": "FILES: name_one, any-depth GROUP peer of ':flatten()'. RESULTS: name_one, any-depth GROUP peer of ':flatten()'. Not built for CSVPATHS.",
+    "having": "CSVPATHS name_one only -- filters the version list by statement-identity presence before any pointer/range reduces further.",
+    "from": "RESULTS: name_one (run-level range) AND name_three (statement-level range, index-mode only). FILES: name_three (version-level range, index+date mode). CSVPATHS: name_one (version-level range, index+date mode) AND name_three (statement-level range, index-mode only, since individual statements have no arrival time of their own).",
+    "to": "always paired with :from() -- same position(s).",
+    "date": "VALUE-role argument wrapper, RESULTS-only in DATATYPES but reused by FILES/CSVPATHS' own date-mode ranges too (accepted via From3/To3's own ARG_TYPES, not a separate per-datatype registration) -- used INSIDE :from()/:to(), never appears bare as a position of its own.",
+    "manifest": "bare or beside a pointer, in the version/run-selector chain for all three datatypes (name_one for CSVPATHS/RESULTS, name_three for FILES) -- also the special root_major='*' global-ledger case for FILES/CSVPATHS.",
+    "definition": "CSVPATHS/FILES only, bare, group/named-file-level (not per-version) -- no position dimension, always the whole resource.",
+    "path": "FILES/CSVPATHS -- wraps another whole-resource function (e.g. :path(:manifest())), rides in the same chain that function would occupy on its own.",
+    "errors": "RESULTS instance-level content accessor -- rides after name_three's statement-identity selection.",
+    "vars": "same position as :errors().",
+    "meta": "same position as :errors().",
+    "data": "same position as :errors().",
+    "unmatched": "same position as :errors().",
+    "file": "same position as :errors() -- takes a literal filename arg (print-mode output file).",
+    "idchain": "RESULTS only -- VALUE-role arg wrapper, used inside :errors(...), never a position of its own.",
+}
+DEFAULT_FIELD_ACCESSOR_NOTE = (
+    "field accessor -- rides beside the matched entity's own pointer, "
+    "same chain/position as :first()/:last()/:index(n) for that datatype."
+)
+
+
+def _unit_test_path(function_cls) -> Path:
+    # e.g. csvpath.references.functions.fields.uuid_3
+    #   -> tests/references/functions/fields/test_uuid_3.py
+    mod_parts = function_cls.__module__.split(".")
+    subpkg, modname = mod_parts[-2], mod_parts[-1]
+    return REPO_ROOT / "tests" / "references" / "functions" / subpkg / f"test_{modname}.py"
+
+
+def _integration_hits(name: str, datatype: str) -> bool:
+    # require both a '$' (a real reference string's own marker) and
+    # ':name(' on the SAME line -- a bare ':from()'/':to()' mention in a
+    # comment/docstring (extremely common in this codebase) would
+    # otherwise false-positive as "tested" with a plain ':name\(' search.
+    # Deliberately NOT excluding quote characters between the two: a
+    # nested string arg (e.g. ':name("orders.csv").:from(1):to(3)') puts
+    # quotes between '$' and a LATER function call on the same line, so
+    # excluding them would wrongly break the match at the first nested arg.
+    pattern = re.compile(r"\$.*:" + re.escape(name) + r"\(")
+    for path in INTEGRATION_TEST_FILES[datatype]:
+        if not path.exists():
+            continue
+        for line in path.read_text().splitlines():
+            if pattern.search(line):
+                return True
+    return False
+
+
+def main() -> None:
+    RFF.get_registered_class("first")  # triggers _load() -- see factory's own laziness
+    rows = []
+    for name, cls in sorted(RFF._FUNCTIONS.items()):
+        datatypes = cls.DATATYPES or ()
+        unit_tested = _unit_test_path(cls).exists()
+        integration = {
+            dt: (_integration_hits(name, dt) if dt in datatypes else None)
+            for dt in ("files", "csvpaths", "results")
+        }
+        rows.append(
+            {
+                "name": name,
+                "role": cls.ROLE,
+                "datatypes": datatypes,
+                "arg_required": cls.ARG_REQUIRED,
+                "source": cls.SOURCE,
+                "unit_tested": unit_tested,
+                "integration": integration,
+                "note": POSITION_NOTES.get(name, DEFAULT_FIELD_ACCESSOR_NOTE),
+            }
+        )
+
+    def cell(v) -> str:
+        if v is None:
+            return "n/a"
+        return "yes" if v else "**MISSING**"
+
+    out = []
+    out.append("# CSVPath References v3 -- function coverage matrix\n\n")
+    out.append(
+        "Generated by `tests/references/tools/generate_function_matrix.py` -- "
+        "re-run any time the function registry or test files change; do not "
+        "hand-edit the table below (edit the script's own `POSITION_NOTES` "
+        "dict instead, for the one manually-curated column).\n\n"
+    )
+    out.append(
+        "| Function | Role | Datatypes | Arg required | Source | Unit test | "
+        "FILES | CSVPATHS | RESULTS | Position / notes |\n"
+    )
+    out.append("|---|---|---|---|---|---|---|---|---|---|\n")
+    for r in rows:
+        out.append(
+            f"| `:{r['name']}()` | {r['role']} | {', '.join(r['datatypes']) or '-'} | "
+            f"{'yes' if r['arg_required'] else 'no'} | {r['source'] or '-'} | "
+            f"{cell(r['unit_tested'])} | {cell(r['integration']['files'])} | "
+            f"{cell(r['integration']['csvpaths'])} | {cell(r['integration']['results'])} | "
+            f"{r['note']} |\n"
+        )
+
+    missing = [
+        r
+        for r in rows
+        if not r["unit_tested"] or any(v is False for v in r["integration"].values())
+    ]
+    out.append("\n## Gaps found\n\n")
+    if not missing:
+        out.append(
+            "None -- every registered function has a unit test and at least "
+            "one integration-test hit for every datatype it declares support "
+            "for.\n"
+        )
+    else:
+        for r in missing:
+            problems = []
+            if not r["unit_tested"]:
+                problems.append("no unit test file")
+            for dt, v in r["integration"].items():
+                if v is False:
+                    problems.append(f"no {dt} integration-test hit")
+            out.append(f"- `:{r['name']}()` -- {'; '.join(problems)}\n")
+
+    report_path = REPO_ROOT / "references_notes" / "notes" / "function_coverage_matrix.md"
+    report_path.write_text("".join(out))
+    print(f"wrote {report_path} ({len(rows)} functions, {len(missing)} with gaps)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/references/tools/generate_function_matrix.py
+++ b/tests/references/tools/generate_function_matrix.py
@@ -1,16 +1,17 @@
 """Generates a coverage matrix of every registered references-v3 function:
-role, which datatypes it declares support for, arg shape, field source, and
-whether it has real test coverage -- both at the function-unit level and
-integration-tested (actually exercised via a real reference string against a
-real Finder) per datatype.
+role, which datatypes it declares support for, arg shape, field source,
+which name_one/name_two/name_three position it is legal in per datatype,
+and whether it has real test coverage -- both at the function-unit level
+and integration-tested (actually exercised via a real reference string
+against a real Finder) per datatype.
 
 David asked for "a better lay of the land" on the references-v3 surface --
-this is the mechanical half of that: it turns "what's covered" from tribal
-knowledge spread across three Finder files plus one doc into a single,
-regeneratable, auditable table. Deliberately NOT a fuzzer (that idea is
-deferred, separately) -- this only reports on the finite, enumerable set of
-functions that already exist; it does not explore what a random/generated
-reference string would do at runtime.
+this is the mechanical half of that: it turns "what's covered, and where"
+from tribal knowledge spread across three Finder files plus one doc into a
+single, regeneratable, auditable table. Deliberately NOT a fuzzer (that
+idea is deferred, separately) -- this only reports on the finite,
+enumerable set of functions that already exist; it does not explore what a
+random/generated reference string would do at runtime.
 
 Run:
     CSVPATH_CONFIG_PATH=assets/config/config.ini poetry run python3 \
@@ -20,16 +21,22 @@ Writes the report to references_notes/notes/function_coverage_matrix.md.
 
 Mechanically derived every run (always accurate, no manual upkeep): role,
 datatypes, arg shape, source, unit-test-file-exists, integration-test-grep-
-hit-per-datatype.
+hit-per-datatype, and the POSITION of every plain field-accessor function
+(SOURCE set) -- FILES field accessors ride at name_three, CSVPATHS field
+accessors ride at name_one (both mirror that datatype's own version-
+selector position), and RESULTS field accessors are derived from whether
+their own KEY dict has a Reference3.RESULTS entry (name_one/run-level), a
+Reference3.RESULT entry (name_three/instance-level), or both.
 
-Manually curated (accurate as of 2026-08-13; re-check if a Finder's query()
-logic changes): the position/notes column. WHERE in a reference string
-(name_one/name_two/name_three) a function is legal is enforced by
-procedural code scattered across three different Finder classes, not
-declared anywhere as data -- reliably auto-deriving it would need a much
-heavier static-analysis pass than this script attempts, so it is
-hand-written here instead, from direct reading of all three Finders during
-the same work that produced this script.
+Manually curated (accurate as of 2026-08-13; re-check if a Finder's
+query() logic changes): position for the ~20 non-field-accessor functions
+(pointers, context setters, well-known-file/wrapper functions, argument-
+only VALUE wrappers) in SPECIAL_POSITIONS/SPECIAL_NOTES below. WHERE these
+are legal is enforced by procedural code scattered across three different
+Finder classes, not declared anywhere as data -- reliably auto-deriving it
+would need a much heavier static-analysis pass than this script attempts,
+so it is hand-written here instead, from direct reading of all three
+Finders during the same work that produced this script.
 """
 
 import re
@@ -38,6 +45,7 @@ from pathlib import Path
 from csvpath.references.functions.reference_function_factory_3 import (
     ReferenceFunctionFactory as RFF,
 )
+from csvpath.references.reference_3 import Reference3
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -57,38 +65,87 @@ INTEGRATION_TEST_FILES = {
 }
 
 #
-# manually curated -- see module docstring's "Manually curated" section.
-# Every function NOT listed here is a plain field accessor (SOURCE=
-# "manifest"/"definition"/"computed") and gets DEFAULT_FIELD_ACCESSOR_NOTE
-# instead -- they all share one rule (ride beside the matched entity's own
-# pointer chain), so listing each individually would be pure repetition.
+# manually curated positions for the ~20 functions that are NOT plain
+# field accessors -- see module docstring's "Manually curated" section.
+# One entry per datatype: a position string, None (not supported/not
+# meaningful), or a flagged string for a known declared-but-broken case
+# (see ":name()" below).
 #
-POSITION_NOTES = {
-    "first": "CSVPATHS/RESULTS: name_one (version/run selector). FILES: name_three (version selector).",
-    "last": "same position(s) as :first().",
-    "index": "same position(s) as :first().",
-    "name": "FILES name_one only -- the literal-path-building selector (:name(\"x\")). Not meaningful for CSVPATHS/RESULTS (no path dimension in name_one there); RESULTS uses literal/'*' path segments instead of :name().",
-    "all": "FILES/CSVPATHS: rides beside the pointer in whichever chain occupies the version-selector position (name_three for FILES, name_one for CSVPATHS). RESULTS: name_one (run-level), one-level GROUP peer of '*'.",
-    "flatten": "FILES: name_one, first-segment-only, any-depth POOL peer of ':all()'/'*'. RESULTS: name_one, any-depth POOL peer of ':all()'/'*'. Not built for CSVPATHS -- no depth dimension to flatten (groups do not nest).",
-    "groups": "FILES: name_one, any-depth GROUP peer of ':flatten()'. RESULTS: name_one, any-depth GROUP peer of ':flatten()'. Not built for CSVPATHS.",
-    "having": "CSVPATHS name_one only -- filters the version list by statement-identity presence before any pointer/range reduces further.",
-    "from": "RESULTS: name_one (run-level range) AND name_three (statement-level range, index-mode only). FILES: name_three (version-level range, index+date mode). CSVPATHS: name_one (version-level range, index+date mode) AND name_three (statement-level range, index-mode only, since individual statements have no arrival time of their own).",
-    "to": "always paired with :from() -- same position(s).",
-    "date": "VALUE-role argument wrapper, RESULTS-only in DATATYPES but reused by FILES/CSVPATHS' own date-mode ranges too (accepted via From3/To3's own ARG_TYPES, not a separate per-datatype registration) -- used INSIDE :from()/:to(), never appears bare as a position of its own.",
-    "manifest": "bare or beside a pointer, in the version/run-selector chain for all three datatypes (name_one for CSVPATHS/RESULTS, name_three for FILES) -- also the special root_major='*' global-ledger case for FILES/CSVPATHS.",
-    "definition": "CSVPATHS/FILES only, bare, group/named-file-level (not per-version) -- no position dimension, always the whole resource.",
-    "path": "FILES/CSVPATHS -- wraps another whole-resource function (e.g. :path(:manifest())), rides in the same chain that function would occupy on its own.",
-    "errors": "RESULTS instance-level content accessor -- rides after name_three's statement-identity selection.",
-    "vars": "same position as :errors().",
-    "meta": "same position as :errors().",
-    "data": "same position as :errors().",
-    "unmatched": "same position as :errors().",
-    "file": "same position as :errors() -- takes a literal filename arg (print-mode output file).",
-    "idchain": "RESULTS only -- VALUE-role arg wrapper, used inside :errors(...), never a position of its own.",
+SPECIAL_POSITIONS = {
+    "first": {"files": "name_three", "csvpaths": "name_one", "results": "name_one"},
+    "last": {"files": "name_three", "csvpaths": "name_one", "results": "name_one"},
+    "index": {"files": "name_three", "csvpaths": "name_one", "results": "name_one"},
+    "name": {
+        "files": "name_one",
+        "csvpaths": "**declared but broken -- silently no-ops, see Notes**",
+        "results": None,
+    },
+    "all": {"files": "name_three", "csvpaths": "name_one", "results": "name_one"},
+    "flatten": {"files": "name_one", "csvpaths": None, "results": "name_one"},
+    "groups": {"files": "name_one", "csvpaths": None, "results": "name_one"},
+    "having": {"files": None, "csvpaths": "name_one", "results": None},
+    "from": {
+        "files": "name_three",
+        "csvpaths": "name_one, name_three",
+        "results": "name_one, name_three",
+    },
+    "to": {
+        "files": "name_three",
+        "csvpaths": "name_one, name_three",
+        "results": "name_one, name_three",
+    },
+    "date": {
+        "files": "argument (inside :from()/:to())",
+        "csvpaths": "argument (inside :from()/:to())",
+        "results": "argument (inside :from()/:to())",
+    },
+    "manifest": {"files": "name_three", "csvpaths": "name_one", "results": "name_one"},
+    "definition": {"files": "name_one (bare)", "csvpaths": "name_one (bare)", "results": None},
+    "path": {"files": "name_three", "csvpaths": "name_one", "results": None},
+    "errors": {"files": None, "csvpaths": None, "results": "name_three (instance-level)"},
+    "vars": {"files": None, "csvpaths": None, "results": "name_three (instance-level)"},
+    "meta": {"files": None, "csvpaths": None, "results": "name_three (instance-level)"},
+    "data": {"files": None, "csvpaths": None, "results": "name_three (instance-level)"},
+    "unmatched": {"files": None, "csvpaths": None, "results": "name_three (instance-level)"},
+    "file": {"files": None, "csvpaths": None, "results": "name_three (instance-level)"},
+    "idchain": {"files": None, "csvpaths": None, "results": "argument (inside :errors())"},
 }
-DEFAULT_FIELD_ACCESSOR_NOTE = (
-    "field accessor -- rides beside the matched entity's own pointer, "
-    "same chain/position as :first()/:last()/:index(n) for that datatype."
+
+SPECIAL_NOTES = {
+    "name": (
+        "DATATYPES includes csvpaths, but CsvpathsReferenceFinder3."
+        "_resolve_versions() has no unrecognized-function guard the way "
+        "query()'s name_three handling does -- $acme.csvpaths.:name(\"x\") "
+        "silently no-ops instead of raising, contradicting the class's own "
+        "docstring. Flagged 2026-08-13, not fixed."
+    ),
+    "all": (
+        "FILES/CSVPATHS: switches the version-selector chain from POINTER-"
+        "reduces-to-one to unreduced-list-of-every-match. RESULTS: one-level "
+        "GROUP peer of '*'."
+    ),
+    "flatten": "any-depth POOL peer of ':all()'/'*'. Not built for CSVPATHS -- no depth dimension (groups do not nest).",
+    "groups": "any-depth GROUP peer of ':flatten()'. Not built for CSVPATHS.",
+    "having": "filters the version list by statement-identity presence before any pointer/range reduces further.",
+    "from": "':to()' is INCLUSIVE. Index-mode (int/:index(n)) POSITIONALLY slices; date-mode (str/:date(...)) FILTERS by arrival time. A real pointer riding alongside reduces the RANGE, not the full candidate set.",
+    "to": "always paired with :from() -- see its own note.",
+    "date": "VALUE-role wrapper; DATATYPES declares results only, but is reused inside FILES/CSVPATHS' own :from()/:to() via their ARG_TYPES, not a separate per-datatype registration.",
+    "manifest": "may ride bare or beside a pointer -- never narrows/selects itself. Also the special root_major='*' global-ledger case for FILES/CSVPATHS.",
+    "definition": "group/named-file-level, not per-version -- always the whole resource.",
+    "path": "wraps another whole-resource function (e.g. :path(:manifest())) -- returns its filesystem path instead of its content.",
+    "idchain": "arg to :errors(...) -- filters by a matching-line's idchain value.",
+    "first": "version/run/instance selector.",
+    "last": "version/run/instance selector.",
+    "index": "version/run/instance selector.",
+    "errors": "instance-level content accessor -- :idchain() may be passed as its arg to filter further.",
+    "vars": "instance-level content accessor, same position as :errors().",
+    "meta": "instance-level content accessor, same position as :errors().",
+    "data": "instance-level content accessor, same position as :errors().",
+    "unmatched": "instance-level content accessor, same position as :errors().",
+    "file": "instance-level content accessor (print-mode output file) -- takes a literal filename arg.",
+}
+DEFAULT_NOTE = (
+    "field accessor -- rides beside the matched entity's own pointer."
 )
 
 
@@ -119,16 +176,43 @@ def _integration_hits(name: str, datatype: str) -> bool:
     return False
 
 
+def _default_position(cls, datatype: str) -> str | None:
+    """mechanical position for a plain field accessor (SOURCE set, not in
+    SPECIAL_POSITIONS) -- FILES/CSVPATHS mirror that datatype's own
+    version-selector position; RESULTS is derived from whether the
+    function's own KEY dict serves the run level (Reference3.RESULTS),
+    the instance level (Reference3.RESULT), or both."""
+    if datatype not in (cls.DATATYPES or ()):
+        return None
+    if datatype == "files":
+        return "name_three"
+    if datatype == "csvpaths":
+        return "name_one"
+    # results
+    has_run = Reference3.RESULTS in cls.KEY
+    has_instance = Reference3.RESULT in cls.KEY
+    if has_run and has_instance:
+        return "name_one, name_three"
+    if has_instance:
+        return "name_three (instance-level only)"
+    if has_run:
+        return "name_one (run-level only)"
+    return "name_one"  # SOURCE="-" default-shape functions not otherwise flagged
+
+
 def main() -> None:
     RFF.get_registered_class("first")  # triggers _load() -- see factory's own laziness
     rows = []
     for name, cls in sorted(RFF._FUNCTIONS.items()):
         datatypes = cls.DATATYPES or ()
         unit_tested = _unit_test_path(cls).exists()
-        integration = {
-            dt: (_integration_hits(name, dt) if dt in datatypes else None)
-            for dt in ("files", "csvpaths", "results")
-        }
+        positions = SPECIAL_POSITIONS.get(name)
+        note = SPECIAL_NOTES.get(name, DEFAULT_NOTE if positions is None else "")
+        cells = {}
+        for dt in ("files", "csvpaths", "results"):
+            pos = positions[dt] if positions is not None else _default_position(cls, dt)
+            tested = _integration_hits(name, dt) if dt in datatypes else None
+            cells[dt] = (pos, tested)
         rows.append(
             {
                 "name": name,
@@ -137,42 +221,45 @@ def main() -> None:
                 "arg_required": cls.ARG_REQUIRED,
                 "source": cls.SOURCE,
                 "unit_tested": unit_tested,
-                "integration": integration,
-                "note": POSITION_NOTES.get(name, DEFAULT_FIELD_ACCESSOR_NOTE),
+                "cells": cells,
+                "note": note,
             }
         )
 
-    def cell(v) -> str:
-        if v is None:
+    def cell_text(pos, tested) -> str:
+        if pos is None:
             return "n/a"
-        return "yes" if v else "**MISSING**"
+        if tested is None:
+            return pos
+        return f"{pos} -- {'tested' if tested else '**MISSING**'}"
 
     out = []
-    out.append("# CSVPath References v3 -- function coverage matrix\n\n")
+    out.append("# CsvPath References v3 -- function coverage matrix\n\n")
     out.append(
         "Generated by `tests/references/tools/generate_function_matrix.py` -- "
         "re-run any time the function registry or test files change; do not "
-        "hand-edit the table below (edit the script's own `POSITION_NOTES` "
-        "dict instead, for the one manually-curated column).\n\n"
+        "hand-edit the table below (edit the script's own `SPECIAL_POSITIONS`/"
+        "`SPECIAL_NOTES` dicts instead, for the manually-curated parts).\n\n"
     )
     out.append(
         "| Function | Role | Datatypes | Arg required | Source | Unit test | "
-        "FILES | CSVPATHS | RESULTS | Position / notes |\n"
+        "FILES | CSVPATHS | RESULTS | Notes |\n"
     )
     out.append("|---|---|---|---|---|---|---|---|---|---|\n")
     for r in rows:
+        c = r["cells"]
         out.append(
             f"| `:{r['name']}()` | {r['role']} | {', '.join(r['datatypes']) or '-'} | "
             f"{'yes' if r['arg_required'] else 'no'} | {r['source'] or '-'} | "
-            f"{cell(r['unit_tested'])} | {cell(r['integration']['files'])} | "
-            f"{cell(r['integration']['csvpaths'])} | {cell(r['integration']['results'])} | "
-            f"{r['note']} |\n"
+            f"{'yes' if r['unit_tested'] else '**MISSING**'} | "
+            f"{cell_text(*c['files'])} | {cell_text(*c['csvpaths'])} | "
+            f"{cell_text(*c['results'])} | {r['note']} |\n"
         )
 
     missing = [
         r
         for r in rows
-        if not r["unit_tested"] or any(v is False for v in r["integration"].values())
+        if not r["unit_tested"] or any(v[1] is False for v in r["cells"].values())
     ]
     out.append("\n## Gaps found\n\n")
     if not missing:
@@ -186,8 +273,8 @@ def main() -> None:
             problems = []
             if not r["unit_tested"]:
                 problems.append("no unit test file")
-            for dt, v in r["integration"].items():
-                if v is False:
+            for dt, (pos, tested) in r["cells"].items():
+                if tested is False:
                     problems.append(f"no {dt} integration-test hit")
             out.append(f"- `:{r['name']}()` -- {'; '.join(problems)}\n")
 


### PR DESCRIPTION
## Summary
- Adds `tests/references/tools/generate_function_matrix.py` -- a coverage matrix generator for the whole references-v3 function surface (56 registered functions): role, declared datatypes, arg shape, source, unit-test presence, and per-datatype integration-test presence (a real reference string exercising it, not just a comment mentioning it).
- Output is a single auditable table, regenerated any time the function registry or test files change, written to `references_notes/notes/function_coverage_matrix.md` (untracked, same as the other references_notes working docs -- not part of this commit).
- Position/notes (which of name_one/name_two/name_three a function is legal in) is hand-curated in the script's `POSITION_NOTES` dict, not auto-derived -- that is enforced by procedural code spread across three different Finder classes, not declared as data anywhere.

## What running it found
- A cluster of ~13 RESULTS field-accessor functions (`:time()`, `:username()`, `:status()`, `:method()`, `:hostname()`, `:actual_data_file()`, `:file_fingerprints()`, `:idchain()`, `:identity()`, `:named_paths_name()`, `:named_results_name()`, `:origin_data_file()`, `:preceding_instance_identity()`, `:source_mode_preceding()`, `:time_completed()`) have real unit tests but zero integration-test coverage for RESULTS -- built and individually correct, never exercised end to end through a real reference string.
- A real bug, found while sanity-checking the tool's own output rather than by the tool itself: `:name()` declares CSVPATHS in its `DATATYPES`, but `CsvpathsReferenceFinder3._resolve_versions()` has no "unrecognized function in name_one" guard the way `query()`'s name_three handling does -- so `$acme.csvpaths.:name("x")` is silently ignored (no-op, same as a redundant bare `:all()`) instead of raising, contradicting the class's own docstring, which claims literal/path-building content "is not meaningful for csvpaths and are rejected." Not fixed here -- flagging for a decision on whether/how to close it.

## Test plan
- [x] `tests/references/` -- 966 passed (no code paths touched, tooling only)
- [x] Ran the script twice, spot-checked several "MISSING" flags against real test files by hand to confirm they were not false positives from the grep heuristic (one regex bug found and fixed in the process: nested string args like `:name("orders.csv").:from(1):to(3)` put quotes between `$` and a later function call on the same line, which an earlier version of the regex excluded)
