### PR TITLE
Add enforced per-function position declarations, starting with CSVPATHS

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -169,18 +169,19 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         if name_three is not None:
             if name_three.functions:
                 built = ReferenceFunctionFactory.build_chain(name_three.functions)
+                # replaces a hand-written "unrecognized" check (settled
+                # 2026-08-14) -- see _check_position()'s own docstring
+                # and _resolve_versions()'s equivalent check for
+                # name_one. Only :from()/:to() declare name_three as
+                # legal for csvpaths, so this rejects anything else
+                # (e.g. a literal identity's own function chain trying
+                # to add something other than a range) exactly as
+                # before, just via the shared mechanism instead of a
+                # local tuple.
+                for f in built:
+                    self._check_position(f, Reference3.NAME_THREE, Reference3.CSVPATHS)
                 from_call = next((f for f in built if f.name == "from"), None)
                 to_call = next((f for f in built if f.name == "to"), None)
-                unrecognized = [
-                    f for f in built if f.name not in ("from", "to")
-                ]
-                if unrecognized:
-                    raise ReferenceException3(
-                        "CsvpathsReferenceFinder3 does not yet support "
-                        f":{unrecognized[0].name}() on name_three -- only "
-                        "a literal statement identity/index, or "
-                        "':from()'/':to()', are supported."
-                    )
                 for f in (from_call, to_call):
                     if f is not None and isinstance(self._range_bound(f), str):
                         raise ReferenceException3(
@@ -471,7 +472,13 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         version(s) to work with, so its path_prefix must reduce to
         exactly one function-segment (no literal/"*" path-building, no
         worksheet marker) -- combined with its own trailing function
-        chain, if any. ':having("identity")' (added 2026-08-13) filters
+        chain, if any. Every function in that combined chain must
+        declare name_one as legal for csvpaths in its own POSITIONS
+        (added 2026-08-14, see ReferenceFinder3._check_position()) --
+        e.g. ":name()" is registered for csvpaths but has nowhere legal
+        to go there, so it now raises here instead of silently no-
+        opping the way it used to. ':having("identity")' (added
+        2026-08-13) filters
         `manifest` down to versions whose own "named_paths_identities"
         list contains that identity, BEFORE any pointer reduces further
         -- e.g. ":having('my_validations'):last()" is "the last version
@@ -499,6 +506,8 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
             )
         calls = [name_one.path[0], *name_one.functions]
         built = ReferenceFunctionFactory.build_chain(calls)
+        for f in built:
+            self._check_position(f, Reference3.NAME_ONE, Reference3.CSVPATHS)
         having_call = next((f for f in built if f.name == "having"), None)
         if having_call is not None:
             manifest = [

--- a/csvpath/references/functions/fields/destinations_3.py
+++ b/csvpath/references/functions/fields/destinations_3.py
@@ -25,3 +25,4 @@ class Destinations3(Function3):
     KEY = {
         Reference3.CSVPATHS: "destinations",
     }
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/fingerprint_3.py
+++ b/csvpath/references/functions/fields/fingerprint_3.py
@@ -48,3 +48,8 @@ class Fingerprint3(Function3):
         Reference3.FILES: "fingerprint",
         Reference3.CSVPATHS: "fingerprint",
     }
+    #
+    # CSVPATHS has no bare-lookup shape (that's FILES-only, see above) --
+    # always the ordinary field-accessor position.
+    #
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/home_3.py
+++ b/csvpath/references/functions/fields/home_3.py
@@ -30,3 +30,9 @@ class Home3(Function3):
         Reference3.RESULTS: "run_home",
         Reference3.RESULT: "instance_home",
     }
+    #
+    # CSVPATHS has no "bare :home() as zero-level selector" case (that
+    # is FILES/RESULTS-only -- CSVPATHS' name_one has no path dimension
+    # to be zero-level of) -- always the ordinary field-accessor position.
+    #
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/manifest_path_3.py
+++ b/csvpath/references/functions/fields/manifest_path_3.py
@@ -26,3 +26,4 @@ class ManifestPath3(Function3):
         Reference3.RESULTS: "manifest_path",
         Reference3.RESULT: "manifest_path",
     }
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/named_paths_count_3.py
+++ b/csvpath/references/functions/fields/named_paths_count_3.py
@@ -21,3 +21,4 @@ class NamedPathsCount3(Function3):
     KEY = {
         Reference3.CSVPATHS: "named_paths_count",
     }
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/named_paths_identities_3.py
+++ b/csvpath/references/functions/fields/named_paths_identities_3.py
@@ -22,3 +22,4 @@ class NamedPathsIdentities3(Function3):
     KEY = {
         Reference3.CSVPATHS: "named_paths_identities",
     }
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/named_paths_name_3.py
+++ b/csvpath/references/functions/fields/named_paths_name_3.py
@@ -25,3 +25,4 @@ class NamedPathsName3(Function3):
         Reference3.CSVPATHS: "named_paths_name",
         Reference3.RESULTS: "named_paths_name",
     }
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/origin_3.py
+++ b/csvpath/references/functions/fields/origin_3.py
@@ -31,3 +31,4 @@ class Origin3(Function3):
         Reference3.FILES: "from",
         Reference3.CSVPATHS: "source_path",
     }
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/scripts_3.py
+++ b/csvpath/references/functions/fields/scripts_3.py
@@ -24,3 +24,4 @@ class Scripts3(Function3):
     KEY = {
         Reference3.CSVPATHS: "scripts",
     }
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/time_3.py
+++ b/csvpath/references/functions/fields/time_3.py
@@ -27,3 +27,4 @@ class Time3(Function3):
         Reference3.RESULTS: "time",
         Reference3.RESULT: "time",
     }
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/time_completed_3.py
+++ b/csvpath/references/functions/fields/time_completed_3.py
@@ -24,3 +24,4 @@ class TimeCompleted3(Function3):
         Reference3.CSVPATHS: "time_completed",
         Reference3.RESULTS: "time_completed",
     }
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/transfers_3.py
+++ b/csvpath/references/functions/fields/transfers_3.py
@@ -30,3 +30,4 @@ class Transfers3(Function3):
     KEY = {
         Reference3.CSVPATHS: "transfers.path_transfers",
     }
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/uuid_3.py
+++ b/csvpath/references/functions/fields/uuid_3.py
@@ -44,3 +44,4 @@ class Uuid3(Function3):
         Reference3.RESULTS: "run_uuid",
         Reference3.RESULT: "uuid",
     }
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/webhooks_3.py
+++ b/csvpath/references/functions/fields/webhooks_3.py
@@ -23,3 +23,4 @@ class Webhooks3(Function3):
     KEY = {
         Reference3.CSVPATHS: "webhooks",
     }
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/function_3.py
+++ b/csvpath/references/functions/function_3.py
@@ -40,6 +40,28 @@ class Function3:
     ARG_REQUIRED: bool = False
 
     #
+    # {datatype: (position, ...)} -- which of Reference3.NAME_ONE/
+    # NAME_TWO/NAME_THREE this function is legal to appear in, per
+    # datatype it applies to. Added 2026-08-14, rolled out incrementally
+    # per Finder (CSVPATHS first -- see ReferenceFinder3._check_position()
+    # and CsvpathsReferenceFinder3's own call sites) rather than all at
+    # once. Unlike DATATYPES (descriptive only -- confirmed nothing reads
+    # it except Function3.describe(), a future type-ahead layer's own
+    # registry query, not a runtime gate), POSITIONS is the ENFORCED
+    # source of truth once a Finder calls _check_position() with it:
+    # replaces the scattered, inconsistent "is this recognized" guards
+    # each Finder used to hand-write on its own. A datatype key absent
+    # from this dict, or present but empty, both mean "not legal here"
+    # -- the difference is only documentation intent (declared-and-
+    # rejected vs. not yet declared for that datatype/Finder). Never
+    # declared for argument-only VALUE wrappers (e.g. :date(), :idchain())
+    # -- those are never a top-level chain member to check a position
+    # for; they only ever appear nested inside another function's own
+    # arg.
+    #
+    POSITIONS: dict = {}
+
+    #
     # field-accessor functions only (e.g. :uuid(), :time(), :on_arrival())
     # -- both left unset (None/{}) for every other function. SOURCE names
     # which well-known, per-entity resource this field lives in ("manifest"

--- a/csvpath/references/functions/selectors/all_3.py
+++ b/csvpath/references/functions/selectors/all_3.py
@@ -28,3 +28,4 @@ class All3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/selectors/first_3.py
+++ b/csvpath/references/functions/selectors/first_3.py
@@ -9,3 +9,4 @@ class First3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/selectors/from_3.py
+++ b/csvpath/references/functions/selectors/from_3.py
@@ -54,3 +54,10 @@ class From3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = (int, Index3, str, Date3)
     ARG_REQUIRED = True
+    #
+    # CSVPATHS only, so far (2026-08-14) -- name_one (version-level
+    # range) and name_three (statement-level range) both. FILES/RESULTS
+    # entries deferred until those Finders are retrofitted to enforce
+    # POSITIONS the same way (see Function3.POSITIONS's own docstring).
+    #
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE, Reference3.NAME_THREE)}

--- a/csvpath/references/functions/selectors/having_3.py
+++ b/csvpath/references/functions/selectors/having_3.py
@@ -31,3 +31,4 @@ class Having3(Function3):
     DATATYPES = (Reference3.CSVPATHS,)
     ARG_TYPES = (str,)
     ARG_REQUIRED = True
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/selectors/index_3.py
+++ b/csvpath/references/functions/selectors/index_3.py
@@ -12,3 +12,9 @@ class Index3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = (int,)
     ARG_REQUIRED = True
+    #
+    # position only applies when used as a top-level pointer -- when
+    # nested inside :from()/:to()'s own arg (e.g. ":from(:index(2))"),
+    # it is unwrapped via .arg and never reaches a position check at all.
+    #
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/selectors/last_3.py
+++ b/csvpath/references/functions/selectors/last_3.py
@@ -9,3 +9,4 @@ class Last3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/selectors/name_3.py
+++ b/csvpath/references/functions/selectors/name_3.py
@@ -21,3 +21,18 @@ class Name3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = (str,)
     ARG_REQUIRED = True
+    #
+    # CSVPATHS deliberately maps to an EMPTY tuple, not an absent key --
+    # DATATYPES lists csvpaths (it type-checks fine as an argument-typed
+    # function), but name_one has no path-building dimension for
+    # csvpaths (STRUCTURE table: name_one is purely a version-selecting
+    # function chain there) -- :name() has never had anywhere legal to
+    # go. Before 2026-08-14 this was enforced by nothing at all:
+    # CsvpathsReferenceFinder3._resolve_versions() had no unrecognized-
+    # function guard, so "$acme.csvpaths.:name(\"x\")" silently no-opped
+    # instead of raising, contradicting the class's own docstring
+    # ("literal/path-building content... are not meaningful for
+    # csvpaths and are rejected"). This is the fix -- see
+    # ReferenceFinder3._check_position().
+    #
+    POSITIONS = {Reference3.CSVPATHS: ()}

--- a/csvpath/references/functions/selectors/to_3.py
+++ b/csvpath/references/functions/selectors/to_3.py
@@ -28,3 +28,7 @@ class To3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = (int, Index3, str, Date3)
     ARG_REQUIRED = True
+    #
+    # see From3's own POSITIONS comment -- always paired, same positions.
+    #
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE, Reference3.NAME_THREE)}

--- a/csvpath/references/functions/well_known_files/definition_3.py
+++ b/csvpath/references/functions/well_known_files/definition_3.py
@@ -39,3 +39,4 @@ class Definition3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/well_known_files/manifest_3.py
+++ b/csvpath/references/functions/well_known_files/manifest_3.py
@@ -41,3 +41,9 @@ class Manifest3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
+    #
+    # name_one covers both the bare/beside-a-pointer shape and the
+    # special root_major='*' global-ledger case for CSVPATHS -- root_major
+    # is a separate axis from position, not a different position.
+    #
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/wrappers/path_3.py
+++ b/csvpath/references/functions/wrappers/path_3.py
@@ -42,3 +42,4 @@ class Path3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS)
     ARG_TYPES = (Function3,)
     ARG_REQUIRED = True
+    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -420,6 +420,21 @@ class Reference3:
     METADATA_FILE = "metadata_file"
     METADATA_FIELD = "metadata_field"
 
+    #
+    # position identity -- which of a reference's three name segments a
+    # function was found in. Added 2026-08-14 for Function3.POSITIONS
+    # (see that class's own docstring): the enforced, per-datatype
+    # source of truth for where a function is legal, replacing the
+    # scattered, inconsistent "is this recognized" guards each Finder
+    # used to hand-write on its own (the gap that let
+    # "$acme.csvpaths.:name(\"x\")" silently no-op instead of raising --
+    # CsvpathsReferenceFinder3._resolve_versions() had no such guard at
+    # all, while query()'s name_three handling did).
+    #
+    NAME_ONE = "name_one"
+    NAME_TWO = "name_two"
+    NAME_THREE = "name_three"
+
     def __init__(
         self,
         *,

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -186,6 +186,28 @@ class ReferenceFinder3(ABC):
         return result
 
     @staticmethod
+    def _check_position(function, position: str, datatype: str) -> None:
+        """raises unless `function` declares `position` as legal for
+        `datatype` in its own Function3.POSITIONS -- added 2026-08-14,
+        the enforced replacement for the scattered, inconsistent "is
+        this recognized" guards each Finder used to hand-write on its
+        own (the gap that let "$acme.csvpaths.:name('x')" silently
+        no-op instead of raising -- CsvpathsReferenceFinder3.
+        _resolve_versions() had no such guard at all, while query()'s
+        name_three handling did). Rolled out incrementally per Finder
+        (CSVPATHS first) rather than all at once -- a function with no
+        POSITIONS entry for a given datatype has simply not been
+        migrated to this mechanism yet by that datatype's own Finder,
+        not necessarily rejected everywhere; only a Finder that
+        actually calls this method enforces it. See Function3.POSITIONS
+        and Reference3.NAME_ONE/TWO/THREE's own docstrings."""
+        legal = function.POSITIONS.get(datatype, ())
+        if position not in legal:
+            raise ReferenceException3(
+                f":{function.name}() is not legal at {position} for {datatype}."
+            )
+
+    @staticmethod
     def _is_bare_pointer_reference(reference: Reference3, name: str) -> bool:
         """true when name_one's entire content is a single, argument-
         less ":name()" call -- no other path segments, no trailing

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -752,14 +752,16 @@ class TestFieldAccessorFunctions:
         ).resolve()
         assert [r.data for r in results.results] == [2, 1]
 
-    def test_function_with_no_key_for_this_datatype_gives_none_not_a_crash(self):
-        # :mark()'s own DATATYPES is FILES-only, but nothing currently
-        # enforces DATATYPES against the reference it is actually used
-        # in (a pre-existing gap, not introduced here) -- so this reaches
-        # _extract_data() and must degrade to None rather than crashing
-        # on a KEY lookup that has no CSVPATHS entry.
-        results = _finder("$acme.csvpaths.:first():mark()", RICH_MANIFEST).resolve()
-        assert results.results[0].data is None
+    def test_function_not_legal_here_is_rejected_not_silently_degraded(self):
+        # :mark()'s own DATATYPES is FILES-only, and it has no POSITIONS
+        # entry for csvpaths at all -- added 2026-08-14: this now raises
+        # via ReferenceFinder3._check_position(), called from
+        # _resolve_versions(), instead of silently reaching
+        # _extract_data() and degrading to None on a KEY lookup with no
+        # CSVPATHS entry (the old, undetected gap this test used to
+        # lock in).
+        with pytest.raises(ReferenceException3):
+            _finder("$acme.csvpaths.:first():mark()", RICH_MANIFEST).query()
 
 
 class TestDefinitionFieldAccessorFunctions:
@@ -899,3 +901,40 @@ class TestScopeLimits:
         finder = _finder("$acme.csvpaths.:first().:meta()")
         with pytest.raises(ReferenceException3):
             finder._extract_data(ReferenceResult3(path="p", uuid="v0-uuid"))
+
+
+class TestPositionEnforcement:
+    # ReferenceFinder3._check_position() -- added 2026-08-14, the
+    # enforced replacement for the scattered "is this recognized"
+    # guards each Finder used to hand-write on its own. CSVPATHS is the
+    # first Finder retrofitted to call it.
+    def test_name_is_registered_for_csvpaths_but_has_nowhere_legal_to_go(self):
+        # the actual bug this mechanism was built to close: :name()'s
+        # own DATATYPES includes csvpaths (it type-checks fine as an
+        # argument-typed function), but it has no path-building
+        # dimension there -- POSITIONS[csvpaths] is an explicit empty
+        # tuple, not an absent key, so this now raises instead of
+        # silently no-opping the way it used to.
+        with pytest.raises(ReferenceException3):
+            _finder('$acme.csvpaths.:name("x")').query()
+
+    def test_a_function_not_declared_for_csvpaths_at_all_is_rejected(self):
+        # :mark() is FILES-only in its own DATATYPES and has no
+        # POSITIONS entry for csvpaths at all -- same rejection path,
+        # different starting point (never declared vs. declared-empty).
+        with pytest.raises(ReferenceException3):
+            _finder("$acme.csvpaths.:first():mark()", RICH_MANIFEST).query()
+
+    def test_a_legal_function_is_unaffected(self):
+        # sanity check that the new check does not over-reject --
+        # :having() legitimately declares name_one for csvpaths.
+        results = _finder(
+            '$acme.csvpaths.:having("company_names"):last()', RICH_MANIFEST
+        ).query()
+        assert results.uuids == ["v0-uuid"]
+
+    def test_having_is_not_legal_at_name_three(self):
+        # :having() only declares name_one -- riding on name_three
+        # (where it has never been meaningful) is rejected the same way.
+        with pytest.raises(ReferenceException3):
+            _finder('$acme.csvpaths.:last().:having("x")', RICH_MANIFEST).query()

--- a/tests/references/tools/generate_function_matrix.py
+++ b/tests/references/tools/generate_function_matrix.py
@@ -21,22 +21,21 @@ Writes the report to references_notes/notes/function_coverage_matrix.md.
 
 Mechanically derived every run (always accurate, no manual upkeep): role,
 datatypes, arg shape, source, unit-test-file-exists, integration-test-grep-
-hit-per-datatype, and the POSITION of every plain field-accessor function
-(SOURCE set) -- FILES field accessors ride at name_three, CSVPATHS field
-accessors ride at name_one (both mirror that datatype's own version-
-selector position), and RESULTS field accessors are derived from whether
-their own KEY dict has a Reference3.RESULTS entry (name_one/run-level), a
-Reference3.RESULT entry (name_three/instance-level), or both.
+hit-per-datatype, and position for every function.
 
-Manually curated (accurate as of 2026-08-13; re-check if a Finder's
-query() logic changes): position for the ~20 non-field-accessor functions
-(pointers, context setters, well-known-file/wrapper functions, argument-
-only VALUE wrappers) in SPECIAL_POSITIONS/SPECIAL_NOTES below. WHERE these
-are legal is enforced by procedural code scattered across three different
-Finder classes, not declared anywhere as data -- reliably auto-deriving it
-would need a much heavier static-analysis pass than this script attempts,
-so it is hand-written here instead, from direct reading of all three
-Finders during the same work that produced this script.
+Position itself is a mix of two sources, preferring the real one whenever
+it exists: **CSVPATHS position is now real, ENFORCED declared data**
+(Function3.POSITIONS, added 2026-08-14 -- see ReferenceFinder3.
+_check_position(), called from CsvpathsReferenceFinder3) -- this script
+just reads it straight off each function class, same as DATATYPES/ROLE.
+**FILES/RESULTS position is still hand-curated** in SPECIAL_POSITIONS/
+SPECIAL_NOTES below (or mechanically guessed for plain field accessors via
+_default_position()) -- those two Finders have not been retrofitted to
+declare/enforce POSITIONS yet, so there is no real data to read for them.
+As FILES and then RESULTS get retrofitted the same way CSVPATHS was, their
+entries in SPECIAL_POSITIONS become dead (superseded by real data, same as
+CSVPATHS' already are) and can be deleted -- once all three are done, this
+whole hand-curated mechanism goes away entirely.
 """
 
 import re
@@ -65,59 +64,47 @@ INTEGRATION_TEST_FILES = {
 }
 
 #
-# manually curated positions for the ~20 functions that are NOT plain
-# field accessors -- see module docstring's "Manually curated" section.
-# One entry per datatype: a position string, None (not supported/not
-# meaningful), or a flagged string for a known declared-but-broken case
-# (see ":name()" below).
+# manually curated FILES/RESULTS positions for the ~20 functions that are
+# NOT plain field accessors -- see module docstring. No "csvpaths" key in
+# any entry below -- CSVPATHS position is now real declared data, read
+# directly off each function class in main(), taking precedence over
+# anything here (these dicts are consulted only as a FILES/RESULTS
+# fallback). One entry per remaining datatype: a position string, or None
+# (not supported/not meaningful there).
 #
 SPECIAL_POSITIONS = {
-    "first": {"files": "name_three", "csvpaths": "name_one", "results": "name_one"},
-    "last": {"files": "name_three", "csvpaths": "name_one", "results": "name_one"},
-    "index": {"files": "name_three", "csvpaths": "name_one", "results": "name_one"},
-    "name": {
-        "files": "name_one",
-        "csvpaths": "**declared but broken -- silently no-ops, see Notes**",
-        "results": None,
-    },
-    "all": {"files": "name_three", "csvpaths": "name_one", "results": "name_one"},
-    "flatten": {"files": "name_one", "csvpaths": None, "results": "name_one"},
-    "groups": {"files": "name_one", "csvpaths": None, "results": "name_one"},
-    "having": {"files": None, "csvpaths": "name_one", "results": None},
-    "from": {
-        "files": "name_three",
-        "csvpaths": "name_one, name_three",
-        "results": "name_one, name_three",
-    },
-    "to": {
-        "files": "name_three",
-        "csvpaths": "name_one, name_three",
-        "results": "name_one, name_three",
-    },
+    "first": {"files": "name_three", "results": "name_one"},
+    "last": {"files": "name_three", "results": "name_one"},
+    "index": {"files": "name_three", "results": "name_one"},
+    "name": {"files": "name_one", "results": None},
+    "all": {"files": "name_three", "results": "name_one"},
+    "flatten": {"files": "name_one", "results": "name_one"},
+    "groups": {"files": "name_one", "results": "name_one"},
+    "having": {"files": None, "results": None},
+    "from": {"files": "name_three", "results": "name_one, name_three"},
+    "to": {"files": "name_three", "results": "name_one, name_three"},
     "date": {
         "files": "argument (inside :from()/:to())",
-        "csvpaths": "argument (inside :from()/:to())",
         "results": "argument (inside :from()/:to())",
     },
-    "manifest": {"files": "name_three", "csvpaths": "name_one", "results": "name_one"},
-    "definition": {"files": "name_one (bare)", "csvpaths": "name_one (bare)", "results": None},
-    "path": {"files": "name_three", "csvpaths": "name_one", "results": None},
-    "errors": {"files": None, "csvpaths": None, "results": "name_three (instance-level)"},
-    "vars": {"files": None, "csvpaths": None, "results": "name_three (instance-level)"},
-    "meta": {"files": None, "csvpaths": None, "results": "name_three (instance-level)"},
-    "data": {"files": None, "csvpaths": None, "results": "name_three (instance-level)"},
-    "unmatched": {"files": None, "csvpaths": None, "results": "name_three (instance-level)"},
-    "file": {"files": None, "csvpaths": None, "results": "name_three (instance-level)"},
-    "idchain": {"files": None, "csvpaths": None, "results": "argument (inside :errors())"},
+    "manifest": {"files": "name_three", "results": "name_one"},
+    "definition": {"files": "name_one (bare)", "results": None},
+    "path": {"files": "name_three", "results": None},
+    "errors": {"files": None, "results": "name_three (instance-level)"},
+    "vars": {"files": None, "results": "name_three (instance-level)"},
+    "meta": {"files": None, "results": "name_three (instance-level)"},
+    "data": {"files": None, "results": "name_three (instance-level)"},
+    "unmatched": {"files": None, "results": "name_three (instance-level)"},
+    "file": {"files": None, "results": "name_three (instance-level)"},
+    "idchain": {"files": None, "results": "argument (inside :errors())"},
 }
 
 SPECIAL_NOTES = {
     "name": (
-        "DATATYPES includes csvpaths, but CsvpathsReferenceFinder3."
-        "_resolve_versions() has no unrecognized-function guard the way "
-        "query()'s name_three handling does -- $acme.csvpaths.:name(\"x\") "
-        "silently no-ops instead of raising, contradicting the class's own "
-        "docstring. Flagged 2026-08-13, not fixed."
+        "DATATYPES includes csvpaths, but name_one has no path-building "
+        "dimension there -- POSITIONS[csvpaths] is an explicit empty tuple. "
+        "Was a real bug until 2026-08-14 (silently no-opped instead of "
+        "raising) -- now enforced/fixed."
     ),
     "all": (
         "FILES/CSVPATHS: switches the version-selector chain from POINTER-"
@@ -177,18 +164,21 @@ def _integration_hits(name: str, datatype: str) -> bool:
 
 
 def _default_position(cls, datatype: str) -> str | None:
-    """mechanical position for a plain field accessor (SOURCE set, not in
-    SPECIAL_POSITIONS) -- FILES/CSVPATHS mirror that datatype's own
-    version-selector position; RESULTS is derived from whether the
-    function's own KEY dict serves the run level (Reference3.RESULTS),
-    the instance level (Reference3.RESULT), or both."""
+    """mechanical GUESS at position for a plain field accessor (SOURCE
+    set, not in SPECIAL_POSITIONS), for FILES/RESULTS only -- neither is
+    retrofitted to enforce real POSITIONS data yet (main() never calls
+    this for CSVPATHS -- see its own comment). FILES mirrors its own
+    version-selector position (name_three); RESULTS is derived from
+    whether the function's own KEY dict serves the run level
+    (Reference3.RESULTS), the instance level (Reference3.RESULT), or
+    both."""
     if datatype not in (cls.DATATYPES or ()):
         return None
     if datatype == "files":
         return "name_three"
-    if datatype == "csvpaths":
-        return "name_one"
-    # results
+    # results -- datatype == "csvpaths" never reaches here, see main()'s
+    # own comment: that datatype is read straight from real POSITIONS
+    # data now, never guessed.
     has_run = Reference3.RESULTS in cls.KEY
     has_instance = Reference3.RESULT in cls.KEY
     if has_run and has_instance:
@@ -210,7 +200,19 @@ def main() -> None:
         note = SPECIAL_NOTES.get(name, DEFAULT_NOTE if positions is None else "")
         cells = {}
         for dt in ("files", "csvpaths", "results"):
-            pos = positions[dt] if positions is not None else _default_position(cls, dt)
+            if dt == Reference3.CSVPATHS:
+                # real, enforced data -- see module docstring. No
+                # fallback guessing here: since CsvpathsReferenceFinder3
+                # now fail-closes on anything without a POSITIONS entry
+                # (see ReferenceFinder3._check_position()), a guessed
+                # default could show "looks fine" for a function that
+                # would actually be rejected at runtime.
+                declared = cls.POSITIONS.get(Reference3.CSVPATHS)
+                pos = ", ".join(declared) if declared else None
+            elif positions is not None:
+                pos = positions.get(dt)
+            else:
+                pos = _default_position(cls, dt)
             tested = _integration_hits(name, dt) if dt in datatypes else None
             cells[dt] = (pos, tested)
         rows.append(


### PR DESCRIPTION
## Summary
- David's follow-up to the function coverage matrix (#246): functions should declare where they are legal to appear (`name_one`/`name_two`/`name_three`, per datatype) as real, enforced data, replacing the scattered, inconsistent "is this recognized" guards each Finder used to hand-write on its own.
- Confirmed first that `DATATYPES` (the existing per-function declaration) is purely descriptive today -- nothing reads it except `Function3.describe()`, a future type-ahead layer's own registry query, never a runtime gate. `POSITIONS` is new, and it *is* enforced once a Finder calls the new shared check.
- Adds `Reference3.NAME_ONE`/`NAME_TWO`/`NAME_THREE` constants and `Function3.POSITIONS: dict = {}` (`{datatype: (position, ...)}`).
- Adds `ReferenceFinder3._check_position(function, position, datatype)` -- raises clearly if the function's own declared positions don't include where it was found. Rolled out one Finder at a time, starting with CSVPATHS per David's own sequencing call (smallest, newest, and where the known bug lives) -- FILES and RESULTS are next, separately.
- All 25 CSVPATHS-relevant function classes now declare `POSITIONS[csvpaths]`. `CsvpathsReferenceFinder3` calls the check from `_resolve_versions()` (name_one -- previously unguarded, the actual bug) and `query()`'s name_three handling (replacing its existing hand-written check for identical behavior).

## What this actually fixes
- **The known bug**: `:name()` declares CSVPATHS in `DATATYPES` but has no path-building dimension there -- `POSITIONS[csvpaths]` is an explicit empty tuple, so `$acme.csvpaths.:name("x")` now raises instead of silently no-opping.
- **A second instance of the same bug class, found while testing this fix**: `:mark()` is FILES-only in its own `DATATYPES`, but was reaching `CsvpathsReferenceFinder3._extract_data()` and silently degrading to `None`. A pre-existing test even documented this as a known, unenforced gap ("nothing currently enforces DATATYPES against the reference it is actually used in"). Fixed the test to assert the new, correct behavior.

## Other changes
- `tests/references/tools/generate_function_matrix.py` now reads CSVPATHS position straight off each function's real `POSITIONS` data instead of a hand-curated guess -- FILES/RESULTS keep the hand-curated fallback until they're retrofitted the same way, at which point that whole mechanism goes away.
- Added `TestPositionEnforcement` to `test_csvpaths_reference_finder_3.py` covering both bugs plus a sanity check that legal functions are unaffected.

## Test plan
- [x] `tests/references/test_csvpaths_reference_finder_3.py` + `test_normative_examples_csvpaths.py` -- 135 passed
- [x] `tests/references/` -- 1013 passed
- [x] Full suite -- 2601 passed, 11 failed (known SFTP/S3/Nos baseline, unrelated)
