### PR TITLE
Extend enforced position declarations to FILES

### DIFF
--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -305,6 +305,22 @@ class FilesReferenceFinder3(ReferenceFinder3):
             )
         built = ReferenceFunctionFactory.build_chain(name_three.functions)
         for f in built:
+            # replaces the old "at least one recognized category
+            # present" gate below (settled 2026-08-14) -- that gate only
+            # checked for ABSENCE of every recognized category, it never
+            # rejected an individual EXTRA unrecognized function riding
+            # alongside a legitimate one (e.g. ":last():name('y')" --
+            # confirmed via direct testing this used to silently swallow
+            # the stray :name() instead of raising, the same bug class
+            # already fixed for CSVPATHS). name_three.functions is
+            # guaranteed non-empty here (NameThree3's own constructor
+            # requires a body or functions; body is already confirmed
+            # None above), so `built` can never be empty either -- every
+            # element passing this check already implies "at least one
+            # recognized thing," making the old gate's own "nothing
+            # recognized at all" case unreachable now, not just
+            # redundant.
+            self._check_position(f, Reference3.NAME_THREE, Reference3.FILES)
             if f.name == "fingerprint" and f.arg is not None:
                 # ':fingerprint(...)' only takes an argument in its bare,
                 # name_one lookup form (settled 2026-08-13) -- riding
@@ -378,21 +394,14 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 self._validate_date_format(from_bound)
             if to_is_date:
                 self._validate_date_format(to_bound)
-        if (
-            not pointers
-            and not has_manifest
-            and not has_field_function
-            and not has_path
-            and not has_all
-            and not has_range
-        ):
-            raise ReferenceException3(
-                "FilesReferenceFinder3 requires name_three to resolve to "
-                "exactly one pointer function (:first()/:last()/:index(n)), "
-                "optionally combined with :manifest(), :path(), :all(), "
-                "':from()'/':to()', or a registered field-accessor "
-                "function (e.g. :uuid())."
-            )
+        # the old "at least one recognized category present" gate that
+        # used to live here is now unreachable, not just redundant: the
+        # _check_position() loop above already guarantees every element
+        # of `built` (which is itself guaranteed non-empty, see that
+        # loop's own comment) is one of exactly the categories checked
+        # below (pointers/has_manifest/has_field_function/has_path/
+        # has_all/has_range cover the complete set of name_three-legal
+        # FILES functions), so at least one of them is always true here.
 
         if partitioned and (has_range or (pointers and (has_manifest or has_field_function or has_path))):
             # mirrors ResultsReferenceFinder3's own ':all()'-grouping

--- a/csvpath/references/functions/fields/fingerprint_3.py
+++ b/csvpath/references/functions/fields/fingerprint_3.py
@@ -50,6 +50,11 @@ class Fingerprint3(Function3):
     }
     #
     # CSVPATHS has no bare-lookup shape (that's FILES-only, see above) --
-    # always the ordinary field-accessor position.
+    # always the ordinary field-accessor position. FILES has BOTH: the
+    # bare, name_one, content-hash lookup form, and the ordinary
+    # field-accessor position (name_three, beside a matched pointer).
     #
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_ONE, Reference3.NAME_THREE),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/fields/home_3.py
+++ b/csvpath/references/functions/fields/home_3.py
@@ -34,5 +34,12 @@ class Home3(Function3):
     # CSVPATHS has no "bare :home() as zero-level selector" case (that
     # is FILES/RESULTS-only -- CSVPATHS' name_one has no path dimension
     # to be zero-level of) -- always the ordinary field-accessor position.
+    # FILES has BOTH: the bare, name_one, zero-level-selector shape
+    # (":home().:last()") and the ordinary field-accessor position
+    # (name_three, beside a matched pointer, e.g.
+    # ":name('orders.csv').:last():home()").
     #
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_ONE, Reference3.NAME_THREE),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/fields/mark_3.py
+++ b/csvpath/references/functions/fields/mark_3.py
@@ -23,3 +23,4 @@ class Mark3(Function3):
     KEY = {
         Reference3.FILES: "mark",
     }
+    POSITIONS = {Reference3.FILES: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/fields/named_file_home_3.py
+++ b/csvpath/references/functions/fields/named_file_home_3.py
@@ -22,3 +22,4 @@ class NamedFileHome3(Function3):
     ARG_REQUIRED = False
     SOURCE = "computed"
     KEY = {}
+    POSITIONS = {Reference3.FILES: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/fields/named_file_name_3.py
+++ b/csvpath/references/functions/fields/named_file_name_3.py
@@ -30,3 +30,4 @@ class NamedFileName3(Function3):
         Reference3.RESULTS: "named_file_name",
         Reference3.RESULT: "named_file_name",
     }
+    POSITIONS = {Reference3.FILES: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/fields/on_arrival_3.py
+++ b/csvpath/references/functions/fields/on_arrival_3.py
@@ -29,3 +29,16 @@ class OnArrival3(Function3):
     KEY = {
         Reference3.FILES: "on_arrival",
     }
+    #
+    # BOTH positions -- bare, name_one (settled 2026-08-12, David: an
+    # arrival activation lives in the named-file's own definition.json,
+    # it "doesn't go to the version level" -- matches :definition()
+    # itself, see FilesReferenceFinder3._bare_definition_field_call()),
+    # AND the ordinary name_three field-accessor position beside a
+    # matched pointer (e.g. ":name('orders.csv').:first():on_arrival()")
+    # -- confirmed via existing passing tests, both give the identical
+    # answer regardless of which version is selected, since SOURCE ==
+    # "definition" means _extract_data() never reads result.uuid for
+    # this function either way.
+    #
+    POSITIONS = {Reference3.FILES: (Reference3.NAME_ONE, Reference3.NAME_THREE)}

--- a/csvpath/references/functions/fields/origin_3.py
+++ b/csvpath/references/functions/fields/origin_3.py
@@ -31,4 +31,7 @@ class Origin3(Function3):
         Reference3.FILES: "from",
         Reference3.CSVPATHS: "source_path",
     }
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_THREE,),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/fields/sources_3.py
+++ b/csvpath/references/functions/fields/sources_3.py
@@ -21,3 +21,7 @@ class Sources3(Function3):
     KEY = {
         Reference3.FILES: "sources",
     }
+    #
+    # BOTH positions -- see on_arrival_3.py's own POSITIONS comment.
+    #
+    POSITIONS = {Reference3.FILES: (Reference3.NAME_ONE, Reference3.NAME_THREE)}

--- a/csvpath/references/functions/fields/time_3.py
+++ b/csvpath/references/functions/fields/time_3.py
@@ -27,4 +27,7 @@ class Time3(Function3):
         Reference3.RESULTS: "time",
         Reference3.RESULT: "time",
     }
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_THREE,),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/fields/uuid_3.py
+++ b/csvpath/references/functions/fields/uuid_3.py
@@ -44,4 +44,7 @@ class Uuid3(Function3):
         Reference3.RESULTS: "run_uuid",
         Reference3.RESULT: "uuid",
     }
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_THREE,),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/selectors/all_3.py
+++ b/csvpath/references/functions/selectors/all_3.py
@@ -28,4 +28,7 @@ class All3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_THREE,),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/selectors/first_3.py
+++ b/csvpath/references/functions/selectors/first_3.py
@@ -9,4 +9,7 @@ class First3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_THREE,),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/selectors/flatten_3.py
+++ b/csvpath/references/functions/selectors/flatten_3.py
@@ -37,3 +37,8 @@ class Flatten3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
+    #
+    # RESULTS entry deferred until that Finder is retrofitted to enforce
+    # POSITIONS the same way (see Function3.POSITIONS's own docstring).
+    #
+    POSITIONS = {Reference3.FILES: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/selectors/from_3.py
+++ b/csvpath/references/functions/selectors/from_3.py
@@ -55,9 +55,15 @@ class From3(Function3):
     ARG_TYPES = (int, Index3, str, Date3)
     ARG_REQUIRED = True
     #
-    # CSVPATHS only, so far (2026-08-14) -- name_one (version-level
-    # range) and name_three (statement-level range) both. FILES/RESULTS
-    # entries deferred until those Finders are retrofitted to enforce
-    # POSITIONS the same way (see Function3.POSITIONS's own docstring).
+    # FILES: name_three only (its own version-selector position -- no
+    # name_one range, unlike CSVPATHS/RESULTS' own version-level range,
+    # since FILES' version selector never lives in name_one). CSVPATHS:
+    # both name_one (version-level range) and name_three (statement-
+    # level range). RESULTS entries deferred until that Finder is
+    # retrofitted to enforce POSITIONS the same way (see
+    # Function3.POSITIONS's own docstring).
     #
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE, Reference3.NAME_THREE)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_THREE,),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE, Reference3.NAME_THREE),
+    }

--- a/csvpath/references/functions/selectors/groups_3.py
+++ b/csvpath/references/functions/selectors/groups_3.py
@@ -35,3 +35,8 @@ class Groups3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
+    #
+    # RESULTS entry deferred until that Finder is retrofitted to enforce
+    # POSITIONS the same way (see Function3.POSITIONS's own docstring).
+    #
+    POSITIONS = {Reference3.FILES: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/selectors/index_3.py
+++ b/csvpath/references/functions/selectors/index_3.py
@@ -17,4 +17,7 @@ class Index3(Function3):
     # nested inside :from()/:to()'s own arg (e.g. ":from(:index(2))"),
     # it is unwrapped via .arg and never reaches a position check at all.
     #
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_THREE,),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/selectors/last_3.py
+++ b/csvpath/references/functions/selectors/last_3.py
@@ -9,4 +9,7 @@ class Last3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_THREE,),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/selectors/name_3.py
+++ b/csvpath/references/functions/selectors/name_3.py
@@ -35,4 +35,7 @@ class Name3(Function3):
     # csvpaths and are rejected"). This is the fix -- see
     # ReferenceFinder3._check_position().
     #
-    POSITIONS = {Reference3.CSVPATHS: ()}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_ONE,),
+        Reference3.CSVPATHS: (),
+    }

--- a/csvpath/references/functions/selectors/to_3.py
+++ b/csvpath/references/functions/selectors/to_3.py
@@ -31,4 +31,7 @@ class To3(Function3):
     #
     # see From3's own POSITIONS comment -- always paired, same positions.
     #
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE, Reference3.NAME_THREE)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_THREE,),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE, Reference3.NAME_THREE),
+    }

--- a/csvpath/references/functions/well_known_files/definition_3.py
+++ b/csvpath/references/functions/well_known_files/definition_3.py
@@ -39,4 +39,7 @@ class Definition3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_ONE,),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/well_known_files/manifest_3.py
+++ b/csvpath/references/functions/well_known_files/manifest_3.py
@@ -42,8 +42,13 @@ class Manifest3(Function3):
     ARG_TYPES = ()
     ARG_REQUIRED = False
     #
-    # name_one covers both the bare/beside-a-pointer shape and the
-    # special root_major='*' global-ledger case for CSVPATHS -- root_major
-    # is a separate axis from position, not a different position.
+    # name_one (CSVPATHS)/name_three (FILES) both cover the bare/beside-
+    # a-pointer shape and the special root_major='*' global-ledger case
+    # -- root_major is a separate axis from position, not a different
+    # position. FILES' own version-selector position is name_three
+    # (unlike CSVPATHS/RESULTS, where it is name_one).
     #
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_THREE,),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/wrappers/path_3.py
+++ b/csvpath/references/functions/wrappers/path_3.py
@@ -42,4 +42,7 @@ class Path3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS)
     ARG_TYPES = (Function3,)
     ARG_REQUIRED = True
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_THREE,),
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+    }

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -1631,3 +1631,43 @@ class TestExtractData:
         )
         with pytest.raises(ReferenceException3):
             finder._extract_data(ReferenceResult3(path="p", uuid="u"))
+
+
+class TestPositionEnforcement:
+    # ReferenceFinder3._check_position() -- added 2026-08-14, the
+    # enforced replacement for the scattered "is this recognized"
+    # guards each Finder used to hand-write on its own. FILES is the
+    # second Finder retrofitted to call it, after CSVPATHS.
+    def test_an_extra_unrecognized_function_on_name_three_is_rejected(self):
+        # the actual bug this closes for FILES: the old "at least one
+        # recognized category present" gate never rejected an
+        # individual EXTRA unrecognized function riding alongside a
+        # legitimate one -- confirmed via direct testing before this
+        # fix that ":last():name('y')" silently swallowed the stray
+        # :name() instead of raising, the same bug class already fixed
+        # for CSVPATHS' :name() on name_one.
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$alpha.files.:name("one.csv").:last():name("y")',
+                ALPHA_HOME,
+                ALPHA_MANIFEST,
+            ).query()
+
+    def test_a_legal_function_is_unaffected(self):
+        # sanity check that the new check does not over-reject.
+        results = _finder(
+            '$alpha.files.:name("one.csv").:last()', ALPHA_HOME, ALPHA_MANIFEST
+        ).query()
+        assert len(results.results) == 1
+        assert results.uuids[0] in ("u-one-1", "u-one-2")
+
+    def test_name_is_not_legal_at_name_three(self):
+        # :name() is FILES' own name_one path-building function -- it
+        # has never been meaningful riding beside a matched version at
+        # name_three.
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$alpha.files.:name("one.csv").:name("y")',
+                ALPHA_HOME,
+                ALPHA_MANIFEST,
+            ).query()

--- a/tests/references/tools/generate_function_matrix.py
+++ b/tests/references/tools/generate_function_matrix.py
@@ -24,18 +24,16 @@ datatypes, arg shape, source, unit-test-file-exists, integration-test-grep-
 hit-per-datatype, and position for every function.
 
 Position itself is a mix of two sources, preferring the real one whenever
-it exists: **CSVPATHS position is now real, ENFORCED declared data**
-(Function3.POSITIONS, added 2026-08-14 -- see ReferenceFinder3.
-_check_position(), called from CsvpathsReferenceFinder3) -- this script
-just reads it straight off each function class, same as DATATYPES/ROLE.
-**FILES/RESULTS position is still hand-curated** in SPECIAL_POSITIONS/
-SPECIAL_NOTES below (or mechanically guessed for plain field accessors via
-_default_position()) -- those two Finders have not been retrofitted to
-declare/enforce POSITIONS yet, so there is no real data to read for them.
-As FILES and then RESULTS get retrofitted the same way CSVPATHS was, their
-entries in SPECIAL_POSITIONS become dead (superseded by real data, same as
-CSVPATHS' already are) and can be deleted -- once all three are done, this
-whole hand-curated mechanism goes away entirely.
+it exists: **CSVPATHS and FILES position are now real, ENFORCED declared
+data** (Function3.POSITIONS, added 2026-08-14 -- see ReferenceFinder3.
+_check_position(), called from CsvpathsReferenceFinder3 and
+FilesReferenceFinder3) -- this script just reads it straight off each
+function class, same as DATATYPES/ROLE. **RESULTS position is still hand-
+curated** in SPECIAL_POSITIONS/SPECIAL_NOTES below (or mechanically
+guessed for plain field accessors via _default_position()) -- that Finder
+has not been retrofitted to declare/enforce POSITIONS yet, so there is no
+real data to read for it. Once RESULTS gets the same retrofit, this whole
+hand-curated mechanism goes away entirely.
 """
 
 import re
@@ -64,39 +62,35 @@ INTEGRATION_TEST_FILES = {
 }
 
 #
-# manually curated FILES/RESULTS positions for the ~20 functions that are
-# NOT plain field accessors -- see module docstring. No "csvpaths" key in
-# any entry below -- CSVPATHS position is now real declared data, read
+# manually curated RESULTS positions for the ~20 functions that are NOT
+# plain field accessors -- see module docstring. No "files"/"csvpaths"
+# keys in any entry below -- both are now real declared data, read
 # directly off each function class in main(), taking precedence over
-# anything here (these dicts are consulted only as a FILES/RESULTS
-# fallback). One entry per remaining datatype: a position string, or None
-# (not supported/not meaningful there).
+# anything here (this dict is consulted only as a RESULTS fallback). One
+# entry: a position string, or None (not supported/not meaningful there).
 #
 SPECIAL_POSITIONS = {
-    "first": {"files": "name_three", "results": "name_one"},
-    "last": {"files": "name_three", "results": "name_one"},
-    "index": {"files": "name_three", "results": "name_one"},
-    "name": {"files": "name_one", "results": None},
-    "all": {"files": "name_three", "results": "name_one"},
-    "flatten": {"files": "name_one", "results": "name_one"},
-    "groups": {"files": "name_one", "results": "name_one"},
-    "having": {"files": None, "results": None},
-    "from": {"files": "name_three", "results": "name_one, name_three"},
-    "to": {"files": "name_three", "results": "name_one, name_three"},
-    "date": {
-        "files": "argument (inside :from()/:to())",
-        "results": "argument (inside :from()/:to())",
-    },
-    "manifest": {"files": "name_three", "results": "name_one"},
-    "definition": {"files": "name_one (bare)", "results": None},
-    "path": {"files": "name_three", "results": None},
-    "errors": {"files": None, "results": "name_three (instance-level)"},
-    "vars": {"files": None, "results": "name_three (instance-level)"},
-    "meta": {"files": None, "results": "name_three (instance-level)"},
-    "data": {"files": None, "results": "name_three (instance-level)"},
-    "unmatched": {"files": None, "results": "name_three (instance-level)"},
-    "file": {"files": None, "results": "name_three (instance-level)"},
-    "idchain": {"files": None, "results": "argument (inside :errors())"},
+    "first": {"results": "name_one"},
+    "last": {"results": "name_one"},
+    "index": {"results": "name_one"},
+    "name": {"results": None},
+    "all": {"results": "name_one"},
+    "flatten": {"results": "name_one"},
+    "groups": {"results": "name_one"},
+    "having": {"results": None},
+    "from": {"results": "name_one, name_three"},
+    "to": {"results": "name_one, name_three"},
+    "date": {"results": "argument (inside :from()/:to())"},
+    "manifest": {"results": "name_one"},
+    "definition": {"results": None},
+    "path": {"results": None},
+    "errors": {"results": "name_three (instance-level)"},
+    "vars": {"results": "name_three (instance-level)"},
+    "meta": {"results": "name_three (instance-level)"},
+    "data": {"results": "name_three (instance-level)"},
+    "unmatched": {"results": "name_three (instance-level)"},
+    "file": {"results": "name_three (instance-level)"},
+    "idchain": {"results": "argument (inside :errors())"},
 }
 
 SPECIAL_NOTES = {
@@ -165,20 +159,14 @@ def _integration_hits(name: str, datatype: str) -> bool:
 
 def _default_position(cls, datatype: str) -> str | None:
     """mechanical GUESS at position for a plain field accessor (SOURCE
-    set, not in SPECIAL_POSITIONS), for FILES/RESULTS only -- neither is
-    retrofitted to enforce real POSITIONS data yet (main() never calls
-    this for CSVPATHS -- see its own comment). FILES mirrors its own
-    version-selector position (name_three); RESULTS is derived from
+    set, not in SPECIAL_POSITIONS), for RESULTS only -- that Finder is
+    not retrofitted to enforce real POSITIONS data yet (main() never
+    calls this for FILES/CSVPATHS -- see its own comment). Derived from
     whether the function's own KEY dict serves the run level
     (Reference3.RESULTS), the instance level (Reference3.RESULT), or
     both."""
     if datatype not in (cls.DATATYPES or ()):
         return None
-    if datatype == "files":
-        return "name_three"
-    # results -- datatype == "csvpaths" never reaches here, see main()'s
-    # own comment: that datatype is read straight from real POSITIONS
-    # data now, never guessed.
     has_run = Reference3.RESULTS in cls.KEY
     has_instance = Reference3.RESULT in cls.KEY
     if has_run and has_instance:
@@ -200,14 +188,15 @@ def main() -> None:
         note = SPECIAL_NOTES.get(name, DEFAULT_NOTE if positions is None else "")
         cells = {}
         for dt in ("files", "csvpaths", "results"):
-            if dt == Reference3.CSVPATHS:
+            if dt in (Reference3.FILES, Reference3.CSVPATHS):
                 # real, enforced data -- see module docstring. No
-                # fallback guessing here: since CsvpathsReferenceFinder3
-                # now fail-closes on anything without a POSITIONS entry
-                # (see ReferenceFinder3._check_position()), a guessed
-                # default could show "looks fine" for a function that
-                # would actually be rejected at runtime.
-                declared = cls.POSITIONS.get(Reference3.CSVPATHS)
+                # fallback guessing here: since FilesReferenceFinder3/
+                # CsvpathsReferenceFinder3 now fail-close on anything
+                # without a POSITIONS entry (see ReferenceFinder3.
+                # _check_position()), a guessed default could show
+                # "looks fine" for a function that would actually be
+                # rejected at runtime.
+                declared = cls.POSITIONS.get(dt)
                 pos = ", ".join(declared) if declared else None
             elif positions is not None:
                 pos = positions.get(dt)


### PR DESCRIPTION
## Summary
- Second Finder retrofitted to the enforced position mechanism from #247, per the agreed CSVPATHS-then-FILES-then-RESULTS sequencing.
- All 22 FILES-relevant function classes now declare `POSITIONS[files]`. `FilesReferenceFinder3` calls the shared `ReferenceFinder3._check_position()` from `query()`'s name_three chain validation.

## What this actually fixes
- **A real bug, same class as #247's `:name()` fix**: the old "at least one recognized category present" gate at name_three only checked for *absence* of every recognized category -- it never rejected an individual *extra* unrecognized function riding alongside a legitimate one. Confirmed via direct testing before this fix: `$alpha.files.:name("orders.csv").:last():name("y")` silently swallowed the stray `:name()` instead of raising. Now closed.
- The old gate is providably unreachable now, not just redundant (name_three.functions is guaranteed non-empty by NameThree3's own constructor, and the six existing category flags cover every name_three-legal FILES function), so it's removed rather than left as dead code.
- `name_one`'s own path-building branches were **not** touched -- confirmed via testing they're already safe by construction (each bare-shape detector requires zero trailing functions, falling through to an existing explicit rejection otherwise). Nothing there for the generic check to close.
- Caught and corrected two of my own draft position declarations via the existing test suite: `:on_arrival()`/`:sources()` are usable at *both* name_one (bare) and name_three (the ordinary ride-beside-a-pointer position), not name_one only as I first assumed -- existing passing tests already exercised the name_three form.

## Other changes
- `tests/references/tools/generate_function_matrix.py` now reads FILES position from real declared data too (same treatment as CSVPATHS in #247) -- only RESULTS still uses the hand-curated fallback.
- Added `TestPositionEnforcement` to `test_files_reference_finder_3.py`.

## Test plan
- [x] `tests/references/test_files_reference_finder_3.py` + `test_normative_examples_files.py` -- 174 passed
- [x] `tests/references/` -- 1016 passed
- [x] Full suite -- 2604 passed, 11 failed (known SFTP/S3/Nos baseline, unrelated)
